### PR TITLE
fix: replaced raise `NotImplementedError` with return `NotImplemented`

### DIFF
--- a/third_party/bigframes_vendored/pandas/core/series.py
+++ b/third_party/bigframes_vendored/pandas/core/series.py
@@ -664,13 +664,13 @@ class Series(NDFrame):  # type: ignore[misc]
         """
         Matrix multiplication using binary `@` operator in Python>=3.5.
         """
-        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+        return NotImplemented
 
     def __rmatmul__(self, other):
         """
         Matrix multiplication using binary `@` operator in Python>=3.5.
         """
-        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+        return NotImplemented
 
     def sort_values(
         self,


### PR DESCRIPTION
<!--
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)
-->

## Details
While triaging your project, our bug fixing tool generated the following message(s)-

> In file: [series.py](https://github.com/googleapis/python-bigquery-dataframes/tree/main/third_party/bigframes_vendored/pandas/core/series.py#L572), class: Series, there is a special method `__rmatmul__` that raises a NotImplementedError. If a special method supporting a binary operation is not implemented it should return NotImplemented. On the other hand, NotImplementedError should be raised from abstract methods inside user defined base classes to indicate that derived classes should override those methods. iCR suggested that the special method `__rmatmul__` should return NotImplemented instead of raising an exception. An example of how NotImplemented helps the interpreter support a binary operation is here.

> In file: [series.py](https://github.com/googleapis/python-bigquery-dataframes/tree/main/third_party/bigframes_vendored/pandas/core/series.py#L566), class: Series, there is a special method `__matmul__` that raises a NotImplementedError. If a special method supporting a binary operation is not implemented it should return NotImplemented. On the other hand, NotImplementedError should be raised from abstract methods inside user defined base classes to indicate that derived classes should override those methods. iCR suggested that the special method `__matmul__` should return NotImplemented instead of raising an exception. An example of how NotImplemented helps the interpreter support a binary operation is here.

### Related Documentation
- [docs.python.org - NotImplemented](https://docs.python.org/3/library/constants.html#NotImplemented)
- [docs.python.org - NotImplementedError](https://docs.python.org/3/library/exceptions.html#NotImplementedError)
- [docs.python.org - Implementing Arithmetic Operators](https://docs.python.org/3/library/numbers.html#implementing-the-arithmetic-operations)


## Changes
- Replaced `NotImplementedError` with `NotImplemented`


## Previously Found & Fixed
- https://www.github.com/SciTools/iris/pull/5544
- https://www.github.com/cupy/cupy/pull/7900
- https://www.github.com/ethereum/web3.py/pull/3080


## CLA Requirements
*This section is only relevant if your project requires contributors to sign a Contributor License Agreement (CLA) for external contributions.*

All contributed commits are already automatically signed off.

> The meaning of a signoff depends on the project, but it typically certifies that committer has the rights to submit this work under the same license and agrees to a Developer Certificate of Origin (see [https://developercertificate.org/](https://developercertificate.org/) for more information).
\- [Git Commit SignOff documentation](https://developercertificate.org/)


## Sponsorship and Support
This work is done by the security researchers from OpenRefactory and is supported by the [Open Source Security Foundation (OpenSSF)](https://openssf.org/): [Project Alpha-Omega](https://alpha-omega.dev/). Alpha-Omega is a project partnering with open source software project maintainers to systematically find new, as-yet-undiscovered vulnerabilities in open source code - and get them fixed – to improve global software supply chain security.

The bug is found by running the Intelligent Code Repair (iCR) tool by OpenRefactory and then manually triaging the results.
