### PR TITLE
feat!: rename `bigframes.pandas.reset_session` to `close_session`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,7 +63,7 @@ auto-populates ``bf.options.bigquery.location`` if the user starts with
 directly or in a SQL statement.
 
 If you want to reset the location of the created DataFrame or Series objects,
-you can reset the session by executing ``bigframes.pandas.reset_session()``.
+you can close the session by executing ``bigframes.pandas.close_session()``.
 After that, you can reuse ``bigframes.pandas.options.bigquery.location`` to
 specify another location.
 
@@ -335,7 +335,7 @@ sessions
 ; when this happens, you can’t use previously
 created DataFrame or Series objects and must re-create them using a new
 BigQuery DataFrames session. You can do this by running
-``bigframes.pandas.reset_session()`` and then re-running the BigQuery
+``bigframes.pandas.close_session()`` and then re-running the BigQuery
 DataFrames expressions.
 
 

--- a/bigframes/__init__.py
+++ b/bigframes/__init__.py
@@ -16,7 +16,7 @@
 
 from bigframes._config import options
 from bigframes._config.bigquery_options import BigQueryOptions
-from bigframes.core.global_session import get_global_session, reset_session
+from bigframes.core.global_session import close_session, get_global_session
 from bigframes.session import connect, Session
 from bigframes.version import __version__
 
