### PR TITLE
chore: enforce use of conventional commits

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -7,6 +7,7 @@ branchProtectionRules:
   requiresCodeOwnerReviews: true
   requiresStrictStatusChecks: true
   requiredStatusCheckContexts:
+    - 'conventionalcommits.org'
     - 'cla/google'
     - 'OwlBot Post Processor'
     - 'docs'


### PR DESCRIPTION
This will prevent accidental merging of commits that release-please can't handle.