### PR TITLE
build: enable multi-scm for release job

### DIFF
--- a/.github/release-trigger.yml
+++ b/.github/release-trigger.yml
@@ -1,1 +1,2 @@
 enabled: true
+multiScmName: bigframes


### PR DESCRIPTION
This build uses multi_scm internally where the scm_name for this repo is `bigframes`