@@ -24,7 +24,7 @@ __all__ = [
     "options",
     "BigQueryOptions",
     "get_global_session",
-    "reset_session",
+    "close_session",
     "connect",
     "Session",
     "__version__",

--- a/bigframes/_config/bigquery_options.py
+++ b/bigframes/_config/bigquery_options.py
@@ -23,7 +23,7 @@ import google.auth.credentials
 
 SESSION_STARTED_MESSAGE = (
     "Cannot change '{attribute}' once a session has started. "
-    "Call bigframes.pandas.reset_session() first, if you are using the bigframes.pandas API."
+    "Call bigframes.pandas.close_session() first, if you are using the bigframes.pandas API."
 )
 
 

--- a/bigframes/core/global_session.py
+++ b/bigframes/core/global_session.py
@@ -24,7 +24,7 @@ _global_session: Optional[bigframes.session.Session] = None
 _global_session_lock = threading.Lock()
 
 
-def reset_session() -> None:
+def close_session() -> None:
     """Start a fresh session the next time a function requires a session.
 
     Closes the current session if it was already started.

--- a/bigframes/pandas/__init__.py
+++ b/bigframes/pandas/__init__.py
@@ -447,7 +447,7 @@ options = config.options
 
 # Session management APIs
 get_global_session = global_session.get_global_session
-reset_session = global_session.reset_session
+close_session = global_session.close_session
 
 
 # Use __all__ to let type checkers know what is part of the public API.
@@ -478,5 +478,5 @@ __all___ = [
     "options",
     # Session management APIs
     "get_global_session",
-    "reset_session",
+    "close_session",
 ]

--- a/notebooks/generative_ai/bq_dataframes_llm_code_generation.ipynb
+++ b/notebooks/generative_ai/bq_dataframes_llm_code_generation.ipynb
@@ -354,7 +354,7 @@
         "id": "DTVtFlqeFbrU"
       },
       "source": [
-        "If you want to reset the location of the created DataFrame or Series objects, reset the session by executing `bf.reset_session()`. After that, you can reuse `bf.options.bigquery.location` to specify another location."
+        "If you want to reset the location of the created DataFrame or Series objects, reset the session by executing `bf.close_session()`. After that, you can reuse `bf.options.bigquery.location` to specify another location."
       ]
     },
     {

--- a/notebooks/getting_started/getting_started_bq_dataframes.ipynb
+++ b/notebooks/getting_started/getting_started_bq_dataframes.ipynb
@@ -383,7 +383,7 @@
         "id": "pDfrKwMKE_dK"
       },
       "source": [
-        "If you want to reset the location of the created DataFrame or Series objects, reset the session by executing `bf.reset_session()`. After that, you can reuse `bf.options.bigquery.location` to specify another location."
+        "If you want to reset the location of the created DataFrame or Series objects, reset the session by executing `bf.close_session()`. After that, you can reuse `bf.options.bigquery.location` to specify another location."
       ]
     },
     {

--- a/notebooks/regression/bq_dataframes_ml_linear_regression.ipynb
+++ b/notebooks/regression/bq_dataframes_ml_linear_regression.ipynb
@@ -370,7 +370,7 @@
         "id": "D21CoOlfFTYI"
       },
       "source": [
-        "If you want to reset the location of the created DataFrame or Series objects, reset the session by executing `bf.reset_session()`. After that, you can reuse `bf.options.bigquery.location` to specify another location."
+        "If you want to reset the location of the created DataFrame or Series objects, reset the session by executing `bf.close_session()`. After that, you can reuse `bf.options.bigquery.location` to specify another location."
       ]
     },
     {

--- a/samples/snippets/quickstart_test.py
+++ b/samples/snippets/quickstart_test.py
@@ -23,7 +23,7 @@ def test_quickstart(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     # We need a fresh session since we're modifying connection options.
-    bigframes.pandas.reset_session()
+    bigframes.pandas.close_session()
 
     # TODO(swast): Get project from environment so contributors can run tests.
     quickstart.run_quickstart("bigframes-dev")

--- a/samples/snippets/remote_function_test.py
+++ b/samples/snippets/remote_function_test.py
@@ -23,7 +23,7 @@ def test_remote_function_and_read_gbq_function(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     # We need a fresh session since we're modifying connection options.
-    bigframes.pandas.reset_session()
+    bigframes.pandas.close_session()
 
     # TODO(swast): Get project from environment so contributors can run tests.
     remote_function.run_remote_function_and_read_gbq_function("bigframes-dev")

--- a/tests/system/small/ml/test_llm.py
+++ b/tests/system/small/ml/test_llm.py
@@ -30,7 +30,7 @@ def test_create_text_generator_model(palm2_text_generator_model):
 def test_create_text_generator_model_default_session(bq_connection, llm_text_pandas_df):
     import bigframes.pandas as bpd
 
-    bpd.reset_session()
+    bpd.close_session()
     bpd.options.bigquery.bq_connection = bq_connection
     bpd.options.bigquery.location = "us"
 
@@ -53,7 +53,7 @@ def test_create_text_generator_model_default_connection(llm_text_pandas_df):
     from bigframes import _config
     import bigframes.pandas as bpd
 
-    bpd.reset_session()
+    bpd.close_session()
     _config.options = _config.Options()  # reset configs
 
     llm_text_df = bpd.read_pandas(llm_text_pandas_df)
@@ -130,7 +130,7 @@ def test_create_embedding_generator_model(palm2_embedding_generator_model):
 def test_create_text_embedding_generator_model_defaults(bq_connection):
     import bigframes.pandas as bpd
 
-    bpd.reset_session()
+    bpd.close_session()
     bpd.options.bigquery.bq_connection = bq_connection
     bpd.options.bigquery.location = "us"
 

--- a/tests/system/small/test_pandas_options.py
+++ b/tests/system/small/test_pandas_options.py
@@ -26,7 +26,7 @@ import bigframes.pandas as bpd
 
 @pytest.fixture(autouse=True)
 def reset_default_session_and_location():
-    bpd.reset_session()
+    bpd.close_session()
     bpd.options.bigquery.location = None
 
 
@@ -79,8 +79,8 @@ def test_read_gbq_start_sets_session_location(
     ):
         read_method(query)
 
-    # Reset global session to start over
-    bpd.reset_session()
+    # Close global session to start over
+    bpd.close_session()
 
     # There should still be the previous location set in the bigquery options
     assert bpd.options.bigquery.location == tokyo_location
@@ -254,7 +254,7 @@ def test_read_gbq_must_comply_with_set_location_non_US(
     assert df is not None
 
 
-def test_reset_session_after_credentials_need_reauthentication(monkeypatch):
+def test_close_session_after_credentials_need_reauthentication(monkeypatch):
     # Use a simple test query to verify that default session works to interact
     # with BQ
     test_query = "SELECT 1"
@@ -288,8 +288,8 @@ def test_reset_session_after_credentials_need_reauthentication(monkeypatch):
         with pytest.raises(google.auth.exceptions.RefreshError):
             bpd.read_gbq(test_query)
 
-        # Now verify that resetting the session works
-        bpd.reset_session()
+        # Now verify that closing the session works
+        bpd.close_session()
         assert bigframes.core.global_session._global_session is None
 
     # Now verify that use is able to start over

--- a/tests/unit/test_pandas.py
+++ b/tests/unit/test_pandas.py
@@ -116,7 +116,7 @@ def test_pandas_attribute():
     assert bpd.ArrowDtype is pd.ArrowDtype
 
 
-def test_reset_session_after_bq_session_ended(monkeypatch):
+def test_close_session_after_bq_session_ended(monkeypatch):
     bqclient = mock.create_autospec(google.cloud.bigquery.Client, instance=True)
     bqclient.project = "test-project"
     session = resources.create_bigquery_session(
@@ -144,7 +144,7 @@ def test_reset_session_after_bq_session_ended(monkeypatch):
         bpd.read_gbq("SELECT 1")
 
     # Even though the query to stop the session raises an exception, we should
-    # still be able to reset it without raising an error to the user.
-    bpd.reset_session()
+    # still be able to close it without raising an error to the user.
+    bpd.close_session()
     assert "CALL BQ.ABORT_SESSION('JUST_A_TEST')" in bqclient.query.call_args.args[0]
     assert bigframes.core.global_session._global_session is None


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat!: rename `bigframes.pandas.reset_session` to `close_session` (#101)

Release-As: 0.9.0
END_COMMIT_OVERRIDE