### PR TITLE
feat: add `bigframes.options.bigquery.application_name` for partner attribution

### DIFF
--- a/bigframes/_config/bigquery_options.py
+++ b/bigframes/_config/bigquery_options.py
@@ -37,13 +37,32 @@ class BigQueryOptions:
         location: Optional[str] = None,
         bq_connection: Optional[str] = None,
         use_regional_endpoints: bool = False,
+        application_name: Optional[str] = None,
     ):
         self._credentials = credentials
         self._project = project
         self._location = location
         self._bq_connection = bq_connection
         self._use_regional_endpoints = use_regional_endpoints
+        self._application_name = application_name
         self._session_started = False
+
+    @property
+    def application_name(self) -> Optional[str]:
+        """The application name to amend to the user-agent sent to Google APIs.
+
+        Recommended format is ``"appplication-name/major.minor.patch_version"``
+        or ``"(gpn:PartnerName;)"`` for official Google partners.
+        """
+        return self._application_name
+
+    @application_name.setter
+    def application_name(self, value: Optional[str]):
+        if self._session_started and self._application_name != value:
+            raise ValueError(
+                SESSION_STARTED_MESSAGE.format(attribute="application_name")
+            )
+        self._application_name = value
 
     @property
     def credentials(self) -> Optional[google.auth.credentials.Credentials]:

--- a/bigframes/pandas/__init__.py
+++ b/bigframes/pandas/__init__.py
@@ -51,6 +51,7 @@ import bigframes.core.reshape
 import bigframes.dataframe
 import bigframes.series
 import bigframes.session
+import bigframes.session.clients
 import third_party.bigframes_vendored.pandas.core.reshape.concat as vendored_pandas_concat
 import third_party.bigframes_vendored.pandas.core.reshape.merge as vendored_pandas_merge
 import third_party.bigframes_vendored.pandas.core.reshape.tile as vendored_pandas_tile
@@ -180,7 +181,7 @@ def _set_default_session_location_if_possible(query):
     ):
         return
 
