### PR TITLE
feat: support `date_series.astype("string[pyarrow]")` to cast DATE to STRING

### DIFF
--- a/bigframes/dtypes.py
+++ b/bigframes/dtypes.py
@@ -375,7 +375,7 @@ def cast_ibis_value(
         ),
         ibis_dtypes.float64: (ibis_dtypes.string, ibis_dtypes.int64),
         ibis_dtypes.string: (ibis_dtypes.int64, ibis_dtypes.float64),
-        ibis_dtypes.date: (),
+        ibis_dtypes.date: (ibis_dtypes.string,),
         ibis_dtypes.Decimal(precision=38, scale=9): (ibis_dtypes.float64,),
         ibis_dtypes.Decimal(precision=76, scale=38): (ibis_dtypes.float64,),
         ibis_dtypes.time: (),

--- a/tests/system/small/test_series.py
+++ b/tests/system/small/test_series.py
@@ -2498,6 +2498,7 @@ def test_mask_custom_value(scalars_dfs):
         # with timezone conversions, so we'll allow it.
         ("timestamp_col", pd.ArrowDtype(pa.timestamp("us"))),
         ("datetime_col", pd.ArrowDtype(pa.timestamp("us", tz="UTC"))),
+        ("date_col", "string[pyarrow]"),
         # TODO(bmil): fix Ibis bug: BigQuery backend rounds to nearest int
         # ("float64_col", "Int64"),
         # TODO(bmil): decide whether to fix Ibis bug: BigQuery backend


### PR DESCRIPTION
Adds support for `date_series.astype("string[pyarrow]") to cast DATE to STRING.

As discussed with @tswast in a BigFrames feedback submission - column in source table was `date`, but wanted BigFrames to read it and save in another table as `string`. Thanks for the assist and encouragement.