### PR TITLE
fix: expose `bigframes.pandas.reset_session` as a public API

### DIFF
--- a/bigframes/pandas/__init__.py
+++ b/bigframes/pandas/__init__.py
@@ -484,4 +484,5 @@ __all___ = [
     # Session management APIs
     "get_global_session",
     "close_session",
+    "reset_session",
 ]


### PR DESCRIPTION
Follow-up to https://github.com/googleapis/python-bigquery-dataframes/pull/124
