### PR TITLE
fix: for reset_index on unnamed multiindex, always use level_[n] label

### DIFF
--- a/bigframes/core/blocks.py
+++ b/bigframes/core/blocks.py
@@ -282,7 +282,7 @@ class Block:
             column_labels_modified = self.column_labels
             for level, label in enumerate(index_labels):
                 if label is None:
-                    if "index" not in self.column_labels:
+                    if "index" not in self.column_labels and len(index_labels) <= 1:
                         label = "index"
                     else:
                         label = f"level_{level}"

--- a/tests/system/small/test_dataframe.py
+++ b/tests/system/small/test_dataframe.py
@@ -1207,6 +1207,28 @@ def test_reset_index_with_unnamed_index(
     pandas.testing.assert_frame_equal(bf_result, pd_result)
 
 
+def test_reset_index_with_unnamed_multiindex(
+    scalars_df_index,
+    scalars_pandas_df_index,
+):
+    bf_df = dataframe.DataFrame(
+        ([1, 2, 3], [2, 5, 7]),
+        index=pd.MultiIndex.from_tuples([("a", "aa"), ("a", "aa")]),
+    )
+    pd_df = pd.DataFrame(
+        ([1, 2, 3], [2, 5, 7]),
+        index=pd.MultiIndex.from_tuples([("a", "aa"), ("a", "aa")]),
+    )
+
+    bf_df = bf_df.reset_index()
+    pd_df = pd_df.reset_index()
+
+    assert pd_df.columns[0] == "level_0"
+    assert bf_df.columns[0] == "level_0"
+    assert pd_df.columns[1] == "level_1"
+    assert bf_df.columns[1] == "level_1"
+
+
 def test_reset_index_with_unnamed_index_and_index_column(
     scalars_df_index,
     scalars_pandas_df_index,


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
