### PR TITLE
fix: chance default connection name in getting_started.ipnyb

### DIFF
--- a/notebooks/getting_started/getting_started_bq_dataframes.ipynb
+++ b/notebooks/getting_started/getting_started_bq_dataframes.ipynb
@@ -925,7 +925,7 @@
         "# # Delete the BigQuery Connection\n",
         "# from google.cloud import bigquery_connection_v1 as bq_connection\n",
         "# client = bq_connection.ConnectionServiceClient()\n",
-        "# CONNECTION_ID = f\"projects/{PROJECT_ID}/locations/{REGION}/connections/bigframes-rf-conn\"\n",
+        "# CONNECTION_ID = f\"projects/{PROJECT_ID}/locations/{REGION}/connections/bigframes-default-connection\"\n",
         "# client.delete_connection(name=CONNECTION_ID)\n",
         "# print(\"Deleted connection '{}'.\".format(CONNECTION_ID))"
       ]


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [X ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [X ] Ensure the tests and linter pass
- [ X] Code coverage does not decrease (if any source code was changed)
- [X ] Appropriate docs were updated (if necessary)

Fixes #346

The existing notebook references an incorrect default connection name. This PR corrects that so that users can more easily cleanup after they use the [getting started notebook](https://github.com/googleapis/python-bigquery-dataframes/blob/main/notebooks/getting_started/getting_started_bq_dataframes.ipynb)

