### PR TITLE
fix: use table clone instead of system time for `read_gbq_table`

### DIFF
--- a/bigframes/constants.py
+++ b/bigframes/constants.py
@@ -26,4 +26,4 @@ FEEDBACK_LINK = (
 
 ABSTRACT_METHOD_ERROR_MESSAGE = f"Abstract method. You have likely encountered a bug. Please share this stacktrace and how you reached it with the BigQuery DataFrames team. {FEEDBACK_LINK}"
 
-DEFAULT_EXPIRATION = datetime.timedelta(days=1)
+DEFAULT_EXPIRATION = datetime.timedelta(days=7)

--- a/bigframes/dataframe.py
+++ b/bigframes/dataframe.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import datetime
 import re
 import textwrap
 import typing
@@ -2309,7 +2310,8 @@ class DataFrame(vendored_pandas_frame.DataFrame):
                 self._session.bqclient,
                 self._session._anonymous_dataset,
                 # TODO(swast): allow custom expiration times, probably via session configuration.
-                constants.DEFAULT_EXPIRATION,
+                datetime.datetime.now(datetime.timezone.utc)
+                + constants.DEFAULT_EXPIRATION,
             )
 
             if if_exists is not None and if_exists != "replace":

--- a/bigframes/session/__init__.py
+++ b/bigframes/session/__init__.py
@@ -518,6 +518,15 @@ class Session(
         index and ordering. See:
         https://cloud.google.com/bigquery/docs/table-clones-create
         """
+        if table_ref.dataset_id.upper() == "_SESSION":
+            # _SESSION tables aren't supported by the tables.get REST API.
+            return (
+                self.ibis_client.sql(
+                    f"SELECT * FROM `_SESSION`.`{table_ref.table_id}`"
+                ),
+                None,
+            )
+
         now = datetime.datetime.now(datetime.timezone.utc)
         destination = bigframes_io.create_table_clone(
             table_ref,

--- a/bigframes/session/__init__.py
+++ b/bigframes/session/__init__.py
@@ -664,17 +664,7 @@ class Session(
                 total_ordering_columns=frozenset(index_cols),
             )
 
-            # We have a total ordering, so query via "time travel" so that
-            # the underlying data doesn't mutate.
-            if is_total_ordering:
-                # Get the timestamp from the job metadata rather than the query
-                # text so that the query for determining uniqueness of the ID
-                # columns can be cached.
-                current_timestamp = query_job.started
-
-                # The job finished, so we should have a start time.
-                assert current_timestamp is not None
-            else:
+            if not is_total_ordering:
                 # Make sure when we generate an ordering, the row_number()
                 # coresponds to the index columns.
                 table_expression = table_expression.order_by(index_cols)

--- a/bigframes/session/__init__.py
+++ b/bigframes/session/__init__.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import datetime
 import logging
 import os
 import re
@@ -517,10 +518,12 @@ class Session(
         index and ordering. See:
         https://cloud.google.com/bigquery/docs/table-clones-create
         """
+        now = datetime.datetime.now(datetime.timezone.utc)
         destination = bigframes_io.create_table_clone(
             table_ref,
             self._anonymous_dataset,
-            constants.DEFAULT_EXPIRATION,
+            # TODO(swast): Allow the default expiration to be configured.
+            now + constants.DEFAULT_EXPIRATION,
             self,
             api_name,
         )

--- a/bigframes/session/_io/bigquery.py
+++ b/bigframes/session/_io/bigquery.py
@@ -77,6 +77,17 @@ def create_export_data_statement(
 
 
 def random_table(dataset: bigquery.DatasetReference) -> bigquery.TableReference:
+    """Generate a random table ID with BigQuery DataFrames prefix.
+
+    Args:
+        dataset (google.cloud.bigquery.DatasetReference):
+            The dataset to make the table reference in. Usually the anonymous
+            dataset for the session.
+
+    Returns:
+        google.cloud.bigquery.TableReference:
+            Fully qualified table ID of a table that doesn't exist.
+    """
     now = datetime.datetime.now(datetime.timezone.utc)
     random_id = uuid.uuid4().hex
     table_id = TEMP_TABLE_PREFIX.format(
@@ -86,6 +97,7 @@ def random_table(dataset: bigquery.DatasetReference) -> bigquery.TableReference:
 
 
 def table_ref_to_sql(table: bigquery.TableReference) -> str:
+    """Format a table reference as escaped SQL."""
     return f"`{table.project}`.`{table.dataset_id}`.`{table.table_id}`"
 
 
@@ -124,7 +136,10 @@ def create_table_clone(
         """
     )
     job_config = bigquery.QueryJobConfig()
-    job_config.labels = {"bigframes-api": api_name}
+    job_config.labels = {
+        "source": "bigquery-dataframes-temp",
+        "bigframes-api": api_name,
+    }
     session._start_query(ddl, job_config=job_config)
     return destination
 

--- a/bigframes/session/_io/bigquery.py
+++ b/bigframes/session/_io/bigquery.py
@@ -92,13 +92,16 @@ def table_ref_to_sql(table: bigquery.TableReference) -> str:
 def create_table_clone(
     source: bigquery.TableReference,
     dataset: bigquery.DatasetReference,
-    expiration: datetime.timedelta,
+    expiration: datetime.datetime,
     session: bigframes.session.Session,
     api_name: str,
 ) -> bigquery.TableReference:
     """Create a table clone for consistent reads."""
-    now = datetime.datetime.now(datetime.timezone.utc)
-    expiration_timestamp = now + expiration
+    # If we have an anonymous query results table, it can't be modified and
+    # there isn't any BigQuery time travel.
+    if source.dataset_id.startswith("_"):
+        return source
+
     fully_qualified_source_id = table_ref_to_sql(source)
     destination = random_table(dataset)
     fully_qualified_destination_id = table_ref_to_sql(destination)
@@ -112,7 +115,7 @@ def create_table_clone(
         {fully_qualified_destination_id}
         CLONE {fully_qualified_source_id}
         OPTIONS(
-            expiration_timestamp=TIMESTAMP "{expiration_timestamp.isoformat()}",
+            expiration_timestamp=TIMESTAMP "{expiration.isoformat()}",
             labels=[
                 ("source", "bigquery-dataframes-temp"),
                 ("bigframes-api", {repr(api_name)})
@@ -120,20 +123,21 @@ def create_table_clone(
         )
         """
     )
-    session._start_query(ddl)
+    job_config = bigquery.QueryJobConfig()
+    job_config.labels = {"bigframes-api": api_name}
+    session._start_query(ddl, job_config=job_config)
     return destination
 
 
 def create_temp_table(
     bqclient: bigquery.Client,
     dataset: bigquery.DatasetReference,
-    expiration: datetime.timedelta,
+    expiration: datetime.datetime,
 ) -> str:
     """Create an empty table with an expiration in the desired dataset."""
     table_ref = random_table(dataset)
     destination = bigquery.Table(table_ref)
-    now = datetime.datetime.now(datetime.timezone.utc)
-    destination.expires = now + expiration
+    destination.expires = expiration
     bqclient.create_table(destination)
     return f"{table_ref.project}.{table_ref.dataset_id}.{table_ref.table_id}"
 

--- a/tests/system/small/test_session.py
+++ b/tests/system/small/test_session.py
@@ -252,9 +252,6 @@ def test_read_gbq_w_primary_keys_table(
     sorted_result = result.sort_values(primary_keys)
     pd.testing.assert_frame_equal(result, sorted_result)
 
-    # Verify that we're working from a snapshot rather than a copy of the table.
-    assert "FOR SYSTEM_TIME AS OF TIMESTAMP" in df.sql
-
 
 @pytest.mark.parametrize(
     ("query_or_table", "max_results"),

--- a/tests/unit/session/test_io_bigquery.py
+++ b/tests/unit/session/test_io_bigquery.py
@@ -19,46 +19,63 @@ import unittest.mock as mock
 import google.cloud.bigquery as bigquery
 import pytest
 
+import bigframes.session
 import bigframes.session._io.bigquery
 
 
-def test_create_table_clone_doesnt_timetravel_anonymous_datasets():
-    table_ref = bigquery.TableReference.from_string(
+def test_create_table_clone_doesnt_clone_anonymous_datasets():
+    session = mock.create_autospec(bigframes.session.Session)
+    source = bigquery.TableReference.from_string(
         "my-test-project._e8166e0cdb.anonbb92cd"
     )
 
-    sql = bigframes.core.io.create_table_clone(
-        table_ref, datetime.datetime.now(datetime.timezone.utc)
+    destination = bigframes.session._io.bigquery.create_table_clone(
+        source,
+        bigquery.DatasetReference("other-project", "other_dataset"),
+        datetime.datetime(2023, 11, 2, 15, 43, 21, tzinfo=datetime.timezone.utc),
+        session,
+        "test_api",
     )
 
-    # Anonymous query results tables don't support time travel.
-    assert "SYSTEM_TIME" not in sql
-
-    # Need fully-qualified table name.
-    assert "`my-test-project`.`_e8166e0cdb`.`anonbb92cd`" in sql
+    # Anonymous query results tables don't support CLONE
+    assert destination is source
+    session._start_query.assert_not_called()
 
 
-def test_create_table_clone_doesnt_timetravel_session_datasets():
-    table_ref = bigquery.TableReference.from_string("my-test-project._session.abcdefg")
-
-    sql = bigframes.core.io.create_table_clone(
-        table_ref, datetime.datetime.now(datetime.timezone.utc)
+def test_create_table_clone_sets_expiration():
+    session = mock.create_autospec(bigframes.session.Session)
+    source = bigquery.TableReference.from_string(
+        "my-test-project.test_dataset.some_table"
     )
 
-    # We aren't modifying _SESSION tables, so don't use time travel.
-    assert "SYSTEM_TIME" not in sql
+    expiration = datetime.datetime(
+        2023, 11, 2, 15, 43, 21, tzinfo=datetime.timezone.utc
+    )
+    bigframes.session._io.bigquery.create_table_clone(
+        source,
+        bigquery.DatasetReference("other-project", "other_dataset"),
+        expiration,
+        session,
+        "test_api",
+    )
 
-    # Don't need the project ID for _SESSION tables.
-    assert "my-test-project" not in sql
+    session._start_query.assert_called_once()
+    call_args = session._start_query.call_args
+    query = call_args.args[0]
+    assert "CREATE OR REPLACE TABLE" in query
+    assert "CLONE" in query
+    assert f'expiration_timestamp=TIMESTAMP "{expiration.isoformat()}"' in query
+    assert '("source", "bigquery-dataframes-temp")' in query
+    assert call_args.kwargs["job_config"].labels["bigframes-api"] == "test_api"
 
 
 def test_create_temp_table_default_expiration():
     """Make sure the created table has an expiration."""
     bqclient = mock.create_autospec(bigquery.Client)
     dataset = bigquery.DatasetReference("test-project", "test_dataset")
-    now = datetime.datetime.now(datetime.timezone.utc)
-    expiration = datetime.timedelta(days=3)
-    expected_expires = now + expiration
+    expiration = datetime.datetime(
+        2023, 11, 2, 13, 44, 55, 678901, datetime.timezone.utc
+    )
 
     bigframes.session._io.bigquery.create_temp_table(bqclient, dataset, expiration)
 
@@ -68,10 +85,11 @@ def test_create_temp_table_default_expiration():
     assert table.project == "test-project"
     assert table.dataset_id == "test_dataset"
     assert table.table_id.startswith("bqdf")
+    # TODO(swast): Why isn't the expiration exactly what we set it to?
     assert (
-        (expected_expires - datetime.timedelta(minutes=1))
+        (expiration - datetime.timedelta(minutes=1))
         < table.expires
-        < (expected_expires + datetime.timedelta(minutes=1))
+        < (expiration + datetime.timedelta(minutes=1))
     )
 
 

--- a/tests/unit/session/test_io_bigquery.py
+++ b/tests/unit/session/test_io_bigquery.py
@@ -22,12 +22,12 @@ import pytest
 import bigframes.session._io.bigquery
 
 
-def test_create_snapshot_sql_doesnt_timetravel_anonymous_datasets():
+def test_create_table_clone_doesnt_timetravel_anonymous_datasets():
     table_ref = bigquery.TableReference.from_string(
         "my-test-project._e8166e0cdb.anonbb92cd"
     )
 
-    sql = bigframes.session._io.bigquery.create_snapshot_sql(
+    sql = bigframes.core.io.create_table_clone(
         table_ref, datetime.datetime.now(datetime.timezone.utc)
     )
 
@@ -38,10 +38,10 @@ def test_create_snapshot_sql_doesnt_timetravel_anonymous_datasets():
     assert "`my-test-project`.`_e8166e0cdb`.`anonbb92cd`" in sql
 
 
-def test_create_snapshot_sql_doesnt_timetravel_session_tables():
+def test_create_table_clone_doesnt_timetravel_session_datasets():
     table_ref = bigquery.TableReference.from_string("my-test-project._session.abcdefg")
 
-    sql = bigframes.session._io.bigquery.create_snapshot_sql(
+    sql = bigframes.core.io.create_table_clone(
         table_ref, datetime.datetime.now(datetime.timezone.utc)
     )
 


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
chore(reverted): use table clone instead of system time for read_gbq_table
END_COMMIT_OVERRIDE


Towards internal issue 301645192 to have lower-cost default ordering.

Blocked by internal issue 305235665

Closes internal issue 301459572