### PR TITLE
chore: remove Git-on-Borg check from config

### DIFF
--- a/.kokoro/build.sh
+++ b/.kokoro/build.sh
@@ -15,11 +15,7 @@
 
 set -eo pipefail
 
-if [[ -z "${KOKORO_GOB_COMMIT}" ]]; then
-    PROJECT_SCM="github/python-bigquery-dataframes"
-else
-    PROJECT_SCM="git/bigframes"
-fi
+PROJECT_SCM="github/python-bigquery-dataframes"
 
 if [[ -z "${PROJECT_ROOT:-}" ]]; then
     PROJECT_ROOT="${KOKORO_ARTIFACTS_DIR}/${PROJECT_SCM}"

--- a/.kokoro/continuous/common.cfg
+++ b/.kokoro/continuous/common.cfg
@@ -7,4 +7,4 @@ action {
   }
 }
 
-build_file: "bigframes/.kokoro/build.sh"
+build_file: "python-bigquery-dataframes/.kokoro/build.sh"

--- a/.kokoro/continuous/nightly.cfg
+++ b/.kokoro/continuous/nightly.cfg
@@ -1,3 +1,3 @@
 # Format: //devtools/kokoro/config/proto/build.proto
 
-build_file: "bigframes/.kokoro/release-nightly.sh"
+build_file: "python-bigquery-dataframes/.kokoro/release-nightly.sh"


### PR DESCRIPTION
Continuous jobs are incorrectly identifying themselves as Git-on-Borg jobs and using the wrong job path.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
