### PR TITLE
chore: filter errors explicitly caught in BF dashboard

### DIFF
--- a/bigframes/session/__init__.py
+++ b/bigframes/session/__init__.py
@@ -294,6 +294,7 @@ class Session(
         try:
             # Write to temp table to workaround BigQuery 10 GB query results
             # limit. See: internal issue 303057336.
+            job_config.labels["error_caught"] = "True"
             _, query_job = self._start_query(query, job_config=job_config)
             return query_job.destination, query_job
         except google.api_core.exceptions.BadRequest:


### PR DESCRIPTION
plx script change

Line 44 - 49: +

    AND (configuration.labels.label IS NULL
      OR (
        SELECT l.value
          FROM UNNEST(configuration.labels.label) AS l
          WHERE l.key = "error_caught"
      ) != "True"))