### PR TITLE
fix: exclude pandas 2.2.0rc0 to unblock prerelease tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -518,9 +518,13 @@ def prerelease(session: nox.sessions.Session, tests_path):
         "--prefer-binary",
         "--pre",
         "--upgrade",
-        # TODO(shobs): Remove tying to version 2.1.3 after
-        # https://github.com/pandas-dev/pandas/issues/56463 is resolved
-        "pandas!=2.1.4",
+        # TODO(shobs): Remove excluding version 2.1.4 after
+        # https://github.com/pandas-dev/pandas/issues/56463 is resolved.
+        #
+        # TODO(shobs): Remove excluding version 2.2.0rc0 after
+        # https://github.com/pandas-dev/pandas/issues/56646 and
+        # https://github.com/pandas-dev/pandas/issues/56651 are resolved.
+        "pandas!=2.1.4,!=2.2.0rc0",
     )
     already_installed.add("pandas")
 


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes internal issue 317908521 🦕
