### PR TITLE
chore: remove unused reference to `THIRD_PARTY_NOTICES` from "nightly"

### DIFF
--- a/.kokoro/release-nightly.sh
+++ b/.kokoro/release-nightly.sh
@@ -93,7 +93,6 @@ for gcs_path in gs://vertex_sdk_private_releases/bigframe/ \
     do
       gsutil cp -v dist/* ${gcs_path}
       gsutil cp -v LICENSE ${gcs_path}
-      gsutil cp -v ${THIRD_PARTY_NOTICES_FILE} ${gcs_path}
       gsutil -m cp -r -v "notebooks/" ${gcs_path}notebooks/
 
     done


### PR DESCRIPTION
Note: "nightly" build mostly just needed from API coverage now.

Hopefully fixes failing "nightly" on main.
🦕