-    clients_provider = bigframes.session.ClientsProvider(
+    clients_provider = bigframes.session.clients.ClientsProvider(
         project=options.bigquery.project,
         location=options.bigquery.location,
         use_regional_endpoints=options.bigquery.use_regional_endpoints,

--- a/bigframes/pandas/__init__.py
+++ b/bigframes/pandas/__init__.py
@@ -185,6 +185,7 @@ def _set_default_session_location_if_possible(query):
         location=options.bigquery.location,
         use_regional_endpoints=options.bigquery.use_regional_endpoints,
         credentials=options.bigquery.credentials,
+        application_name=options.bigquery.application_name,
     )
 
     bqclient = clients_provider.bqclient

--- a/bigframes/session/clients.py
+++ b/bigframes/session/clients.py
@@ -1,0 +1,196 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Clients manages the connection to Google APIs."""
+
+import os
+import typing
+from typing import Optional
+
+import google.api_core.client_info
+import google.api_core.client_options
+import google.api_core.exceptions
+import google.api_core.gapic_v1.client_info
+import google.auth.credentials
+import google.cloud.bigquery as bigquery
+import google.cloud.bigquery_connection_v1
+import google.cloud.bigquery_storage_v1
+import google.cloud.functions_v2
+import google.cloud.resourcemanager_v3
+import pydata_google_auth
+
+import bigframes.version
+
+_ENV_DEFAULT_PROJECT = "GOOGLE_CLOUD_PROJECT"
+_APPLICATION_NAME = f"bigframes/{bigframes.version.__version__}"
+_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
+
+# BigQuery is a REST API, which requires the protocol as part of the URL.
+_BIGQUERY_REGIONAL_ENDPOINT = "https://{location}-bigquery.googleapis.com"
+
+# BigQuery Connection and Storage are gRPC APIs, which don't support the
+# https:// protocol in the API endpoint URL.
+_BIGQUERYCONNECTION_REGIONAL_ENDPOINT = "{location}-bigqueryconnection.googleapis.com"
+_BIGQUERYSTORAGE_REGIONAL_ENDPOINT = "{location}-bigquerystorage.googleapis.com"
+
+
+def _get_default_credentials_with_project():
+    return pydata_google_auth.default(scopes=_SCOPES, use_local_webserver=False)
+
+
+class ClientsProvider:
+    """Provides client instances necessary to perform cloud operations."""
+
+    def __init__(
+        self,
+        project: Optional[str],
+        location: Optional[str],
+        use_regional_endpoints: Optional[bool],
+        credentials: Optional[google.auth.credentials.Credentials],
+        application_name: Optional[str],
+    ):
+        credentials_project = None
+        if credentials is None:
+            credentials, credentials_project = _get_default_credentials_with_project()
+
+        # Prefer the project in this order:
+        # 1. Project explicitly specified by the user
+        # 2. Project set in the environment
+        # 3. Project associated with the default credentials
+        project = (
+            project
+            or os.getenv(_ENV_DEFAULT_PROJECT)
+            or typing.cast(Optional[str], credentials_project)
+        )
+
+        if not project:
+            raise ValueError(
+                "Project must be set to initialize BigQuery client. "
+                "Try setting `bigframes.options.bigquery.project` first."
+            )
+
+        self._application_name = (
+            f"{_APPLICATION_NAME} {application_name}"
+            if application_name
+            else _APPLICATION_NAME
+        )
+        self._project = project
+        self._location = location
+        self._use_regional_endpoints = use_regional_endpoints
+        self._credentials = credentials
+
+        # cloud clients initialized for lazy load
+        self._bqclient = None
+        self._bqconnectionclient = None
+        self._bqstoragereadclient = None
+        self._cloudfunctionsclient = None
+        self._resourcemanagerclient = None
+
+    @property
+    def bqclient(self):
+        if not self._bqclient:
+            bq_options = None
+            if self._use_regional_endpoints:
+                bq_options = google.api_core.client_options.ClientOptions(
+                    api_endpoint=_BIGQUERY_REGIONAL_ENDPOINT.format(
+                        location=self._location
+                    ),
+                )
+            bq_info = google.api_core.client_info.ClientInfo(
+                user_agent=self._application_name
+            )
+            self._bqclient = bigquery.Client(
+                client_info=bq_info,
+                client_options=bq_options,
+                credentials=self._credentials,
+                project=self._project,
+                location=self._location,
+            )
+
+        return self._bqclient
+
+    @property
+    def bqconnectionclient(self):
+        if not self._bqconnectionclient:
+            bqconnection_options = None
+            if self._use_regional_endpoints:
+                bqconnection_options = google.api_core.client_options.ClientOptions(
+                    api_endpoint=_BIGQUERYCONNECTION_REGIONAL_ENDPOINT.format(
+                        location=self._location
+                    )
+                )
+            bqconnection_info = google.api_core.gapic_v1.client_info.ClientInfo(
+                user_agent=self._application_name
+            )
+            self._bqconnectionclient = (
+                google.cloud.bigquery_connection_v1.ConnectionServiceClient(
+                    client_info=bqconnection_info,
+                    client_options=bqconnection_options,
+                    credentials=self._credentials,
+                )
+            )
+
+        return self._bqconnectionclient
+
+    @property
+    def bqstoragereadclient(self):
+        if not self._bqstoragereadclient:
+            bqstorage_options = None
+            if self._use_regional_endpoints:
+                bqstorage_options = google.api_core.client_options.ClientOptions(
+                    api_endpoint=_BIGQUERYSTORAGE_REGIONAL_ENDPOINT.format(
+                        location=self._location
+                    )
+                )
+            bqstorage_info = google.api_core.gapic_v1.client_info.ClientInfo(
+                user_agent=self._application_name
+            )
+            self._bqstoragereadclient = (
+                google.cloud.bigquery_storage_v1.BigQueryReadClient(
+                    client_info=bqstorage_info,
+                    client_options=bqstorage_options,
+                    credentials=self._credentials,
+                )
+            )
+
+        return self._bqstoragereadclient
+
+    @property
+    def cloudfunctionsclient(self):
+        if not self._cloudfunctionsclient:
+            functions_info = google.api_core.gapic_v1.client_info.ClientInfo(
+                user_agent=self._application_name
+            )
+            self._cloudfunctionsclient = (
+                google.cloud.functions_v2.FunctionServiceClient(
+                    client_info=functions_info,
+                    credentials=self._credentials,
+                )
+            )
+
+        return self._cloudfunctionsclient
+
+    @property
+    def resourcemanagerclient(self):
+        if not self._resourcemanagerclient:
+            resourcemanager_info = google.api_core.gapic_v1.client_info.ClientInfo(
+                user_agent=self._application_name
+            )
+            self._resourcemanagerclient = (
+                google.cloud.resourcemanager_v3.ProjectsClient(
+                    credentials=self._credentials, client_info=resourcemanager_info
+                )
+            )
+
+        return self._resourcemanagerclient

--- a/tests/unit/_config/test_bigquery_options.py
+++ b/tests/unit/_config/test_bigquery_options.py
@@ -28,6 +28,7 @@ import bigframes._config.bigquery_options as bigquery_options
         ("location", "us-east1", "us-central1"),
         ("project", "my-project", "my-other-project"),
         ("bq_connection", "path/to/connection/1", "path/to/connection/2"),
+        ("use_regional_endpoints", False, True),
     ],
 )
 def test_setter_raises_if_session_started(attribute, original_value, new_value):
@@ -59,6 +60,7 @@ def test_setter_raises_if_session_started(attribute, original_value, new_value):
             "location",
             "project",
             "bq_connection",
+            "use_regional_endpoints",
         ]
     ],
 )

--- a/tests/unit/_config/test_bigquery_options.py
+++ b/tests/unit/_config/test_bigquery_options.py
@@ -22,6 +22,7 @@ import bigframes._config.bigquery_options as bigquery_options
 @pytest.mark.parametrize(
     ["attribute", "original_value", "new_value"],
     [
+        ("application_name", None, "test-partner"),
         # For credentials, the match is by reference.
         ("credentials", object(), object()),
         ("location", "us-east1", "us-central1"),
@@ -53,6 +54,7 @@ def test_setter_raises_if_session_started(attribute, original_value, new_value):
     [
         (attribute,)
         for attribute in [
+            "application_name",
             "credentials",
             "location",
             "project",

--- a/tests/unit/resources.py
+++ b/tests/unit/resources.py
@@ -22,6 +22,7 @@ import pandas
 
 import bigframes
 import bigframes.core as core
+import bigframes.session.clients
 
 """Utilities for creating test resources."""
 
@@ -37,7 +38,7 @@ def create_bigquery_session(
         bqclient = mock.create_autospec(google.cloud.bigquery.Client, instance=True)
         bqclient.project = "test-project"
 
-    clients_provider = mock.create_autospec(bigframes.session.ClientsProvider)
+    clients_provider = mock.create_autospec(bigframes.session.clients.ClientsProvider)
     type(clients_provider).bqclient = mock.PropertyMock(return_value=bqclient)
     clients_provider._credentials = credentials
 

--- a/tests/unit/session/__init__.py
+++ b/tests/unit/session/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/unit/session/test_clients.py
+++ b/tests/unit/session/test_clients.py
@@ -1,0 +1,114 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Optional
+import unittest.mock as mock
+
+import google.api_core.client_info
+import google.api_core.client_options
+import google.api_core.exceptions
+import google.api_core.gapic_v1.client_info
+import google.auth.credentials
+import google.cloud.bigquery
+import google.cloud.bigquery_connection_v1
+import google.cloud.bigquery_storage_v1
+import google.cloud.functions_v2
+import google.cloud.resourcemanager_v3
+
+import bigframes.session.clients as clients
+import bigframes.version
+
+
+def create_clients_provider(application_name: Optional[str] = None):
+    credentials = mock.create_autospec(google.auth.credentials.Credentials)
+    return clients.ClientsProvider(
+        project="test-project",
+        location="test-region",
+        use_regional_endpoints=False,
+        credentials=credentials,
+        application_name=application_name,
+    )
+
+
+def monkeypatch_client_constructors(monkeypatch):
+    bqclient = mock.create_autospec(google.cloud.bigquery.Client)
+    bqclient.return_value = bqclient
+    monkeypatch.setattr(google.cloud.bigquery, "Client", bqclient)
+
+    bqconnectionclient = mock.create_autospec(
+        google.cloud.bigquery_connection_v1.ConnectionServiceClient
+    )
+    bqconnectionclient.return_value = bqconnectionclient
+    monkeypatch.setattr(
+        google.cloud.bigquery_connection_v1,
+        "ConnectionServiceClient",
+        bqconnectionclient,
+    )
+
+    bqstoragereadclient = mock.create_autospec(
+        google.cloud.bigquery_storage_v1.BigQueryReadClient
+    )
+    bqstoragereadclient.return_value = bqstoragereadclient
+    monkeypatch.setattr(
+        google.cloud.bigquery_storage_v1, "BigQueryReadClient", bqstoragereadclient
+    )
+
+    cloudfunctionsclient = mock.create_autospec(
+        google.cloud.functions_v2.FunctionServiceClient
+    )
+    cloudfunctionsclient.return_value = cloudfunctionsclient
+    monkeypatch.setattr(
+        google.cloud.functions_v2, "FunctionServiceClient", cloudfunctionsclient
+    )
+
+    resourcemanagerclient = mock.create_autospec(
+        google.cloud.resourcemanager_v3.ProjectsClient
+    )
+    resourcemanagerclient.return_value = resourcemanagerclient
+    monkeypatch.setattr(
+        google.cloud.resourcemanager_v3, "ProjectsClient", resourcemanagerclient
+    )
+
+
+def assert_constructed_w_user_agent(mock_client: mock.Mock, expected_user_agent: str):
+    assert (
+        expected_user_agent
+        in mock_client.call_args.kwargs["client_info"].to_user_agent()
+    )
+
+
+def assert_clients_w_user_agent(
+    provider: clients.ClientsProvider, expected_user_agent: str
+):
+    assert_constructed_w_user_agent(provider.bqclient, expected_user_agent)
+    assert_constructed_w_user_agent(provider.bqconnectionclient, expected_user_agent)
+    assert_constructed_w_user_agent(provider.bqstoragereadclient, expected_user_agent)
+    assert_constructed_w_user_agent(provider.cloudfunctionsclient, expected_user_agent)
+    assert_constructed_w_user_agent(provider.resourcemanagerclient, expected_user_agent)
+
+
+def test_user_agent_default(monkeypatch):
+    monkeypatch_client_constructors(monkeypatch)
+    provider = create_clients_provider(application_name=None)
+    assert_clients_w_user_agent(provider, f"bigframes/{bigframes.version.__version__}")
+
+
+def test_user_agent_custom(monkeypatch):
+    monkeypatch_client_constructors(monkeypatch)
+    provider = create_clients_provider(application_name="(gpn:testpartner;)")
+    assert_clients_w_user_agent(provider, "(gpn:testpartner;)")
+
+    # We still need to include attribution to bigframes, even if there's also a
+    # partner using the package.
+    assert_clients_w_user_agent(provider, f"bigframes/{bigframes.version.__version__}")

--- a/tests/unit/session/test_session.py
+++ b/tests/unit/session/test_session.py
@@ -20,7 +20,7 @@ import pytest
 
 import bigframes
 
-from . import resources
+from .. import resources
 
 
 @pytest.mark.parametrize("missing_parts_table_id", [(""), ("table")])


### PR DESCRIPTION
Because `session.py` was getting long, this also refactors `session.py` to separate client construction in a separate module.

Fixes internal issue 305950924
🦕
