### PR TITLE
chore: sync from internal git

### DIFF
--- a/.kokoro/docs/docs-presubmit-gerrit.cfg
+++ b/.kokoro/docs/docs-presubmit-gerrit.cfg
@@ -1,0 +1,23 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+env_vars: {
+    key: "V2_STAGING_BUCKET"
+    value: "gcloud-python-test"
+}
+
+# We only upload the image in the main `docs` build.
+env_vars: {
+    key: "TRAMPOLINE_IMAGE_UPLOAD"
+    value: "false"
+}
+
+env_vars: {
+    key: "TRAMPOLINE_BUILD_FILE"
+    value: ".kokoro/build.sh"
+}
+
+# Only run this nox session.
+env_vars: {
+    key: "NOX_SESSION"
+    value: "docfx"
+}

--- a/.kokoro/presubmit/e2e-gerrit.cfg
+++ b/.kokoro/presubmit/e2e-gerrit.cfg
@@ -1,0 +1,7 @@
+# Format: //devtools/kokoro/config/proto/build.proto
+
+# Only run this nox session.
+env_vars: {
+    key: "NOX_SESSION"
+    value: "system_noextras e2e notebook samples"
+}

--- a/.kokoro/presubmit/presubmit-gerrit.cfg
+++ b/.kokoro/presubmit/presubmit-gerrit.cfg
@@ -1,0 +1,1 @@
+# Format: //devtools/kokoro/config/proto/build.proto

--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,4 @@
+ashleyxu@google.com
 bmil@google.com
 chelsealin@google.com
 garrettwu@google.com

--- a/README.rst
+++ b/README.rst
@@ -57,9 +57,13 @@ internally to manage metadata on the service side. This session is tied to a
 BigQuery DataFrames uses the US multi-region as the default location, but you
 can use ``session_options.location`` to set a different location. Every query
 in a session is executed in the location where the session was created.
+BigQuery DataFrames
+auto-populates ``bf.options.bigquery.location`` if the user starts with
+``read_gbq/read_gbq_table/read_gbq_query()`` and specifies a table, either
+directly or in a SQL statement.
 
 If you want to reset the location of the created DataFrame or Series objects,
-can reset the session by executing ``bigframes.pandas.reset_session()``.
+you can reset the session by executing ``bigframes.pandas.reset_session()``.
 After that, you can reuse ``bigframes.pandas.options.bigquery.location`` to
 specify another location.
 
@@ -68,6 +72,11 @@ specify another location.
 querying is not in the US multi-region. If you try to read a table from another
 location, you get a NotFound exception.
 
+Project
+-------
+If ``bf.options.bigquery.project`` is not set, the ``$GOOGLE_CLOUD_PROJECT``
+environment variable is used, which is set in the notebook runtime serving the
+BigQuery Studio/Vertex Notebooks.
 
 ML Capabilities
 ---------------

--- a/bigframes/core/__init__.py
+++ b/bigframes/core/__init__.py
@@ -518,8 +518,8 @@ class ArrayValue:
         """
         Apply aggregations to the expression.
         Arguments:
-            by_column_id: column id of the aggregation key, this is preserved through the transform
             aggregations: input_column_id, operation, output_column_id tuples
+            by_column_id: column id of the aggregation key, this is preserved through the transform
             dropna: whether null keys should be dropped
         """
         table = self.to_ibis_expr(ordering_mode="unordered")

--- a/bigframes/core/blocks.py
+++ b/bigframes/core/blocks.py
@@ -709,8 +709,9 @@ class Block:
         window_spec: core.WindowSpec,
         *,
         skip_null_groups: bool = False,
-    ) -> Block:
+    ) -> typing.Tuple[Block, typing.Sequence[str]]:
         block = self
+        result_ids = []
         for i, col_id in enumerate(columns):
             label = self.col_id_to_label[col_id]
             block, result_id = block.apply_window_op(
@@ -721,9 +722,8 @@ class Block:
                 result_label=label,
                 skip_null_groups=skip_null_groups,
             )
-            block = block.copy_values(result_id, col_id)
-            block = block.drop_columns([result_id])
-        return block
+            result_ids.append(result_id)
+        return block, result_ids
 
     def multi_apply_unary_op(
         self,
@@ -1123,7 +1123,9 @@ class Block:
         )
 
     def add_prefix(self, prefix: str, axis: str | int | None = None) -> Block:
-        axis_number = bigframes.core.utils.get_axis_number(axis)
+        axis_number = bigframes.core.utils.get_axis_number(
+            "rows" if (axis is None) else axis
+        )
         if axis_number == 0:
             expr = self._expr
             for index_col in self._index_columns:
@@ -1140,7 +1142,9 @@ class Block:
             return self.rename(columns=lambda label: f"{prefix}{label}")
 
     def add_suffix(self, suffix: str, axis: str | int | None = None) -> Block:
-        axis_number = bigframes.core.utils.get_axis_number(axis)
+        axis_number = bigframes.core.utils.get_axis_number(
+            "rows" if (axis is None) else axis
+        )
         if axis_number == 0:
             expr = self._expr
             for index_col in self._index_columns:

--- a/bigframes/core/utils.py
+++ b/bigframes/core/utils.py
@@ -23,8 +23,8 @@ UNNAMED_COLUMN_ID = "bigframes_unnamed_column"
 UNNAMED_INDEX_ID = "bigframes_unnamed_index"
 
 
-def get_axis_number(axis: typing.Union[str, int, None]) -> typing.Literal[0, 1]:
-    if axis in {0, "index", "rows", None}:
+def get_axis_number(axis: typing.Union[str, int]) -> typing.Literal[0, 1]:
+    if axis in {0, "index", "rows"}:
         return 0
     elif axis in {1, "columns"}:
         return 1

