### PR TITLE
docs: use `head()` to get top `n` results, not to preview results

### DIFF
--- a/samples/snippets/pandas_methods_test.py
+++ b/samples/snippets/pandas_methods_test.py
@@ -22,13 +22,20 @@ def test_bigquery_dataframes_pandas_methods():
     bq_df = bpd.read_gbq(query_or_table)
 
     # Inspect one of the columns (or series) of the DataFrame:
-    bq_df["body_mass_g"].head(10)
+    bq_df["body_mass_g"]
 
     # Compute the mean of this series:
     average_body_mass = bq_df["body_mass_g"].mean()
     print(f"average_body_mass: {average_body_mass}")
 
-    # Calculate the mean body_mass_g by species using the groupby operation:
-    bq_df["body_mass_g"].groupby(by=bq_df["species"]).mean().head()
+    # Find the heaviest species using the groupby operation to calculate the
+    # mean body_mass_g:
+    (
+        bq_df["body_mass_g"]
+        .groupby(by=bq_df["species"])
+        .mean()
+        .sort_values(ascending=False)
+        .head(10)
+    )
     # [END bigquery_dataframes_pandas_methods]
     assert average_body_mass is not None


### PR DESCRIPTION
head() requires ordering. Just peeking at the whole DataFrame or Series is actually more efficient since it doesn't require ordering and still only downloads a fraction of the results.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
