### PR TITLE
build: use standard install in prerelease nox session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -548,8 +548,7 @@ def prerelease(session: nox.sessions.Session, tests_path):
     # Ensure we catch breaking changes in the client libraries early.
     session.install(
         "--upgrade",
-        "-e",
-        "git+https://github.com/googleapis/python-bigquery.git#egg=google-cloud-bigquery",
+        "https://github.com/googleapis/python-bigquery/archive/main.zip",
     )
     already_installed.add("google-cloud-bigquery")
     session.install(


### PR DESCRIPTION
For testing purposes. See https://github.com/googleapis/python-bigquery/pull/1726#issuecomment-1830964317

Editable installs have limitations as described in
https://setuptools.pypa.io/en/latest/userguide/development_mode.html#limitations