### PR TITLE
fix(release): use correct directory name for release build config

### DIFF
--- a/.kokoro/release/common.cfg
+++ b/.kokoro/release/common.cfg
@@ -11,7 +11,7 @@ action {
 gfile_resources: "/bigstore/cloud-devrel-kokoro-resources/trampoline"
 
 # Use the trampoline script to run in docker.
-build_file: "python-bigquery-dataframes/.kokoro/trampoline_v2.sh"
+build_file: "bigframes/.kokoro/trampoline_v2.sh"
 
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
@@ -20,7 +20,7 @@ env_vars: {
 }
 env_vars: {
     key: "TRAMPOLINE_BUILD_FILE"
-    value: "github/python-bigquery-dataframes/.kokoro/release.sh"
+    value: "github/bigframes/.kokoro/release.sh"
 }
 
 # Fetch PyPI password
@@ -43,7 +43,7 @@ env_vars: {
 # what we published, which we can use to generate SBOMs and attestations.
 action {
   define_artifacts {
-    regex: "github/python-bigquery-dataframes/**/*.tar.gz"
-    strip_prefix: "github/python-bigquery-dataframes"
+    regex: "github/bigframes/**/*.tar.gz"
+    strip_prefix: "github/bigframes"
   }
 }


### PR DESCRIPTION
Internally, the multi_scm name is "bigframes"
