### PR TITLE
fix: update default temp table expiration to 7 days

### DIFF
--- a/bigframes/constants.py
+++ b/bigframes/constants.py
@@ -26,4 +26,4 @@ FEEDBACK_LINK = (
 
 ABSTRACT_METHOD_ERROR_MESSAGE = f"Abstract method. You have likely encountered a bug. Please share this stacktrace and how you reached it with the BigQuery DataFrames team. {FEEDBACK_LINK}"
 
-DEFAULT_EXPIRATION = datetime.timedelta(days=1)
+DEFAULT_EXPIRATION = datetime.timedelta(days=7)

--- a/bigframes/dataframe.py
+++ b/bigframes/dataframe.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+import datetime
 import re
 import textwrap
 import typing
@@ -2327,7 +2328,8 @@ class DataFrame(vendored_pandas_frame.DataFrame):
                 self._session.bqclient,
                 self._session._anonymous_dataset,
                 # TODO(swast): allow custom expiration times, probably via session configuration.
-                constants.DEFAULT_EXPIRATION,
+                datetime.datetime.now(datetime.timezone.utc)
+                + constants.DEFAULT_EXPIRATION,
             )
 
             if if_exists is not None and if_exists != "replace":

--- a/bigframes/session/__init__.py
+++ b/bigframes/session/__init__.py
@@ -430,7 +430,9 @@ class Session(
             index_cols = list(index_col)
 
         destination, query_job = self._query_to_destination(
-            query, index_cols, api_name="read_gbq_query"
+            query,
+            index_cols,
+            api_name=api_name,
         )
 
         # If there was no destination table, that means the query must have

--- a/tests/unit/session/test_io_bigquery.py
+++ b/tests/unit/session/test_io_bigquery.py
@@ -56,9 +56,9 @@ def test_create_temp_table_default_expiration():
     """Make sure the created table has an expiration."""
     bqclient = mock.create_autospec(bigquery.Client)
     dataset = bigquery.DatasetReference("test-project", "test_dataset")
-    now = datetime.datetime.now(datetime.timezone.utc)
-    expiration = datetime.timedelta(days=3)
-    expected_expires = now + expiration
+    expiration = datetime.datetime(
+        2023, 11, 2, 13, 44, 55, 678901, datetime.timezone.utc
+    )
 
     bigframes.session._io.bigquery.create_temp_table(bqclient, dataset, expiration)
 
@@ -69,9 +69,9 @@ def test_create_temp_table_default_expiration():
     assert table.dataset_id == "test_dataset"
     assert table.table_id.startswith("bqdf")
     assert (
-        (expected_expires - datetime.timedelta(minutes=1))
+        (expiration - datetime.timedelta(minutes=1))
         < table.expires
-        < (expected_expires + datetime.timedelta(minutes=1))
+        < (expiration + datetime.timedelta(minutes=1))
     )
 
 


### PR DESCRIPTION
Restore helpers for temp tables from #109 without the table clone functionality.

Towards internal issue 309109254 🦕