--- a/bigframes/dtypes.py
+++ b/bigframes/dtypes.py
@@ -157,7 +157,7 @@ def ibis_dtype_to_bigframes_dtype(
         return IBIS_TO_BIGFRAMES[ibis_dtype]
     else:
         raise ValueError(
-            f"Unexpected Ibis data type {type(ibis_dtype)}. {constants.FEEDBACK_LINK}"
+            f"Unexpected Ibis data type {ibis_dtype}. {constants.FEEDBACK_LINK}"
         )
 
 

--- a/bigframes/ml/base.py
+++ b/bigframes/ml/base.py
@@ -133,7 +133,7 @@ class TrainablePredictor(Predictor):
     Also the predictor can be attached to a pipeline with transformers."""
 
     @abc.abstractmethod
-    def fit(self, X, y, transforms):
+    def _fit(self, X, y, transforms=None):
         pass
 
     @abc.abstractmethod
@@ -144,6 +144,36 @@ class TrainablePredictor(Predictor):
     @abc.abstractmethod
     def to_gbq(self, model_name, replace):
         pass
+
+
+class SupervisedTrainablePredictor(TrainablePredictor):
+    """A BigQuery DataFrames ML Supervised Model base class that can be used to fit and predict outputs.
+
+    Need to provide both X and y in supervised tasks."""
+
+    _T = TypeVar("_T", bound="SupervisedTrainablePredictor")
+
+    def fit(
+        self: _T,
+        X: Union[bpd.DataFrame, bpd.Series],
+        y: Union[bpd.DataFrame, bpd.Series],
+    ) -> _T:
+        return self._fit(X, y)
+
+
+class UnsupervisedTrainablePredictor(TrainablePredictor):
+    """A BigQuery DataFrames ML Unsupervised Model base class that can be used to fit and predict outputs.
+
+    Only need to provide both X (y is optional and ignored) in unsupervised tasks."""
+
+    _T = TypeVar("_T", bound="UnsupervisedTrainablePredictor")
+
+    def fit(
+        self: _T,
+        X: Union[bpd.DataFrame, bpd.Series],
+        y: Optional[Union[bpd.DataFrame, bpd.Series]] = None,
+    ) -> _T:
+        return self._fit(X, y)
 
 
 class Transformer(BaseEstimator):

--- a/bigframes/ml/cluster.py
+++ b/bigframes/ml/cluster.py
@@ -28,13 +28,13 @@ import third_party.bigframes_vendored.sklearn.cluster._kmeans
 
 
 class KMeans(
+    base.UnsupervisedTrainablePredictor,
     third_party.bigframes_vendored.sklearn.cluster._kmeans.KMeans,
-    base.TrainablePredictor,
 ):
 
     __doc__ = third_party.bigframes_vendored.sklearn.cluster._kmeans.KMeans.__doc__
 
-    def __init__(self, n_clusters=8):
+    def __init__(self, n_clusters: int = 8):
         self.n_clusters = n_clusters
         self._bqml_model: Optional[core.BqmlModel] = None
 
@@ -58,7 +58,7 @@ class KMeans(
         """The model options as they will be set for BQML"""
         return {"model_type": "KMEANS", "num_clusters": self.n_clusters}
 
-    def fit(
+    def _fit(
         self,
         X: Union[bpd.DataFrame, bpd.Series],
         y=None,  # ignored

--- a/bigframes/ml/compose.py
+++ b/bigframes/ml/compose.py
@@ -33,8 +33,8 @@ CompilablePreprocessorType = Union[
 
 
 class ColumnTransformer(
-    third_party.bigframes_vendored.sklearn.compose._column_transformer.ColumnTransformer,
     base.Transformer,
+    third_party.bigframes_vendored.sklearn.compose._column_transformer.ColumnTransformer,
 ):
     __doc__ = (
         third_party.bigframes_vendored.sklearn.compose._column_transformer.ColumnTransformer.__doc__

--- a/bigframes/ml/decomposition.py
+++ b/bigframes/ml/decomposition.py
@@ -28,12 +28,12 @@ import third_party.bigframes_vendored.sklearn.decomposition._pca
 
 
 class PCA(
+    base.UnsupervisedTrainablePredictor,
     third_party.bigframes_vendored.sklearn.decomposition._pca.PCA,
-    base.TrainablePredictor,
 ):
     __doc__ = third_party.bigframes_vendored.sklearn.decomposition._pca.PCA.__doc__
 
-    def __init__(self, n_components=3):
+    def __init__(self, n_components: int = 3):
         self.n_components = n_components
         self._bqml_model: Optional[core.BqmlModel] = None
 
@@ -52,7 +52,7 @@ class PCA(
         new_pca._bqml_model = core.BqmlModel(session, model)
         return new_pca
 
-    def fit(
+    def _fit(
         self,
         X: Union[bpd.DataFrame, bpd.Series],
         y=None,

--- a/bigframes/ml/ensemble.py
+++ b/bigframes/ml/ensemble.py
@@ -48,8 +48,8 @@ _BQML_PARAMS_MAPPING = {
 
 
 class XGBRegressor(
+    base.SupervisedTrainablePredictor,
     third_party.bigframes_vendored.xgboost.sklearn.XGBRegressor,
-    base.TrainablePredictor,
 ):
     __doc__ = third_party.bigframes_vendored.xgboost.sklearn.XGBRegressor.__doc__
 
@@ -57,22 +57,22 @@ class XGBRegressor(
         self,
         num_parallel_tree: int = 1,
         booster: Literal["gbtree", "dart"] = "gbtree",
-        dart_normalized_type: Literal["TREE", "FOREST"] = "TREE",
+        dart_normalized_type: Literal["tree", "forest"] = "tree",
         tree_method: Literal["auto", "exact", "approx", "hist"] = "auto",
         min_tree_child_weight: int = 1,
-        colsample_bytree=1.0,
-        colsample_bylevel=1.0,
-        colsample_bynode=1.0,
-        gamma=0.0,
+        colsample_bytree: float = 1.0,
+        colsample_bylevel: float = 1.0,
+        colsample_bynode: float = 1.0,
+        gamma: float = 0.0,
         max_depth: int = 6,
-        subsample=1.0,
-        reg_alpha=0.0,
-        reg_lambda=1.0,
-        early_stop=True,
-        learning_rate=0.3,
+        subsample: float = 1.0,
+        reg_alpha: float = 0.0,
+        reg_lambda: float = 1.0,
+        early_stop: float = True,
+        learning_rate: float = 0.3,
         max_iterations: int = 20,
-        min_rel_progress=0.01,
-        enable_global_explain=False,
+        min_rel_progress: float = 0.01,
+        enable_global_explain: bool = False,
         xgboost_version: Literal["0.9", "1.1"] = "0.9",
     ):
         self.num_parallel_tree = num_parallel_tree
@@ -143,7 +143,7 @@ class XGBRegressor(
             "xgboost_version": self.xgboost_version,
         }
 
-    def fit(
+    def _fit(
         self,
         X: Union[bpd.DataFrame, bpd.Series],
         y: Union[bpd.DataFrame, bpd.Series],
@@ -211,8 +211,8 @@ class XGBRegressor(
 
 
 class XGBClassifier(
+    base.SupervisedTrainablePredictor,
     third_party.bigframes_vendored.xgboost.sklearn.XGBClassifier,
-    base.TrainablePredictor,
 ):
 
     __doc__ = third_party.bigframes_vendored.xgboost.sklearn.XGBClassifier.__doc__
@@ -221,22 +221,22 @@ class XGBClassifier(
         self,
         num_parallel_tree: int = 1,
         booster: Literal["gbtree", "dart"] = "gbtree",
-        dart_normalized_type: Literal["TREE", "FOREST"] = "TREE",
+        dart_normalized_type: Literal["tree", "forest"] = "tree",
         tree_method: Literal["auto", "exact", "approx", "hist"] = "auto",
         min_tree_child_weight: int = 1,
-        colsample_bytree=1.0,
-        colsample_bylevel=1.0,
-        colsample_bynode=1.0,
-        gamma=0.0,
+        colsample_bytree: float = 1.0,
+        colsample_bylevel: float = 1.0,
+        colsample_bynode: float = 1.0,
+        gamma: float = 0.0,
         max_depth: int = 6,
-        subsample=1.0,
-        reg_alpha=0.0,
-        reg_lambda=1.0,
-        early_stop=True,
-        learning_rate=0.3,
+        subsample: float = 1.0,
+        reg_alpha: float = 0.0,
+        reg_lambda: float = 1.0,
+        early_stop: bool = True,
+        learning_rate: float = 0.3,
         max_iterations: int = 20,
-        min_rel_progress=0.01,
-        enable_global_explain=False,
+        min_rel_progress: float = 0.01,
+        enable_global_explain: bool = False,
         xgboost_version: Literal["0.9", "1.1"] = "0.9",
     ):
         self.num_parallel_tree = num_parallel_tree
@@ -307,7 +307,7 @@ class XGBClassifier(
             "xgboost_version": self.xgboost_version,
         }
 
-    def fit(
+    def _fit(
         self,
         X: Union[bpd.DataFrame, bpd.Series],
         y: Union[bpd.DataFrame, bpd.Series],
@@ -374,8 +374,8 @@ class XGBClassifier(
 
 
 class RandomForestRegressor(
+    base.SupervisedTrainablePredictor,
     third_party.bigframes_vendored.sklearn.ensemble._forest.RandomForestRegressor,
-    base.TrainablePredictor,
 ):
 
     __doc__ = (
@@ -461,7 +461,7 @@ class RandomForestRegressor(
             "xgboost_version": self.xgboost_version,
         }
 
-    def fit(
+    def _fit(
         self,
         X: Union[bpd.DataFrame, bpd.Series],
         y: Union[bpd.DataFrame, bpd.Series],
@@ -542,8 +542,8 @@ class RandomForestRegressor(
 
 
 class RandomForestClassifier(
+    base.SupervisedTrainablePredictor,
     third_party.bigframes_vendored.sklearn.ensemble._forest.RandomForestClassifier,
-    base.TrainablePredictor,
 ):
 
     __doc__ = (
@@ -629,7 +629,7 @@ class RandomForestClassifier(
             "xgboost_version": self.xgboost_version,
         }
 
-    def fit(
+    def _fit(
         self,
         X: Union[bpd.DataFrame, bpd.Series],
         y: Union[bpd.DataFrame, bpd.Series],

--- a/bigframes/ml/forecasting.py
+++ b/bigframes/ml/forecasting.py
@@ -27,7 +27,7 @@ import bigframes.pandas as bpd
 _PREDICT_OUTPUT_COLUMNS = ["forecast_timestamp", "forecast_value"]
 
 
-class ARIMAPlus(base.TrainablePredictor):
+class ARIMAPlus(base.SupervisedTrainablePredictor):
     """Time Series ARIMA Plus model."""
 
     def __init__(self):
@@ -48,7 +48,7 @@ class ARIMAPlus(base.TrainablePredictor):
         """The model options as they will be set for BQML."""
         return {"model_type": "ARIMA_PLUS"}
 
-    def fit(
+    def _fit(
         self,
         X: Union[bpd.DataFrame, bpd.Series],
         y: Union[bpd.DataFrame, bpd.Series],

--- a/bigframes/ml/linear_model.py
+++ b/bigframes/ml/linear_model.py
@@ -30,8 +30,8 @@ import third_party.bigframes_vendored.sklearn.linear_model._logistic
 
 
 class LinearRegression(
+    base.SupervisedTrainablePredictor,
     third_party.bigframes_vendored.sklearn.linear_model._base.LinearRegression,
-    base.TrainablePredictor,
 ):
     __doc__ = (
         third_party.bigframes_vendored.sklearn.linear_model._base.LinearRegression.__doc__
@@ -39,7 +39,7 @@ class LinearRegression(
 
     def __init__(
         self,
-        fit_intercept=True,
+        fit_intercept: bool = True,
     ):
         self.fit_intercept = fit_intercept
         self._bqml_model: Optional[core.BqmlModel] = None
@@ -71,7 +71,7 @@ class LinearRegression(
             "fit_intercept": self.fit_intercept,
         }
 
-    def fit(
+    def _fit(
         self,
         X: Union[bpd.DataFrame, bpd.Series],
         y: Union[bpd.DataFrame, bpd.Series],
@@ -136,8 +136,8 @@ class LinearRegression(
 
 
 class LogisticRegression(
+    base.SupervisedTrainablePredictor,
     third_party.bigframes_vendored.sklearn.linear_model._logistic.LogisticRegression,
-    base.TrainablePredictor,
 ):
     __doc__ = (
         third_party.bigframes_vendored.sklearn.linear_model._logistic.LogisticRegression.__doc__
@@ -189,12 +189,13 @@ class LogisticRegression(
             # "class_weights": self.class_weights,
         }
 
-    def fit(
+    def _fit(
         self,
         X: Union[bpd.DataFrame, bpd.Series],
         y: Union[bpd.DataFrame, bpd.Series],
         transforms: Optional[List[str]] = None,
     ) -> LogisticRegression:
+        """Fit model with transforms."""
         X, y = utils.convert_to_dataframe(X, y)
 
         self._bqml_model = core.create_bqml_model(

--- a/bigframes/ml/llm.py
+++ b/bigframes/ml/llm.py
@@ -100,26 +100,26 @@ class PaLM2TextGenerator(base.Predictor):
                 Temperature controls the degree of randomness in token selection. Lower temperatures are good for prompts that expect a true or correct response,
                 while higher temperatures can lead to more diverse or unexpected results. A temperature of 0 is deterministic:
                 the highest probability token is always selected. For most use cases, try starting with a temperature of 0.2.
-                Default 0.
+                Default 0. Possible values [0.0, 1.0].
 
             max_output_tokens (int, default 128):
                 Maximum number of tokens that can be generated in the response. Specify a lower value for shorter responses and a higher value for longer responses.
                 A token may be smaller than a word. A token is approximately four characters. 100 tokens correspond to roughly 60-80 words.
-                Default 128.
+                Default 128. Possible values [1, 1024].
 
             top_k (int, default 40):
                 Top-k changes how the model selects tokens for output. A top-k of 1 means the selected token is the most probable among all tokens
                 in the model’s vocabulary (also called greedy decoding), while a top-k of 3 means that the next token is selected from among the 3 most probable tokens (using temperature).
                 For each token selection step, the top K tokens with the highest probabilities are sampled. Then tokens are further filtered based on topP with the final token selected using temperature sampling.
                 Specify a lower value for less random responses and a higher value for more random responses.
-                Default 40.
+                Default 40. Possible values [1, 40].
 
             top_p (float, default 0.95)::
                 Top-p changes how the model selects tokens for output. Tokens are selected from most K (see topK parameter) probable to least until the sum of their probabilities equals the top-p value.
                 For example, if tokens A, B, and C have a probability of 0.3, 0.2, and 0.1 and the top-p value is 0.5, then the model will select either A or B as the next token (using temperature)
                 and not consider C at all.
                 Specify a lower value for less random responses and a higher value for more random responses.
-                Default 0.95.
+                Default 0.95. Possible values [0.0, 1.0].
 
 
         Returns:

--- a/bigframes/ml/preprocessing.py
+++ b/bigframes/ml/preprocessing.py
@@ -29,8 +29,8 @@ import third_party.bigframes_vendored.sklearn.preprocessing._encoder
 
 
 class StandardScaler(
-    third_party.bigframes_vendored.sklearn.preprocessing._data.StandardScaler,
     base.Transformer,
+    third_party.bigframes_vendored.sklearn.preprocessing._data.StandardScaler,
 ):
     __doc__ = (
         third_party.bigframes_vendored.sklearn.preprocessing._data.StandardScaler.__doc__
@@ -105,8 +105,8 @@ class StandardScaler(
 
 
 class OneHotEncoder(
-    third_party.bigframes_vendored.sklearn.preprocessing._encoder.OneHotEncoder,
     base.Transformer,
+    third_party.bigframes_vendored.sklearn.preprocessing._encoder.OneHotEncoder,
 ):
     # BQML max value https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-one-hot-encoder#syntax
     TOP_K_DEFAULT = 1000000

--- a/bigframes/pandas/__init__.py
+++ b/bigframes/pandas/__init__.py
@@ -399,6 +399,7 @@ def remote_function(
     dataset: Optional[str] = None,
     bigquery_connection: Optional[str] = None,
     reuse: bool = True,
+    name: Optional[str] = None,
 ):
     return global_session.with_default_session(
         bigframes.session.Session.remote_function,
@@ -407,6 +408,7 @@ def remote_function(
         dataset=dataset,
         bigquery_connection=bigquery_connection,
         reuse=reuse,
+        name=name,
     )
 
 

--- a/bigframes/remote_function.py
+++ b/bigframes/remote_function.py
@@ -28,6 +28,8 @@ import tempfile
 import textwrap
 from typing import List, NamedTuple, Optional, Sequence, TYPE_CHECKING
 
+import requests
+
 if TYPE_CHECKING:
     from bigframes.session import Session
 
@@ -99,7 +101,7 @@ def get_remote_function_locations(bq_location):
 
 
 def _get_hash(def_):
-    "Get hash of a function."
+    "Get hash (32 digits alphanumeric) of a function."
     def_repr = cloudpickle.dumps(def_, protocol=_pickle_protocol_version)
     return hashlib.md5(def_repr).hexdigest()
 
@@ -128,7 +130,7 @@ class IbisSignature(NamedTuple):
 
 
 def get_cloud_function_name(def_, uniq_suffix=None):
-    """Get the name of the cloud function."""
+    "Get a name for the cloud function for the given user defined function."
     cf_name = _get_hash(def_)
     cf_name = f"bigframes-{cf_name}"  # for identification
     if uniq_suffix:
@@ -137,7 +139,7 @@ def get_cloud_function_name(def_, uniq_suffix=None):
 
 
 def get_remote_function_name(def_, uniq_suffix=None):
-    """Get the name for the BQ remote function."""
+    "Get a name for the BQ remote function for the given user defined function."
     bq_rf_name = _get_hash(def_)
     bq_rf_name = f"bigframes_{bq_rf_name}"  # for identification
     if uniq_suffix:
@@ -206,9 +208,15 @@ class RemoteFunctionClient:
         query_job.result()  # Wait for the job to complete.
         logger.info(f"Created remote function {query_job.ddl_target_routine}")
 
+    def get_cloud_function_fully_qualified_parent(self):
+        "Get the fully qualilfied parent for a cloud function."
+        return self._cloud_functions_client.common_location_path(
+            self._gcp_project_id, self._cloud_function_region
+        )
+
     def get_cloud_function_fully_qualified_name(self, name):
         "Get the fully qualilfied name for a cloud function."
-        return "projects/{}/locations/{}/functions/{}".format(
+        return self._cloud_functions_client.function_path(
             self._gcp_project_id, self._cloud_function_region, name
         )
 
@@ -319,6 +327,7 @@ class RemoteFunctionClient:
         # Build and deploy folder structure containing cloud function
         with tempfile.TemporaryDirectory() as dir:
             entry_point = self.generate_cloud_function_code(def_, dir)
+            archive_path = shutil.make_archive(dir, "zip", dir)
 
             # We are creating cloud function source code from the currently running
             # python version. Use the same version to deploy. This is necessary
@@ -331,50 +340,56 @@ class RemoteFunctionClient:
                 sys.version_info.major, sys.version_info.minor
             )
 
-            # deploy/redeploy the cloud function
-            # TODO(shobs): Figure out a way to skip this step if a cloud function
-            # already exists with the same name and source code
-            command = (
-                "gcloud functions deploy"
-                + f" {cf_name} --gen2"
-                + f" --runtime={python_version}"
-                + f" --project={self._gcp_project_id}"
-                + f" --region={self._cloud_function_region}"
-                + f" --source={dir}"
-                + f" --entry-point={entry_point}"
-                + " --trigger-http"
+            # Determine an upload URL for user code
+            upload_url_request = functions_v2.GenerateUploadUrlRequest()
+            upload_url_request.parent = self.get_cloud_function_fully_qualified_parent()
+            upload_url_response = self._cloud_functions_client.generate_upload_url(
+                request=upload_url_request
             )
 
-            # If the cloud function is being created for the first time, then let's
-            # make it not allow unauthenticated calls. If it was previously created
-            # then this invocation will update it, in which case do not touch that
-            # aspect and let the previous policy hold. The reason we do this is to
-            # avoid an IAM permission needed to update the invocation policy.
-            # For example, when a cloud function is being created for the first
-            # time, i.e.
-            # $ gcloud functions deploy python-foo-http --gen2 --runtime=python310
-            #       --region=us-central1
-            #       --source=/source/code/dir
-            #       --entry-point=foo_http
-            #       --trigger-http
-            #       --no-allow-unauthenticated
-            # It works. When an invocation of the same command is done for the
-            # second time, it may run into an error like:
-            # ERROR: (gcloud.functions.deploy) PERMISSION_DENIED: Permission
-            # 'run.services.setIamPolicy' denied on resource
-            # 'projects/my_project/locations/us-central1/services/python-foo-http' (or resource may not exist)
-            # But when --no-allow-unauthenticated is omitted then it goes through.
-            # It suggests that in the second invocation the command is trying to set
-            # the IAM policy of the service, and the user running BigQuery
-            # DataFrame may not have privilege to do so, so better avoid this
-            # if we can.
-            if self.get_cloud_function_endpoint(cf_name):
-                logger.info(f"Updating existing cloud function: {command}")
-            else:
-                command = f"{command} --no-allow-unauthenticated"
-                logger.info(f"Creating new cloud function: {command}")
+            # Upload the code to GCS
+            with open(archive_path, "rb") as f:
+                response = requests.put(
+                    upload_url_response.upload_url,
+                    data=f,
+                    headers={"content-type": "application/zip"},
+                )
+                if response.status_code != 200:
+                    raise RuntimeError(
+                        "Failed to upload user code. code={}, reason={}, text={}".format(
+                            response.status_code, response.reason, response.text
+                        )
+                    )
 
-            _run_system_command(command)
+            # Deploy Cloud Function
+            create_function_request = functions_v2.CreateFunctionRequest()
+            create_function_request.parent = (
+                self.get_cloud_function_fully_qualified_parent()
+            )
+            create_function_request.function_id = cf_name
+            function = functions_v2.Function()
+            function.name = self.get_cloud_function_fully_qualified_name(cf_name)
+            function.build_config = functions_v2.BuildConfig()
+            function.build_config.runtime = python_version
+            function.build_config.entry_point = entry_point
+            function.build_config.source = functions_v2.Source()
+            function.build_config.source.storage_source = functions_v2.StorageSource()
+            function.build_config.source.storage_source.bucket = (
+                upload_url_response.storage_source.bucket
+            )
+            function.build_config.source.storage_source.object_ = (
+                upload_url_response.storage_source.object_
+            )
+            create_function_request.function = function
+
+            # Create the cloud function and wait for it to be ready to use
+            operation = self._cloud_functions_client.create_function(
+                request=create_function_request
+            )
+            operation.result()
+
+            # Cleanup
+            os.remove(archive_path)
 
         # Fetch the endpoint of the just created function
         endpoint = self.get_cloud_function_endpoint(cf_name)
@@ -389,23 +404,47 @@ class RemoteFunctionClient:
         return endpoint
 
     def provision_bq_remote_function(
-        self, def_, input_types, output_type, uniq_suffix=None
+        self,
+        def_,
+        input_types,
+        output_type,
+        reuse,
+        name,
     ):
         """Provision a BigQuery remote function."""
-        # Derive the name of the underlying cloud function and first create
-        # it if it does not exist
+        # If reuse of any existing function with the same name (indicated by the
+        # same hash of its source code) is not intended, then attach a unique
+        # suffix to the intended function name to make it unique.
+        uniq_suffix = None
+        if not reuse:
+            uniq_suffix = "".join(
+                random.choices(string.ascii_lowercase + string.digits, k=8)
+            )
+
+        # Derive the name of the cloud function underlying the intended BQ
+        # remote function
         cloud_function_name = get_cloud_function_name(def_, uniq_suffix)
         cf_endpoint = self.get_cloud_function_endpoint(cloud_function_name)
+
+        # Create the cloud function if it does not exist
         if not cf_endpoint:
-            self.check_cloud_function_tools_and_permissions()
             cf_endpoint = self.create_cloud_function(def_, cloud_function_name)
         else:
             logger.info(f"Cloud function {cloud_function_name} already exists.")
 
-        # Derive the name of the remote function and create/replace it if needed
-        remote_function_name = get_remote_function_name(def_, uniq_suffix)
+        # Derive the name of the remote function
+        remote_function_name = name
+        if not remote_function_name:
+            remote_function_name = get_remote_function_name(def_, uniq_suffix)
         rf_endpoint, rf_conn = self.get_remote_function_specs(remote_function_name)
-        if rf_endpoint != cf_endpoint or rf_conn != self._bq_connection_id:
+
+        # Create the BQ remote function in following circumstances:
+        # 1. It does not exist
+        # 2. It exists but the existing remote function has different
+        #    configuration than intended
+        if not rf_endpoint or (
+            rf_endpoint != cf_endpoint or rf_conn != self._bq_connection_id
+        ):
             input_args = inspect.getargs(def_.__code__).args
             if len(input_args) != len(input_types):
                 raise ValueError(
@@ -438,27 +477,6 @@ class RemoteFunctionClient:
                         bq_connection = os.path.basename(bq_connection)
                 break
         return (http_endpoint, bq_connection)
-
-    def check_cloud_function_tools_and_permissions(self):
-        """Check if the necessary tools and permissions are in place for creating remote function"""
-        # gcloud CLI comes with bq CLI and they are required for creating google
-        # cloud function and BigQuery remote function respectively
-        if not shutil.which("gcloud"):
-            raise ValueError(
-                "gcloud tool not installed, install it from https://cloud.google.com/sdk/docs/install. "
-                f"{constants.FEEDBACK_LINK}"
-            )
-
-        # TODO(shobs): Check for permissions too
-        # I (shobs) tried the following method
-        # $ gcloud asset search-all-iam-policies \
-        #   --format=json \
-        #   --scope=projects/{gcp_project_id} \
-        #   --query='policy.role.permissions:cloudfunctions.functions.create'
-        # as a proxy to all the privilges necessary to create cloud function
-        # https://cloud.google.com/functions/docs/reference/iam/roles#cloudfunctions.developer
-        # but that itself required the runner to have the permission to enable
-        # `cloudasset.googleapis.com`
 
 
 def remote_function_node(
@@ -583,6 +601,7 @@ def remote_function(
     dataset: Optional[str] = None,
     bigquery_connection: Optional[str] = None,
     reuse: bool = True,
+    name: Optional[str] = None,
 ):
     """Decorator to turn a user defined function into a BigQuery remote function.
 
@@ -613,7 +632,7 @@ def remote_function(
             * BigQuery Data Editor (roles/bigquery.dataEditor)
             * BigQuery Connection Admin (roles/bigquery.connectionAdmin)
             * Cloud Functions Developer (roles/cloudfunctions.developer)
-            * Service Account User (roles/iam.serviceAccountUser)
+            * Service Account User (roles/iam.serviceAccountUser) on the service account `PROJECT_NUMBER-compute@developer.gserviceaccount.com`
             * Storage Object Viewer (roles/storage.objectViewer)
             * Project IAM Admin (roles/resourcemanager.projectIamAdmin) (Only required if the bigquery connection being used is not pre-created and is created dynamically with user credentials.)
 
@@ -664,10 +683,16 @@ def remote_function(
         reuse (bool, Optional):
             Reuse the remote function if is already exists.
             `True` by default, which results in reusing an existing remote
-            function (if any) that was previously created for the same udf.
-            Setting it to false forces the creation of creating a unique remote function.
+            function and corresponding cloud function (if any) that was
+            previously created for the same udf.
+            Setting it to `False` forces the creation of a unique remote function.
             If the required remote function does not exist then it would be
             created irrespective of this param.
+        name (str, Optional):
+            Explicit name of the persisted BigQuery remote function. Use it with
+            caution, because two users working in the same project and dataset
+            could overwrite each other's remote functions if they use the same
+            persistent name.
 
     """
 
@@ -739,12 +764,6 @@ def remote_function(
             f"{constants.FEEDBACK_LINK}"
         )
 
-    uniq_suffix = None
-    if not reuse:
-        uniq_suffix = "".join(
-            random.choices(string.ascii_lowercase + string.digits, k=8)
-        )
-
     # Check connection_id with `LOCATION.CONNECTION_ID` or `PROJECT_ID.LOCATION.CONNECTION_ID` format.
     if bigquery_connection.count(".") == 1:
         bq_connection_location, bq_connection_id = bigquery_connection.split(".")
@@ -792,8 +811,13 @@ def remote_function(
             bigquery_connection,
             resource_manager_client,
         )
+
         rf_name, cf_name = remote_function_client.provision_bq_remote_function(
-            f, ibis_signature.input_types, ibis_signature.output_type, uniq_suffix
+            f,
+            ibis_signature.input_types,
+            ibis_signature.output_type,
+            reuse,
+            name,
         )
 
         node = remote_function_node(dataset_ref.routine(rf_name), ibis_signature)

--- a/noxfile.py
+++ b/noxfile.py
@@ -42,6 +42,7 @@ UNIT_TEST_STANDARD_DEPENDENCIES = [
     "pytest",
     "pytest-cov",
     "pytest-asyncio",
+    "pytest-mock",
 ]
 UNIT_TEST_EXTERNAL_DEPENDENCIES: List[str] = []
 UNIT_TEST_LOCAL_DEPENDENCIES: List[str] = []

--- a/samples/snippets/remote_function.py
+++ b/samples/snippets/remote_function.py
@@ -39,11 +39,19 @@ def run_remote_function_and_read_gbq_function(project_id: str):
     # already created, BigQuery DataFrames will attempt to create one assuming
     # the necessary APIs and IAM permissions are setup in the project. In our
     # examples we would be using a pre-created connection named
-    # `bigframes-rf-conn`. Let's try a `pandas`-like use case in which we want
-    # to apply a user defined scalar function to every value in a `Series`, more
-    # specifically bucketize the `body_mass_g` value of the penguins, which is a
-    # real number, into a category, which is a string.
-    @bpd.remote_function([float], str, bigquery_connection="bigframes-rf-conn")
+    # `bigframes-rf-conn`. We will also set `reuse=False` to make sure we don't
+    # step over someone else creating remote function in the same project from
+    # the exact same source code at the same time. Let's try a `pandas`-like use
+    # case in which we want to apply a user defined scalar function to every
+    # value in a `Series`, more specifically bucketize the `body_mass_g` value
+    # of the penguins, which is a real number, into a category, which is a
+    # string.
+    @bpd.remote_function(
+        [float],
+        str,
+        bigquery_connection="bigframes-rf-conn",
+        reuse=False,
+    )
     def get_bucket(num):
         if not num:
             return "NA"
@@ -80,9 +88,11 @@ def run_remote_function_and_read_gbq_function(project_id: str):
     # Let's continue trying other potential use cases of remote functions. Let's
     # say we consider the `species`, `island` and `sex` of the penguins
     # sensitive information and want to redact that by replacing with their hash
-    # code instead. Let's define another scalar custom function and decorated it
+    # code instead. Let's define another scalar custom function and decorate it
     # as a remote function
-    @bpd.remote_function([str], str, bigquery_connection="bigframes-rf-conn")
+    @bpd.remote_function(
+        [str], str, bigquery_connection="bigframes-rf-conn", reuse=False
+    )
     def get_hash(input):
         import hashlib
 

--- a/setup.py
+++ b/setup.py
@@ -47,6 +47,7 @@ dependencies = [
     "ibis-framework[bigquery] >=6.0.0,<=6.1.0",
     "pandas >=1.5.0",
     "pydata-google-auth >=1.8.2",
+    "requests >=2.27.1",
     "scikit-learn >=1.2.2",
     "sqlalchemy >=1.4,<3.0",
     "ipywidgets >=7.7.1",
@@ -58,7 +59,7 @@ extras = {
         "pandas-gbq >=0.19.0",
     ],
     # Packages required for basic development flow.
-    "dev": ["pytest", "pre-commit", "nox", "google-cloud-testutils"],
+    "dev": ["pytest", "pytest-mock", "pre-commit", "nox", "google-cloud-testutils"],
 }
 extras["all"] = list(sorted(frozenset(itertools.chain.from_iterable(extras.values()))))
 

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -9,7 +9,7 @@ cachetools==5.3.0
 certifi==2022.12.7
 cffi==1.15.1
 cfgv==3.3.1
-charset-normalizer==3.1.0
+charset-normalizer==2.0.0
 click==8.1.3
 cloudpickle==2.0.0
 colorlog==6.7.0
@@ -90,13 +90,14 @@ pyperclip==1.8.2
 pytest==7.2.2
 pytest-asyncio==0.21.0
 pytest-cov==4.0.0
+pytest-mock==3.11.1
 pytest-retry==1.1.0
 pytest-xdist==3.2.1
 python-dateutil==2.8.2
 pytz==2023.3
 PyYAML==6.0
 readme-renderer==37.3
-requests==2.28.2
+requests==2.27.1
 requests-oauthlib==1.3.1
 requests-toolbelt==0.10.1
 rfc3986==2.0.0

--- a/tests/system/large/ml/test_ensemble.py
+++ b/tests/system/large/ml/test_ensemble.py
@@ -70,7 +70,7 @@ def test_xgbregressor_dart_booster_multiple_params(
 ):
     model = bigframes.ml.ensemble.XGBRegressor(
         booster="dart",
-        tree_method="AUTO",
+        tree_method="auto",
         min_tree_child_weight=2,
         colsample_bytree=0.95,
         colsample_bylevel=0.95,
@@ -121,7 +121,7 @@ def test_xgbregressor_dart_booster_multiple_params(
         in reloaded_model._bqml_model.model_name
     )
     assert reloaded_model.booster == "DART"
-    assert reloaded_model.dart_normalized_type == "TREE"
+    assert reloaded_model.dart_normalized_type == "tree"
     assert reloaded_model.tree_method == "AUTO"
     assert reloaded_model.colsample_bytree == 0.95
     assert reloaded_model.colsample_bylevel == 0.95
@@ -185,7 +185,7 @@ def test_xgbclassifier_dart_booster_multiple_params(
 ):
     model = bigframes.ml.ensemble.XGBClassifier(
         booster="dart",
-        tree_method="AUTO",
+        tree_method="auto",
         min_tree_child_weight=2,
         colsample_bytree=0.95,
         colsample_bylevel=0.95,
@@ -235,7 +235,7 @@ def test_xgbclassifier_dart_booster_multiple_params(
         in reloaded_model._bqml_model.model_name
     )
     assert reloaded_model.booster == "DART"
-    assert reloaded_model.dart_normalized_type == "TREE"
+    assert reloaded_model.dart_normalized_type == "tree"
     assert reloaded_model.tree_method == "AUTO"
     assert reloaded_model.colsample_bytree == 0.95
     assert reloaded_model.colsample_bylevel == 0.95
@@ -297,7 +297,7 @@ def test_randomforestregressor_default_params(penguins_df_default_index, dataset
 @pytest.mark.flaky(retries=2, delay=120)
 def test_randomforestregressor_multiple_params(penguins_df_default_index, dataset_id):
     model = bigframes.ml.ensemble.RandomForestRegressor(
-        tree_method="AUTO",
+        tree_method="auto",
         min_tree_child_weight=2,
         colsample_bytree=0.95,
         colsample_bylevel=0.95,

--- a/tests/system/small/ml/test_core.py
+++ b/tests/system/small/ml/test_core.py
@@ -18,6 +18,7 @@ from unittest import TestCase
 
 import pandas as pd
 import pyarrow as pa
+import pytest
 import pytz
 
 import bigframes
@@ -278,6 +279,7 @@ def test_model_predict_with_unnamed_index(
     )
 
 
+@pytest.mark.flaky(retries=2, delay=120)
 def test_model_generate_text(
     bqml_palm2_text_generator_model: core.BqmlModel, llm_text_df
 ):

--- a/tests/system/small/ml/test_decomposition.py
+++ b/tests/system/small/ml/test_decomposition.py
@@ -16,33 +16,14 @@ import pandas as pd
 
 from bigframes.ml import decomposition
 
-_PD_NEW_PENGUINS = pd.DataFrame(
-    {
-        "tag_number": [1633, 1672, 1690],
-        "species": [
-            "Adelie Penguin (Pygoscelis adeliae)",
-            "Gentoo penguin (Pygoscelis papua)",
-            "Adelie Penguin (Pygoscelis adeliae)",
-        ],
-        "island": ["Dream", "Biscoe", "Torgersen"],
-        "culmen_length_mm": [37.8, 46.5, 41.1],
-        "culmen_depth_mm": [18.1, 14.8, 18.6],
-        "flipper_length_mm": [193.0, 217.0, 189.0],
-        "body_mass_g": [3750.0, 5200.0, 3325.0],
-        "sex": ["MALE", "FEMALE", "MALE"],
-    }
-).set_index("tag_number")
 
-
-def test_pca_predict(session, penguins_pca_model: decomposition.PCA):
-    new_penguins = session.read_pandas(_PD_NEW_PENGUINS)
-
-    predictions = penguins_pca_model.predict(new_penguins).to_pandas()
+def test_pca_predict(penguins_pca_model, new_penguins_df):
+    predictions = penguins_pca_model.predict(new_penguins_df).to_pandas()
     expected = pd.DataFrame(
         {
-            "principal_component_1": [-1.459, 2.258, -1.685],
-            "principal_component_2": [-1.120, -1.351, -0.874],
-            "principal_component_3": [-0.646, 0.443, -0.704],
+            "principal_component_1": [-1.314041, -0.855813, -1.848786],
+            "principal_component_2": [-0.889106, -1.259753, -0.983304],
+            "principal_component_3": [-0.704345, 0.322555, -0.095759],
         },
         dtype="Float64",
         index=pd.Index([1633, 1672, 1690], name="tag_number", dtype="Int64"),

--- a/tests/system/small/test_groupby.py
+++ b/tests/system/small/test_groupby.py
@@ -210,12 +210,14 @@ def test_dataframe_groupby_multi_sum(
         (lambda x: x.cummax(numeric_only=True)),
         (lambda x: x.cummin(numeric_only=True)),
         (lambda x: x.cumprod()),
+        (lambda x: x.shift(periods=2)),
     ],
     ids=[
         "cumsum",
         "cummax",
         "cummin",
         "cumprod",
+        "shift",
     ],
 )
 def test_dataframe_groupby_analytic(
@@ -224,6 +226,30 @@ def test_dataframe_groupby_analytic(
     col_names = ["float64_col", "int64_col", "bool_col", "string_col"]
     bf_result = operator(scalars_df_index[col_names].groupby("string_col"))
     pd_result = operator(scalars_pandas_df_index[col_names].groupby("string_col"))
+    bf_result_computed = bf_result.to_pandas()
+
+    pd.testing.assert_frame_equal(pd_result, bf_result_computed, check_dtype=False)
+
+
+def test_series_groupby_skew(scalars_df_index, scalars_pandas_df_index):
+    bf_result = scalars_df_index.groupby("bool_col")["int64_too"].skew().to_pandas()
+    pd_result = scalars_pandas_df_index.groupby("bool_col")["int64_too"].skew()
+
+    pd.testing.assert_series_equal(pd_result, bf_result, check_dtype=False)
+
+
+def test_dataframe_groupby_skew(scalars_df_index, scalars_pandas_df_index):
+    col_names = ["float64_col", "int64_col", "bool_col"]
+    bf_result = scalars_df_index[col_names].groupby("bool_col").skew().to_pandas()
+    pd_result = scalars_pandas_df_index[col_names].groupby("bool_col").skew()
+
+    pd.testing.assert_frame_equal(pd_result, bf_result, check_dtype=False)
+
+
+def test_dataframe_groupby_diff(scalars_df_index, scalars_pandas_df_index):
+    col_names = ["float64_col", "int64_col", "string_col"]
+    bf_result = scalars_df_index[col_names].groupby("string_col").diff(-1)
+    pd_result = scalars_pandas_df_index[col_names].groupby("string_col").diff(-1)
     bf_result_computed = bf_result.to_pandas()
 
     pd.testing.assert_frame_equal(pd_result, bf_result_computed, check_dtype=False)

--- a/tests/system/small/test_ipython.py
+++ b/tests/system/small/test_ipython.py
@@ -22,7 +22,8 @@ def test_repr_cache(scalars_df_index):
     # Make sure the df has a new block that the method return value
     # is not already cached.
     test_df = scalars_df_index.head()
+    test_df._block.retrieve_repr_request_results.cache_clear()
     results = display_formatter.format(test_df)
     assert results[0].keys() == {"text/plain", "text/html"}
-    assert test_df._block.retrieve_repr_request_results.cache_info().misses == 1
-    assert test_df._block.retrieve_repr_request_results.cache_info().hits == 1
+    assert test_df._block.retrieve_repr_request_results.cache_info().misses >= 1
+    assert test_df._block.retrieve_repr_request_results.cache_info().hits >= 1

--- a/tests/system/small/test_pandas.py
+++ b/tests/system/small/test_pandas.py
@@ -209,3 +209,17 @@ def test_merge_series(scalars_dfs, merge_how):
     )
 
     assert_pandas_df_equal_ignore_ordering(bf_result, pd_result)
+
+
+def test_cut(scalars_dfs):
+    scalars_df, scalars_pandas_df = scalars_dfs
+
+    pd_result = pd.cut(scalars_pandas_df["float64_col"], 5, labels=False)
+    bf_result = bpd.cut(scalars_df["float64_col"], 5, labels=False)
+
+    # make sure the result is a supported dtype
+    assert bf_result.dtype == bpd.Int64Dtype()
+
+    bf_result = bf_result.to_pandas()
+    pd_result = pd_result.astype("Int64")
+    pd.testing.assert_series_equal(bf_result, pd_result)

--- a/tests/unit/ml/test_golden_sql.py
+++ b/tests/unit/ml/test_golden_sql.py
@@ -1,0 +1,47 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import pytest_mock
+
+import bigframes
+from bigframes.ml import linear_model
+import bigframes.pandas as bpd
+
+
+def test_linear_regression_default_fit(mocker: pytest_mock.MockerFixture):
+    mock_session = mock.create_autospec(spec=bigframes.Session)
+
+    mock_X = mock.create_autospec(spec=bpd.DataFrame)
+    mock_X._get_block().expr._session = mock_session
+
+    mock_y = mock.create_autospec(spec=bpd.DataFrame)
+    mock_y.columns.tolist.return_value = ["input_label_column"]
+
+    mock_X.join(mock_y).sql = "input_dataframe_sql"
+
+    # return values we don't care about, but need to provide to continue the program
+    mock_session._start_query.return_value = (None, mock.MagicMock())
+
+    mocker.patch(
+        "bigframes.ml.core._create_temp_model_name", return_value="temp_model_name"
+    )
+
+    model = linear_model.LinearRegression()
+    model.fit(mock_X, mock_y)
+
+    mock_session._start_query.assert_called_once_with(
+        'CREATE TEMP MODEL `temp_model_name`\nOPTIONS(\n  model_type="LINEAR_REG",\n  data_split_method="NO_SPLIT",\n  fit_intercept=True,\n  INPUT_LABEL_COLS=["input_label_column"])\nAS input_dataframe_sql'
+    )

--- a/tests/unit/ml/test_pipeline.py
+++ b/tests/unit/ml/test_pipeline.py
@@ -18,38 +18,35 @@ import sklearn.linear_model as sklearn_linear_model  # type: ignore
 import sklearn.pipeline as sklearn_pipeline  # type: ignore
 import sklearn.preprocessing as sklearn_preprocessing  # type: ignore
 
-import bigframes.ml.compose
-import bigframes.ml.linear_model
-import bigframes.ml.pipeline
-import bigframes.ml.preprocessing
+from bigframes.ml import compose, forecasting, linear_model, pipeline, preprocessing
 
 
 def test_pipeline_repr():
-    pipeline = bigframes.ml.pipeline.Pipeline(
+    pl = pipeline.Pipeline(
         [
             (
                 "preproc",
-                bigframes.ml.compose.ColumnTransformer(
+                compose.ColumnTransformer(
                     [
                         (
                             "onehot",
-                            bigframes.ml.preprocessing.OneHotEncoder(),
+                            preprocessing.OneHotEncoder(),
                             "species",
                         ),
                         (
                             "scale",
-                            bigframes.ml.preprocessing.StandardScaler(),
+                            preprocessing.StandardScaler(),
                             ["culmen_length_mm", "flipper_length_mm"],
                         ),
                     ]
                 ),
             ),
-            ("linreg", bigframes.ml.linear_model.LinearRegression()),
+            ("linreg", linear_model.LinearRegression()),
         ]
     )
 
     assert (
-        pipeline.__repr__()
+        pl.__repr__()
         == """Pipeline(steps=[('preproc',
                  ColumnTransformer(transformers=[('onehot', OneHotEncoder(),
                                                   'species'),
@@ -62,29 +59,29 @@ def test_pipeline_repr():
 
 @pytest.mark.skipif(sklearn_pipeline is None, reason="requires sklearn")
 def test_pipeline_repr_matches_sklearn():
-    bf_pipeline = bigframes.ml.pipeline.Pipeline(
+    bf_pl = pipeline.Pipeline(
         [
             (
                 "preproc",
-                bigframes.ml.compose.ColumnTransformer(
+                compose.ColumnTransformer(
                     [
                         (
                             "onehot",
-                            bigframes.ml.preprocessing.OneHotEncoder(),
+                            preprocessing.OneHotEncoder(),
                             "species",
                         ),
                         (
                             "scale",
-                            bigframes.ml.preprocessing.StandardScaler(),
+                            preprocessing.StandardScaler(),
                             ["culmen_length_mm", "flipper_length_mm"],
                         ),
                     ]
                 ),
             ),
-            ("linreg", bigframes.ml.linear_model.LinearRegression()),
+            ("linreg", linear_model.LinearRegression()),
         ]
     )
-    sk_pipeline = sklearn_pipeline.Pipeline(
+    sk_pl = sklearn_pipeline.Pipeline(
         [
             (
                 "preproc",
@@ -107,4 +104,17 @@ def test_pipeline_repr_matches_sklearn():
         ]
     )
 
-    assert bf_pipeline.__repr__() == sk_pipeline.__repr__()
+    assert bf_pl.__repr__() == sk_pl.__repr__()
+
+
+def test_pipeline_arima_plus_not_implemented():
+    with pytest.raises(NotImplementedError):
+        pipeline.Pipeline(
+            [
+                (
+                    "transform",
+                    preprocessing.StandardScaler(),
+                ),
+                ("estimator", forecasting.ARIMAPlus()),
+            ]
+        )

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -13,9 +13,12 @@
 # limitations under the License.
 
 import ibis
+import ibis.expr.types as ibis_types
 import pandas
 
 import bigframes.core as core
+import bigframes.operations as ops
+import bigframes.operations.aggregations as agg_ops
 
 from . import resources
 
@@ -46,6 +49,42 @@ def test_arrayvalue_constructor_from_ibis_table_adds_all_columns():
     assert len(actual.columns) == 3
 
 
+def test_arrayvalue_with_get_column_type():
+    value = resources.create_arrayvalue(
+        pandas.DataFrame(
+            {
+                "col1": [1, 2, 3],
+                "col2": ["a", "b", "c"],
+                "col3": [0.1, 0.2, 0.3],
+            }
+        ),
+        total_ordering_columns=["col1"],
+    )
+    col1_type = value.get_column_type("col1")
+    col2_type = value.get_column_type("col2")
+    col3_type = value.get_column_type("col3")
+    assert isinstance(col1_type, pandas.Int64Dtype)
+    assert isinstance(col2_type, pandas.StringDtype)
+    assert isinstance(col3_type, pandas.Float64Dtype)
+
+
+def test_arrayvalue_with_get_column():
+    value = resources.create_arrayvalue(
+        pandas.DataFrame(
+            {
+                "col1": [1, 2, 3],
+                "col2": ["a", "b", "c"],
+                "col3": [0.1, 0.2, 0.3],
+            }
+        ),
+        total_ordering_columns=["col1"],
+    )
+    col1 = value.get_column("col1")
+    assert isinstance(col1, ibis_types.Value)
+    assert col1.get_name() == "col1"
+    assert col1.type().is_int64()
+
+
 def test_arrayvalue_to_ibis_expr_with_projection():
     value = resources.create_arrayvalue(
         pandas.DataFrame(
@@ -69,3 +108,133 @@ def test_arrayvalue_to_ibis_expr_with_projection():
     assert actual.columns[0] == "int64_col"
     assert actual.columns[1] == "literals"
     assert actual.columns[2] == "string_col"
+
+
+def test_arrayvalues_to_ibis_expr_with_get_column():
+    value = resources.create_arrayvalue(
+        pandas.DataFrame(
+            {
+                "col1": [1, 2, 3],
+                "col2": ["a", "b", "c"],
+                "col3": [0.1, 0.2, 0.3],
+            }
+        ),
+        total_ordering_columns=["col1"],
+    )
+    expr = value.get_column("col1")
+    assert expr.get_name() == "col1"
+    assert expr.type().is_int64()
+
+
+def test_arrayvalues_to_ibis_expr_with_concat():
+    value = resources.create_arrayvalue(
+        pandas.DataFrame(
+            {
+                "col1": [1, 2, 3],
+                "col2": ["a", "b", "c"],
+                "col3": [0.1, 0.2, 0.3],
+            }
+        ),
+        total_ordering_columns=["col1"],
+    )
+    expr = value.concat([value])
+    actual = expr.to_ibis_expr()
+    assert len(actual.columns) == 3
+    # TODO(ashleyxu, b/299631930): test out the union expression
+    assert actual.columns[0] == "column_0"
+    assert actual.columns[1] == "column_1"
+    assert actual.columns[2] == "column_2"
+
+
+def test_arrayvalues_to_ibis_expr_with_project_unary_op():
+    value = resources.create_arrayvalue(
+        pandas.DataFrame(
+            {
+                "col1": [1, 2, 3],
+                "col2": ["a", "b", "c"],
+                "col3": [0.1, 0.2, 0.3],
+            }
+        ),
+        total_ordering_columns=["col1"],
+    )
+    expr = value.project_unary_op("col1", ops.AsTypeOp("string"))
+    assert value.columns[0].type().is_int64()
+    assert expr.columns[0].type().is_string()
+
+
+def test_arrayvalues_to_ibis_expr_with_project_binary_op():
+    value = resources.create_arrayvalue(
+        pandas.DataFrame(
+            {
+                "col1": [1, 2, 3],
+                "col2": [0.2, 0.3, 0.4],
+                "col3": [0.1, 0.2, 0.3],
+            }
+        ),
+        total_ordering_columns=["col1"],
+    )
+    expr = value.project_binary_op("col2", "col3", ops.add_op, "col4")
+    assert expr.columns[3].type().is_float64()
+    actual = expr.to_ibis_expr()
+    assert len(expr.columns) == 4
+    assert actual.columns[3] == "col4"
+
+
+def test_arrayvalues_to_ibis_expr_with_project_ternary_op():
+    value = resources.create_arrayvalue(
+        pandas.DataFrame(
+            {
+                "col1": [1, 2, 3],
+                "col2": [0.2, 0.3, 0.4],
+                "col3": [True, False, False],
+                "col4": [0.1, 0.2, 0.3],
+            }
+        ),
+        total_ordering_columns=["col1"],
+    )
+    expr = value.project_ternary_op("col2", "col3", "col4", ops.where_op, "col5")
+    assert expr.columns[4].type().is_float64()
+    actual = expr.to_ibis_expr()
+    assert len(expr.columns) == 5
+    assert actual.columns[4] == "col5"
+
+
+def test_arrayvalue_to_ibis_expr_with_aggregate():
+    value = resources.create_arrayvalue(
+        pandas.DataFrame(
+            {
+                "col1": [1, 2, 3],
+                "col2": ["a", "b", "c"],
+                "col3": [0.1, 0.2, 0.3],
+            }
+        ),
+        total_ordering_columns=["col1"],
+    )
+    expr = value.aggregate(
+        aggregations=(("col1", agg_ops.sum_op, "col4"),),
+        by_column_ids=["col1"],
+        dropna=False,
+    )
+    actual = expr.to_ibis_expr()
+    assert len(expr.columns) == 2
+    assert actual.columns[0] == "col1"
+    assert actual.columns[1] == "col4"
+    assert expr.columns[1].type().is_int64()
+
+
+def test_arrayvalue_to_ibis_expr_with_corr_aggregate():
+    value = resources.create_arrayvalue(
+        pandas.DataFrame(
+            {
+                "col1": [1, 2, 3],
+                "col2": ["a", "b", "c"],
+                "col3": [0.1, 0.2, 0.3],
+            }
+        ),
+        total_ordering_columns=["col1"],
+    )
+    expr = value.corr_aggregate(corr_aggregations=[("col1", "col3", "col4")])
+    actual = expr.to_ibis_expr()
+    assert len(expr.columns) == 1
+    assert actual.columns[0] == "col4"
+    assert expr.columns[0].type().is_float64()

--- a/third_party/bigframes_vendored/ibis/backends/bigquery/registry.py
+++ b/third_party/bigframes_vendored/ibis/backends/bigquery/registry.py
@@ -12,8 +12,20 @@ def _approx_quantiles(translator, op: vendored_ibis_ops.ApproximateMultiQuantile
     return f"APPROX_QUANTILES({arg}, {num_bins})"
 
 
+def _first_non_null_value(translator, op: vendored_ibis_ops.FirstNonNullValue):
+    arg = translator.translate(op.arg)
+    return f"FIRST_VALUE({arg} IGNORE NULLS)"
+
+
+def _last_non_null_value(translator, op: vendored_ibis_ops.LastNonNullValue):
+    arg = translator.translate(op.arg)
+    return f"LAST_VALUE({arg} IGNORE NULLS)"
+
+
 patched_ops = {
     vendored_ibis_ops.ApproximateMultiQuantile: _approx_quantiles,
+    vendored_ibis_ops.FirstNonNullValue: _first_non_null_value,
+    vendored_ibis_ops.LastNonNullValue: _last_non_null_value,
 }
 
 OPERATION_REGISTRY.update(patched_ops)

--- a/third_party/bigframes_vendored/ibis/expr/operations/__init__.py
+++ b/third_party/bigframes_vendored/ibis/expr/operations/__init__.py
@@ -1,4 +1,5 @@
 # Contains code from https://github.com/ibis-project/ibis/blob/master/ibis/expr/operations/__init__.py
 from __future__ import annotations
 
+from third_party.bigframes_vendored.ibis.expr.operations.analytic import *  # noqa: F403
 from third_party.bigframes_vendored.ibis.expr.operations.reductions import *  # noqa: F403

--- a/third_party/bigframes_vendored/ibis/expr/operations/analytic.py
+++ b/third_party/bigframes_vendored/ibis/expr/operations/analytic.py
@@ -1,0 +1,26 @@
+# Contains code from https://github.com/ibis-project/ibis/blob/master/ibis/expr/operations/analytic.py
+
+from __future__ import annotations
+
+from ibis.expr.operations.analytic import Analytic
+import ibis.expr.rules as rlz
+
+
+class FirstNonNullValue(Analytic):
+    """Retrieve the first element."""
+
+    arg = rlz.column(rlz.any)
+    output_dtype = rlz.dtype_like("arg")
+
+
+class LastNonNullValue(Analytic):
+    """Retrieve the last element."""
+
+    arg = rlz.column(rlz.any)
+    output_dtype = rlz.dtype_like("arg")
+
+
+__all__ = [
+    "FirstNonNullValue",
+    "LastNonNullValue",
+]

--- a/third_party/bigframes_vendored/pandas/core/frame.py
+++ b/third_party/bigframes_vendored/pandas/core/frame.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from typing import Iterable, Literal, Mapping, Optional, Sequence, Union
 
-import numpy
+import numpy as np
 
 from bigframes import constants
 from third_party.bigframes_vendored.pandas.core.generic import NDFrame
@@ -56,7 +56,7 @@ class DataFrame(NDFrame):
         return [self.index, self.columns]
 
     @property
-    def values(self) -> numpy.ndarray:
+    def values(self) -> np.ndarray:
         """Return the values of DataFrame in the form of a NumPy array.
 
         Args:
@@ -72,9 +72,7 @@ class DataFrame(NDFrame):
 
     # ----------------------------------------------------------------------
     # IO methods (to / from other formats)
-    def to_numpy(
-        self, dtype=None, copy=False, na_value=None, **kwargs
-    ) -> numpy.ndarray:
+    def to_numpy(self, dtype=None, copy=False, na_value=None, **kwargs) -> np.ndarray:
         """
         Convert the DataFrame to a NumPy array.
 
@@ -154,6 +152,250 @@ class DataFrame(NDFrame):
         """
         raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
 
+    def to_dict(
+        self,
+        orient: Literal[
+            "dict", "list", "series", "split", "tight", "records", "index"
+        ] = "dict",
+        into: type[dict] = dict,
+        **kwargs,
+    ) -> dict | list[dict]:
+        """
+        Convert the DataFrame to a dictionary.
+
+        The type of the key-value pairs can be customized with the parameters
+        (see below).
+
+        Args:
+            orient (str {'dict', 'list', 'series', 'split', 'tight', 'records', 'index'}):
+                Determines the type of the values of the dictionary.
+                'dict' (default) : dict like {column -> {index -> value}}.
+                'list' : dict like {column -> [values]}.
+                'series' : dict like {column -> Series(values)}.
+                split' : dict like {'index' -> [index], 'columns' -> [columns], 'data' -> [values]}.
+                'tight' : dict like {'index' -> [index], 'columns' -> [columns], 'data' -> [values],
+                'index_names' -> [index.names], 'column_names' -> [column.names]}.
+                'records' : list like [{column -> value}, ... , {column -> value}].
+                'index' : dict like {index -> {column -> value}}.
+            into (class, default dict):
+                The collections.abc.Mapping subclass used for all Mappings
+                in the return value.  Can be the actual class or an empty
+                instance of the mapping type you want.  If you want a
+                collections.defaultdict, you must pass it initialized.
+
+            index (bool, default True):
+                Whether to include the index item (and index_names item if `orient`
+                is 'tight') in the returned dictionary. Can only be ``False``
+                when `orient` is 'split' or 'tight'.
+
+        Returns:
+            dict or list of dict: Return a collections.abc.Mapping object representing the DataFrame.
+            The resulting transformation depends on the `orient` parameter.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
+    def to_excel(self, excel_writer, sheet_name: str = "Sheet1", **kwargs) -> None:
+        """
+        Write DataFrame to an Excel sheet.
+
+        To write a single DataFrame to an Excel .xlsx file it is only necessary to
+        specify a target file name. To write to multiple sheets it is necessary to
+        create an `ExcelWriter` object with a target file name, and specify a sheet
+        in the file to write to.
+
+        Multiple sheets may be written to by specifying unique `sheet_name`.
+        With all data written to the file it is necessary to save the changes.
+        Note that creating an `ExcelWriter` object with a file name that already
+        exists will result in the contents of the existing file being erased.
+
+        Args:
+            excel_writer (path-like, file-like, or ExcelWriter object):
+                File path or existing ExcelWriter.
+            sheet_name (str, default 'Sheet1'):
+                Name of sheet which will contain DataFrame.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
+    def to_latex(
+        self, buf=None, columns=None, header=True, index=True, **kwargs
+    ) -> str | None:
+        r"""
+        Render object to a LaTeX tabular, longtable, or nested table.
+
+        Requires ``\usepackage{{booktabs}}``.  The output can be copy/pasted
+        into a main LaTeX document or read from an external file
+        with ``\input{{table.tex}}``.
+
+        Args:
+            buf (str, Path or StringIO-like, optional, default None):
+                Buffer to write to. If None, the output is returned as a string.
+            columns (list of label, optional):
+                The subset of columns to write. Writes all columns by default.
+            header (bool or list of str, default True):
+                Write out the column names. If a list of strings is given,
+                it is assumed to be aliases for the column names.
+            index (bool, default True):
+                Write row names (index).
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
+    def to_records(
+        self, index: bool = True, column_dtypes=None, index_dtypes=None
+    ) -> np.recarray:
+        """
+        Convert DataFrame to a NumPy record array.
+
+        Index will be included as the first field of the record array if
+        requested.
+
+        Args:
+            index (bool, default True):
+                Include index in resulting record array, stored in 'index'
+                field or using the index label, if set.
+            column_dtypes (str, type, dict, default None):
+                If a string or type, the data type to store all columns. If
+                a dictionary, a mapping of column names and indices (zero-indexed)
+                to specific data types.
+            index_dtypes (str, type, dict, default None):
+                If a string or type, the data type to store all index levels. If
+                a dictionary, a mapping of index level names and indices
+                (zero-indexed) to specific data types.
+
+                This mapping is applied only if `index=True`.
+
+        Returns:
+            np.recarray: NumPy ndarray with the DataFrame labels as fields and each row
+            of the DataFrame as entries.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
+    def to_string(
+        self,
+        buf=None,
+        columns: Sequence[str] | None = None,
+        col_space=None,
+        header: bool | Sequence[str] = True,
+        index: bool = True,
+        na_rep: str = "NaN",
+        formatters=None,
+        float_format=None,
+        sparsify: bool | None = None,
+        index_names: bool = True,
+        justify: str | None = None,
+        max_rows: int | None = None,
+        max_cols: int | None = None,
+        show_dimensions: bool = False,
+        decimal: str = ".",
+        line_width: int | None = None,
+        min_rows: int | None = None,
+        max_colwidth: int | None = None,
+        encoding: str | None = None,
+    ):
+        """Render a DataFrame to a console-friendly tabular output.
+
+        Args:
+            buf (str, Path or StringIO-like, optional, default None):
+                Buffer to write to. If None, the output is returned as a string.
+            columns (sequence, optional, default None):
+                The subset of columns to write. Writes all columns by default.
+            col_space (int, list or dict of int, optional):
+                The minimum width of each column.
+            header (bool or sequence, optional):
+                Write out the column names. If a list of strings is given, it is assumed to be aliases for the column names.
+            index (bool, optional, default True):
+                Whether to print index (row) labels.
+            na_rep (str, optional, default 'NaN'):
+                String representation of NAN to use.
+            formatters (list, tuple or dict of one-param. functions, optional):
+                Formatter functions to apply to columns' elements by position or
+                name.
+                The result of each function must be a unicode string.
+                List/tuple must be of length equal to the number of columns.
+            float_format (one-parameter function, optional, default None):
+                Formatter function to apply to columns' elements if they are
+                floats. The result of this function must be a unicode string.
+            sparsify (bool, optional, default True):
+                Set to False for a DataFrame with a hierarchical index to print
+                every multiindex key at each row.
+            index_names (bool, optional, default True):
+                Prints the names of the indexes.
+            justify (str, default None):
+                How to justify the column labels. If None uses the option from
+                the print configuration (controlled by set_option), 'right' out
+                of the box. Valid values are, 'left', 'right', 'center', 'justify',
+                'justify-all', 'start', 'end', 'inherit', 'match-parent', 'initial',
+                'unset'.
+            max_rows (int, optional):
+                Maximum number of rows to display in the console.
+            min_rows (int, optional):
+                The number of rows to display in the console in a truncated repr
+                (when number of rows is above `max_rows`).
+            max_cols (int, optional):
+                Maximum number of columns to display in the console.
+            show_dimensions (bool, default False):
+                Display DataFrame dimensions (number of rows by number of columns).
+            decimal (str, default '.'):
+                Character recognized as decimal separator, e.g. ',' in Europe.
+            line_width (int, optional):
+                Width to wrap a line in characters.
+            max_colwidth (int, optional):
+                Max width to truncate each column in characters. By default, no limit.
+            encoding (str, default "utf-8"):
+                Set character encoding.
+
+        Returns:
+            str or None: If buf is None, returns the result as a string. Otherwise returns
+            None.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
+    def to_markdown(
+        self,
+        buf=None,
+        mode: str = "wt",
+        index: bool = True,
+        **kwargs,
+    ):
+        """Print DataFrame in Markdown-friendly format.
+
+        Args:
+            buf (str, Path or StringIO-like, optional, default None):
+                Buffer to write to. If None, the output is returned as a string.
+            mode (str, optional):
+                Mode in which file is opened.
+            index (bool, optional, default True):
+                Add index (row) labels.
+            **kwargs
+                These parameters will be passed to `tabulate                 <https://pypi.org/project/tabulate>`_.
+
+        Returns:
+            DataFrame in Markdown-friendly format.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
+    def to_pickle(self, path, **kwargs) -> None:
+        """Pickle (serialize) object to file.
+
+        Args:
+            path (str):
+                File path where the pickled object will be stored.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
+    def to_orc(self, path=None, **kwargs) -> bytes | None:
+        """
+        Write a DataFrame to the ORC format.
+
+        Args:
+            path (str, file-like object or None, default None):
+                If a string, it will be used as Root Directory path
+                when writing a partitioned dataset. By file-like object,
+                we refer to objects with a write() method, such as a file handle
+                (e.g. via builtin open function). If path is None,
+                a bytes object is returned.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
     # ----------------------------------------------------------------------
     # Unsorted
 
@@ -184,6 +426,53 @@ class DataFrame(NDFrame):
 
     # ----------------------------------------------------------------------
     # Reindexing and alignment
+
+    def reindex(
+        self,
+        labels=None,
+        *,
+        index=None,
+        columns=None,
+        axis=None,
+    ):
+        """Conform DataFrame to new index with optional filling logic.
+
+        Places NA in locations having no value in the previous index. A new object
+        is produced.
+
+        Args:
+            labels (array-like, optional):
+                New labels / index to conform the axis specified by 'axis' to.
+            index (array-like, optional):
+                New labels for the index. Preferably an Index object to avoid
+                duplicating data.
+            columns (array-like, optional):
+                New labels for the columns. Preferably an Index object to avoid
+                duplicating data.
+            axis (int or str, optional):
+                Axis to target. Can be either the axis name ('index', 'columns')
+                or number (0, 1).
+        Returns:
+            DataFrame: DataFrame with changed index.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
+    def reindex_like(self, other):
+        """Return an object with matching indices as other object.
+
+        Conform the object to the same index on all axes. Optional
+        filling logic, placing Null in locations having no value
+        in the previous index.
+
+        Args:
+            other (Object of the same data type):
+                Its row and column indices are used to define the new indices
+                of this object.
+
+        Returns:
+            Series or DataFrame: Same type as caller, but with changed indices on each axis.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
 
     def drop(
         self, labels=None, *, axis=0, index=None, columns=None, level=None
@@ -276,7 +565,9 @@ class DataFrame(NDFrame):
         """
         raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
 
-    def reorder_levels(self, order: Sequence[int | str]) -> DataFrame:
+    def reorder_levels(
+        self, order: Sequence[int | str], axis: str | int = 0
+    ) -> DataFrame:
         """
         Rearrange index levels using input order. May not drop or duplicate levels.
 
@@ -284,13 +575,33 @@ class DataFrame(NDFrame):
             order (list of int or list of str):
                 List representing new level order. Reference level by number
                 (position) or by key (label).
+            axis ({0 or 'index', 1 or 'columns'}, default 0):
+                Where to reorder levels.
 
         Returns:
             DataFrame: DataFrame of rearranged index.
         """
         raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
 
-    def droplevel(self, level):
+    def swaplevel(self, i, j, axis: str | int = 0) -> DataFrame:
+        """
+        Swap levels i and j in a :class:`MultiIndex`.
+
+        Default is to swap the two innermost levels of the index.
+
+        Args:
+            i, j (int or str):
+                Levels of the indices to be swapped. Can pass level name as string.
+            axis ({0 or 'index', 1 or 'columns'}, default 0):
+                The axis to swap levels on. 0 or 'index' for row-wise, 1 or
+                'columns' for column-wise.
+
+        Returns:
+            DataFrame: DataFrame with levels swapped in MultiIndex.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
+    def droplevel(self, level, axis: str | int = 0):
         """
         Return DataFrame with requested index / column level(s) removed.
 
@@ -299,6 +610,11 @@ class DataFrame(NDFrame):
                 If a string is given, must be the name of a level
                 If list-like, elements must be names or positional indexes
                 of levels.
+            axis ({0 or 'index', 1 or 'columns'}, default 0):
+                Axis along which the level(s) is removed:
+
+                * 0 or 'index': remove level(s) in column.
+                * 1 or 'columns': remove level(s) in row.
         Returns:
             DataFrame: DataFrame with requested index / column level(s) removed.
         """
@@ -889,6 +1205,54 @@ class DataFrame(NDFrame):
         """
         raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
 
+    def combine(
+        self, other, func, fill_value=None, overwrite: bool = True
+    ) -> DataFrame:
+        """Perform column-wise combine with another DataFrame.
+
+        Combines a DataFrame with `other` DataFrame using `func`
+        to element-wise combine columns. The row and column indexes of the
+        resulting DataFrame will be the union of the two.
+
+        Args:
+            other (DataFrame):
+                The DataFrame to merge column-wise.
+            func (function):
+                Function that takes two series as inputs and return a Series or a
+                scalar. Used to merge the two dataframes column by columns.
+            fill_value (scalar value, default None):
+                The value to fill NaNs with prior to passing any column to the
+                merge func.
+            overwrite (bool, default True):
+                If True, columns in `self` that do not exist in `other` will be
+                overwritten with NaNs.
+
+        Returns:
+            DataFrame: Combination of the provided DataFrames.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
+    def combine_first(self, other) -> DataFrame:
+        """
+        Update null elements with value in the same location in `other`.
+
+        Combine two DataFrame objects by filling null values in one DataFrame
+        with non-null values from other DataFrame. The row and column indexes
+        of the resulting DataFrame will be the union of the two. The resulting
+        dataframe contains the 'first' dataframe values and overrides the
+        second one values where both first.loc[index, col] and
+        second.loc[index, col] are not missing values, upon calling
+        first.combine_first(second).
+
+        Args:
+            other (DataFrame):
+                Provided DataFrame to use to fill null values.
+
+        Returns:
+            DataFrame: The result of combining the provided DataFrame with the other object.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
     # ----------------------------------------------------------------------
     # Data reshaping
 
@@ -1191,6 +1555,20 @@ class DataFrame(NDFrame):
         """
         raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
 
+    def skew(self, *, numeric_only: bool = False):
+        """Return unbiased skew over requested axis.
+
+        Normalized by N-1.
+
+        Args:
+            numeric_only (bool, default False):
+                Include only float, int, boolean columns.
+
+        Returns:
+            Series
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
     def std(self, *, numeric_only: bool = False):
         """Return sample standard deviation over requested axis.
 
@@ -1219,6 +1597,76 @@ class DataFrame(NDFrame):
         Returns:
             bigframes.series.Series: For each column/row the number of
                 non-NA/null entries. If `level` is specified returns a `DataFrame`.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
+    def nlargest(self, n: int, columns, keep: str = "first"):
+        """
+        Return the first `n` rows ordered by `columns` in descending order.
+
+        Return the first `n` rows with the largest values in `columns`, in
+        descending order. The columns that are not specified are returned as
+        well, but not used for ordering.
+
+        This method is equivalent to
+        ``df.sort_values(columns, ascending=False).head(n)``, but more
+        performant.
+
+        Args:
+            n (int):
+                Number of rows to return.
+            columns (label or list of labels):
+                Column label(s) to order by.
+            keep ({'first', 'last', 'all'}, default 'first'):
+                Where there are duplicate values:
+
+                - ``first`` : prioritize the first occurrence(s)
+                - ``last`` : prioritize the last occurrence(s)
+                - ``all`` : do not drop any duplicates, even it means
+                  selecting more than `n` items.
+
+        Returns:
+            DataFrame: The first `n` rows ordered by the given columns in descending order.
+
+        .. note::
+            This function cannot be used with all column types. For example, when
+            specifying columns with `object` or `category` dtypes, ``TypeError`` is
+            raised.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
+    def nsmallest(self, n: int, columns, keep: str = "first"):
+        """
+        Return the first `n` rows ordered by `columns` in ascending order.
+
+        Return the first `n` rows with the smallest values in `columns`, in
+        ascending order. The columns that are not specified are returned as
+        well, but not used for ordering.
+
+        This method is equivalent to
+        ``df.sort_values(columns, ascending=True).head(n)``, but more
+        performant.
+
+        Args:
+            n (int):
+                Number of rows to return.
+            columns (label or list of labels):
+                Column label(s) to order by.
+            keep ({'first', 'last', 'all'}, default 'first'):
+                Where there are duplicate values:
+
+                - ``first`` : prioritize the first occurrence(s)
+                - ``last`` : prioritize the last occurrence(s)
+                - ``all`` : do not drop any duplicates, even it means
+                  selecting more than `n` items.
+
+        Returns:
+            DataFrame: The first `n` rows ordered by the given columns in ascending order.
+
+        .. note::
+            This function cannot be used with all column types. For example, when
+            specifying columns with `object` or `category` dtypes, ``TypeError`` is
+            raised.
         """
         raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
 
@@ -1268,6 +1716,25 @@ class DataFrame(NDFrame):
 
         Returns:
             bigframes.dataframe.DataFrame: Return cumulative product of DataFrame.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
+    def diff(
+        self,
+        periods: int = 1,
+    ) -> NDFrame:
+        """First discrete difference of element.
+
+        Calculates the difference of a DataFrame element compared with another
+        element in the DataFrame (default is element in previous row).
+
+        Args:
+            periods (int, default 1):
+                Periods to shift for calculating difference, accepts negative
+                values.
+
+        Returns:
+            bigframes.dataframe.DataFrame: First differences of the Series.
         """
         raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
 

--- a/third_party/bigframes_vendored/pandas/core/generic.py
+++ b/third_party/bigframes_vendored/pandas/core/generic.py
@@ -335,6 +335,41 @@ class NDFrame(indexing.IndexingMixin):
     # ----------------------------------------------------------------------
     # Action Methods
 
+    def ffill(self, *, limit: Optional[int] = None):
+        """Fill NA/NaN values by propagating the last valid observation to next valid.
+
+        Args:
+            limit : int, default None
+                If method is specified, this is the maximum number of consecutive
+                NaN values to forward/backward fill. In other words, if there is
+                a gap with more than this number of consecutive NaNs, it will only
+                be partially filled. If method is not specified, this is the
+                maximum number of entries along the entire axis where NaNs will be
+                filled. Must be greater than 0 if not None.
+
+
+        Returns:
+            Series/DataFrame or None: Object with missing values filled.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
+    def bfill(self, *, limit: Optional[int] = None):
+        """Fill NA/NaN values by using the next valid observation to fill the gap.
+
+        Args:
+            limit : int, default None
+                If method is specified, this is the maximum number of consecutive
+                NaN values to forward/backward fill. In other words, if there is
+                a gap with more than this number of consecutive NaNs, it will only
+                be partially filled. If method is not specified, this is the
+                maximum number of entries along the entire axis where NaNs will be
+                filled. Must be greater than 0 if not None.
+
+        Returns:
+            Series/DataFrame or None: Object with missing values filled.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
     def isna(self) -> NDFrame:
         """Detect missing values.
 
@@ -367,6 +402,36 @@ class NDFrame(indexing.IndexingMixin):
 
     notnull = notna
 
+    def filter(
+        self,
+        items=None,
+        like: str | None = None,
+        regex: str | None = None,
+        axis=None,
+    ) -> NDFrame:
+        """
+        Subset the dataframe rows or columns according to the specified index labels.
+
+        Note that this routine does not filter a dataframe on its
+        contents. The filter is applied to the labels of the index.
+
+        Args:
+            items (list-like):
+                Keep labels from axis which are in items.
+            like (str):
+                Keep labels from axis for which "like in label == True".
+            regex (str (regular expression)):
+                Keep labels from axis for which re.search(regex, label) == True.
+            axis ({0 or 'index', 1 or 'columns', None}, default None):
+                The axis to filter on, expressed either as an index (int)
+                or axis name (str). By default this is the info axis, 'columns' for
+                DataFrame. For `Series` this parameter is unused and defaults to `None`.
+
+        Returns:
+            same type as input object
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
     def shift(
         self,
         periods: int = 1,
@@ -381,6 +446,30 @@ class NDFrame(indexing.IndexingMixin):
 
         Returns:
             NDFrame:  Copy of input object, shifted.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
+    def pct_change(self, periods: int = 1):
+        """
+        Fractional change between the current and a prior element.
+
+        Computes the fractional change from the immediately previous row by
+        default. This is useful in comparing the fraction of change in a time
+        series of elements.
+
+        .. note::
+
+            Despite the name of this method, it calculates fractional change
+            (also known as per unit change or relative change) and not
+            percentage change. If you need the percentage change, multiply
+            these values by 100.
+
+        Args:
+            periods (int, default 1):
+                Periods to shift for forming percent change.
+
+        Returns:
+            Series or DataFrame: The same type as the calling object.
         """
         raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
 

--- a/third_party/bigframes_vendored/pandas/core/groupby/__init__.py
+++ b/third_party/bigframes_vendored/pandas/core/groupby/__init__.py
@@ -124,6 +124,26 @@ class GroupBy:
         """
         raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
 
+    def skew(
+        self,
+        *,
+        numeric_only: bool = False,
+    ):
+        """
+        Return unbiased skew within groups.
+
+        Normalized by N-1.
+
+        Args:
+            numeric_only (bool, default False):
+                Include only `float`, `int` or `boolean` data.
+
+        Returns:
+            Series or DataFrame
+                Variance of values within each group.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
     def sum(
         self,
         numeric_only: bool = False,

--- a/third_party/bigframes_vendored/pandas/core/indexes/base.py
+++ b/third_party/bigframes_vendored/pandas/core/indexes/base.py
@@ -21,6 +21,16 @@ class Index:
         """
         raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
 
+    @property
+    def nlevels(self) -> int:
+        """Number of levels."""
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
+    @property
+    def is_unique(self) -> bool:
+        """Return if the index has unique values."""
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
     def to_numpy(self, dtype):
         """
         A NumPy ndarray representing the values in this Series or Index.

--- a/third_party/bigframes_vendored/pandas/core/series.py
+++ b/third_party/bigframes_vendored/pandas/core/series.py
@@ -758,6 +758,41 @@ class Series(NDFrame):  # type: ignore[misc]
         """
         raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
 
+    def reindex(self, index=None):
+        """
+        Conform Series to new index with optional filling logic.
+
+        Places NA/NaN in locations having no value in the previous index. A new object
+        is produced unless the new index is equivalent to the current one and
+        ``copy=False``.
+
+        Args:
+            index (array-like, optional):
+                New labels for the index. Preferably an Index object to avoid
+                duplicating data.
+
+        Returns:
+            Series: Series with changed index.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
+    def reindex_like(self, other):
+        """Return an object with matching indices as other object.
+
+        Conform the object to the same index on all axes. Optional
+        filling logic, placing Null in locations having no value
+        in the previous index.
+
+        Args:
+            other (Object of the same data type):
+                Its row and column indices are used to define the new indices
+                of this object.
+
+        Returns:
+            Series or DataFrame: Same type as caller, but with changed indices on each axis.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
     def drop(
         self, labels=None, *, axis=0, index=None, columns=None, level=None
     ) -> Series | None:
@@ -790,7 +825,7 @@ class Series(NDFrame):  # type: ignore[misc]
         """
         raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
 
-    def reorder_levels(self, order: Sequence) -> Series:
+    def reorder_levels(self, order: Sequence, axis) -> Series:
         """
         Rearrange index levels using input order.
 
@@ -800,12 +835,31 @@ class Series(NDFrame):  # type: ignore[misc]
             order (list of int representing new level order):
                 Reference level by number or key.
 
+            axis ({0 or 'index', 1 or 'columns'}, default 0):
+                For `Series` this parameter is unused and defaults to 0.
+
+
         Returns:
             type of caller (new object)
         """
         raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
 
-    def droplevel(self, level):
+    def swaplevel(self, i, j):
+        """
+        Swap levels i and j in a `MultiIndex`.
+
+        Default is to swap the two innermost levels of the index.
+
+        Args:
+            i, j (int or str):
+                Levels of the indices to be swapped. Can pass level name as string.
+
+        Returns:
+            Series: Series with levels swapped in MultiIndex
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
+    def droplevel(self, level, axis):
         """
         Return Series with requested index / column level(s) removed.
 
@@ -814,6 +868,9 @@ class Series(NDFrame):  # type: ignore[misc]
                 If a string is given, must be the name of a level
                 If list-like, elements must be names or positional indexes
                 of levels.
+
+            axis ({0 or 'index', 1 or 'columns'}, default 0):
+                For `Series` this parameter is unused and defaults to 0.
 
         Returns:
             Series with requested index / column level(s) removed.
@@ -833,6 +890,69 @@ class Series(NDFrame):  # type: ignore[misc]
 
         Returns:
             Series or None: Object with missing values filled or None.
+        """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
+    def replace(
+        self,
+        to_replace,
+        value=None,
+    ) -> Series | None:
+        """
+        Replace values given in `to_replace` with `value`.
+
+        Values of the Series/DataFrame are replaced with other values dynamically.
+        This differs from updating with ``.loc`` or ``.iloc``, which require
+        you to specify a location to update with some value.
+
+        Args:
+            to_replace (str, regex, list, int, float or None):
+                How to find the values that will be replaced.
+
+                * numeric, str or regex:
+
+                    - numeric: numeric values equal to `to_replace` will be
+                      replaced with `value`
+                    - str: string exactly matching `to_replace` will be replaced
+                      with `value`
+                    - regex: regexs matching `to_replace` will be replaced with
+                      `value`
+
+                * list of str, regex, or numeric:
+
+                    - First, if `to_replace` and `value` are both lists, they
+                      **must** be the same length.
+                    - Second, if ``regex=True`` then all of the strings in **both**
+                      lists will be interpreted as regexs otherwise they will match
+                      directly. This doesn't matter much for `value` since there
+                      are only a few possible substitution regexes you can use.
+                    - str, regex and numeric rules apply as above.
+
+            value (scalar, default None):
+                Value to replace any values matching `to_replace` with.
+                For a DataFrame a dict of values can be used to specify which
+                value to use for each column (columns not in the dict will not be
+                filled). Regular expressions, strings and lists or dicts of such
+                objects are also allowed.
+            regex (bool, default False):
+                Whether to interpret `to_replace` and/or `value` as regular
+                expressions. If this is ``True`` then `to_replace` *must* be a
+                string.
+
+        Returns:
+            Series/DataFrame: Object after replacement.
+
+        Raises:
+            TypeError:
+                * If `to_replace` is not a scalar, array-like, ``dict``, or ``None``
+                * If `to_replace` is a ``dict`` and `value` is not a ``list``,
+                  ``dict``, ``ndarray``, or ``Series``
+                * If `to_replace` is ``None`` and `regex` is not compilable
+                  into a regular expression or is a list, dict, ndarray, or
+                  Series.
+                * When replacing multiple ``bool`` or ``datetime64`` objects and
+                  the arguments to `to_replace` does not match the type of the
+                  value being replaced
         """
         raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
 

--- a/third_party/bigframes_vendored/sklearn/base.py
+++ b/third_party/bigframes_vendored/sklearn/base.py
@@ -144,6 +144,7 @@ class TransformerMixin:
             bigframes.dataframe.DataFrame: DataFrame of shape (n_samples, n_features_new)
                 Transformed DataFrame.
         """
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
 
 
 class MetaEstimatorMixin:

--- a/third_party/bigframes_vendored/sklearn/cluster/_kmeans.py
+++ b/third_party/bigframes_vendored/sklearn/cluster/_kmeans.py
@@ -49,7 +49,6 @@ class KMeans(_BaseKMeans):
         self,
         X,
         y=None,
-        transforms: Optional[List[str]] = None,
     ):
         """Compute k-means clustering.
 
@@ -58,10 +57,6 @@ class KMeans(_BaseKMeans):
                 DataFrame of shape (n_samples, n_features). Training data.
             y (default None):
                 Not used, present here for API consistency by convention.
-            transforms (Optional[List[str]], default None):
-                Do not use. Internal param to be deprecated.
-                Use bigframes.ml.pipeline instead.
-
 
         Returns:
             KMeans: Fitted Estimator.

--- a/third_party/bigframes_vendored/sklearn/decomposition/_pca.py
+++ b/third_party/bigframes_vendored/sklearn/decomposition/_pca.py
@@ -49,10 +49,6 @@ class PCA(BaseEstimator, metaclass=ABCMeta):
             y (default None):
                 Ignored.
 
-            transforms (Optional[List[str]], default None):
-                Do not use. Internal param to be deprecated.
-                Use bigframes.ml.pipeline instead.
-
         Returns:
             PCA: Fitted estimator.
         """

--- a/third_party/bigframes_vendored/sklearn/ensemble/_forest.py
+++ b/third_party/bigframes_vendored/sklearn/ensemble/_forest.py
@@ -54,10 +54,6 @@ class BaseForest(MetaEstimatorMixin, BaseEstimator, metaclass=ABCMeta):
                 Series or DataFrame of shape (n_samples,) or (n_samples, n_targets).
                 Target values. Will be cast to X's dtype if necessary.
 
-            transforms (Optional[List[str]], default None):
-                Do not use. Internal param to be deprecated.
-                Use bigframes.ml.pipeline instead.
-
 
         Returns:
             Fitted Estimator.

--- a/third_party/bigframes_vendored/sklearn/linear_model/_base.py
+++ b/third_party/bigframes_vendored/sklearn/linear_model/_base.py
@@ -74,7 +74,6 @@ class LinearRegression(RegressorMixin, LinearModel):
         self,
         X,
         y,
-        transforms: Optional[List[str]] = None,
     ):
         """Fit linear model.
 
@@ -85,10 +84,6 @@ class LinearRegression(RegressorMixin, LinearModel):
             y (bigframes.dataframe.DataFrame or bigframes.series.Series):
                 Series or DataFrame of shape (n_samples,) or (n_samples, n_targets).
                 Target values. Will be cast to X's dtype if necessary.
-
-            transforms (Optional[List[str]], default None):
-                Do not use. Internal param to be deprecated.
-                Use bigframes.ml.pipeline instead.
 
         Returns:
             LinearRegression: Fitted Estimator.

--- a/third_party/bigframes_vendored/sklearn/linear_model/_logistic.py
+++ b/third_party/bigframes_vendored/sklearn/linear_model/_logistic.py
@@ -37,7 +37,6 @@ class LogisticRegression(LinearClassifierMixin, BaseEstimator):
         self,
         X,
         y,
-        transforms: Optional[List[str]] = None,
     ):
         """Fit the model according to the given training data.
 
@@ -49,10 +48,6 @@ class LogisticRegression(LinearClassifierMixin, BaseEstimator):
 
             y (bigframes.dataframe.DataFrame or bigframes.series.Series):
                 DataFrame of shape (n_samples,). Target vector relative to X.
-
-            transforms (Optional[List[str]], default None):
-                Do not use. Internal param to be deprecated.
-                Use bigframes.ml.pipeline instead.
 
 
         Returns:

--- a/third_party/bigframes_vendored/sklearn/preprocessing/_data.py
+++ b/third_party/bigframes_vendored/sklearn/preprocessing/_data.py
@@ -8,10 +8,10 @@
 # License: BSD 3 clause
 
 from bigframes import constants
-from third_party.bigframes_vendored.sklearn.base import BaseEstimator
+from third_party.bigframes_vendored.sklearn.base import BaseEstimator, TransformerMixin
 
 
-class StandardScaler(BaseEstimator):
+class StandardScaler(BaseEstimator, TransformerMixin):
     """Standardize features by removing the mean and scaling to unit variance.
 
     The standard score of a sample `x` is calculated as:z = (x - u) / s
@@ -28,30 +28,23 @@ class StandardScaler(BaseEstimator):
     machine learning estimators: they might behave badly if the
     individual features do not more or less look like standard normally
     distributed data (e.g. Gaussian with 0 mean and unit variance).
-    """
 
-    def fit(self, X):
-        """Compute the mean and std to be used for later scaling.
-
-        Examples:
+    Examples:
 
         .. code-block::
 
             from bigframes.ml.preprocessing import StandardScaler
+            import bigframes.pandas as bpd
 
-            enc = StandardScaler()
-            X = [['Male', 1], ['Female', 3], ['Female', 2]]
-            enc.fit(X)
+            scaler = StandardScaler()
+            data = bpd.DataFrame({"a": [0, 0, 1, 1], "b":[0, 0, 1, 1]})
+            scaler.fit(data)
+            print(scaler.transform(data))
+            print(scaler.transform(bpd.DataFrame({"a": [2], "b":[2]})))
+    """
 
-        Examples:
-
-        .. code-block::
-
-            from bigframes.ml import StandardScaler
-
-            enc = StandardScaler()
-            X = [['Male', 1], ['Female', 3], ['Female', 2]]
-            enc.fit(X)
+    def fit(self, X):
+        """Compute the mean and std to be used for later scaling.
 
         Args:
             X (bigframes.dataframe.DataFrame or bigframes.series.Series):

--- a/third_party/bigframes_vendored/sklearn/preprocessing/_encoder.py
+++ b/third_party/bigframes_vendored/sklearn/preprocessing/_encoder.py
@@ -37,12 +37,8 @@ class OneHotEncoder(BaseEstimator):
             when considering infrequent categories. If there are infrequent categories,
             max_categories includes the category representing the infrequent categories along with the frequent categories.
             Default None, set limit to 1,000,000.
-    """
 
-    def fit(self, X):
-        """Fit OneHotEncoder to X.
-
-        Examples:
+    Examples:
 
         Given a dataset with two features, we let the encoder find the unique
         values per feature and transform the data to a binary one-hot encoding.
@@ -50,10 +46,16 @@ class OneHotEncoder(BaseEstimator):
         .. code-block::
 
             from bigframes.ml.preprocessing import OneHotEncoder
+            import bigframes.pandas as bpd
 
             enc = OneHotEncoder()
-            X = [['Male', 1], ['Female', 3], ['Female', 2]]
+            X = bpd.DataFrame({"a": ["Male", "Female", "Female"], "b": ["1", "3", "2"]})
             enc.fit(X)
+            print(enc.transform(bpd.DataFrame({"a": ["Female", "Male"], "b": ["1", "4"]})))
+    """
+
+    def fit(self, X):
+        """Fit OneHotEncoder to X.
 
         Args:
             X (bigframes.dataframe.DataFrame or bigframes.series.Series):

--- a/third_party/bigframes_vendored/xgboost/sklearn.py
+++ b/third_party/bigframes_vendored/xgboost/sklearn.py
@@ -37,10 +37,6 @@ class XGBModel(XGBModelBase):
                 DataFrame of shape (n_samples,) or (n_samples, n_targets).
                 Target values. Will be cast to X's dtype if necessary.
 
-            transforms (Optional[List[str]], default None):
-                Do not use. Internal param to be deprecated.
-                Use bigframes.ml.pipeline instead.
-
         Returns:
             XGBModel: Fitted Estimator.
         """


### PR DESCRIPTION
feat: add `DataFrame.combine` and `DataFrame.combine_first`
feat: add `DataFrame.skew` and `GroupBy.skew`
test: remove unneeded mock
perf: `bigframes-api` label to I/O query jobs
fix: `remote_function` uses same credentials as other APIs
test: BQML golden SQL unit tests
feat: add `DataFrame.pct_change` and `Series.pct_change`
test: disable `remote_function` reuse in tests
test: fix flaky repr_cache tests
test: add unit tests for private `ArrayValue` class
feat: add `DataFrame.to_dict`, `to_excel`, `to_latex`, `to_records`, `to_string`, `to_markdown`, `to_pickle`, `to_orc`
fix: use for literals `Int64Dtype` in `cut`
feat: add `DataFrame.nlargest`, `nsmallest`
chore: refactor PCA tests
feat: add `bfill` and `ffill` to `DataFrame` and `Series`
feat: add `reindex_like` to `DataFrame` and `Series`
fix: use lowercase strings for parameter literals in `bigframes.ml` (**breaking change**)
feat: support `DataFrame.loc[bool_series, column] = scalar`
fix: support column joins with "None indexer"
docs: document region logic in README
feat: add partial support for `Sereies.replace`
fix: add type hints to models
test: add more unit tests for internal `ArrayValue`
feat: add `filter` and `reindex` to `Series` and `DataFrame`
docs: document possible parameter values for PaLM2TextGenerator
test: mark generate_text test as flaky
feat: support a persistent `name` in `remote_function`
fix: raise error when ARIMAPlus is used with Pipeline
feat: add `swaplevel` to `DataFrame` and `Series`
feat: add `axis` parameter to `droplevel` and `reorder_levels`
docs: fix OneHotEncoder sample
fix: remove `transforms` parameter in `model.fit` (**breaking change**)
feat: add `diff` method to `DataFrame` and `GroupBy`