### PR TITLE
test: fix prerelease tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -548,7 +548,6 @@ def prerelease(session: nox.sessions.Session, tests_path):
     # Ensure we catch breaking changes in the client libraries early.
     session.install(
         "--upgrade",
-        "-e",
         "git+https://github.com/googleapis/python-bigquery.git#egg=google-cloud-bigquery",
     )
     already_installed.add("google-cloud-bigquery")


### PR DESCRIPTION
The heads of google-cloud-bigquery and google-cloud-bigquery-storage packages are installed with -e. This is leading to `from google.cloud import bigquery` looking into the folder of the latter and running into "ImportError: cannot import name 'bigquery' from 'google.cloud' (.../google-cloud-bigquery-storage/google/cloud/__init__.py). Removing -e from google-cloud-bigquery installation gets rid of this error.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes internal issue 313701211 🦕
