### PR TITLE
refactor!: move model optional args to kwargs

### DIFF
--- a/bigframes/ml/base.py
+++ b/bigframes/ml/base.py
@@ -127,6 +127,10 @@ class Predictor(BaseEstimator):
         self._bqml_model.register(vertex_ai_model_id)
         return self
 
+    @abc.abstractmethod
+    def to_gbq(self, model_name, replace):
+        pass
+
 
 class TrainablePredictor(Predictor):
     """A BigQuery DataFrames ML Model base class that can be used to fit and predict outputs.
@@ -139,11 +143,6 @@ class TrainablePredictor(Predictor):
 
     @abc.abstractmethod
     def score(self, X, y):
-        pass
-
-    # TODO(b/291812029): move to Predictor after implement in LLM and imported models
-    @abc.abstractmethod
-    def to_gbq(self, model_name, replace):
         pass
 
 
@@ -165,7 +164,7 @@ class SupervisedTrainablePredictor(TrainablePredictor):
 class UnsupervisedTrainablePredictor(TrainablePredictor):
     """A BigQuery DataFrames ML Unsupervised Model base class that can be used to fit and predict outputs.
 
-    Only need to provide both X (y is optional and ignored) in unsupervised tasks."""
+    Only need to provide X (y is optional and ignored) in unsupervised tasks."""
 
     _T = TypeVar("_T", bound="UnsupervisedTrainablePredictor")
 

--- a/bigframes/ml/ensemble.py
+++ b/bigframes/ml/ensemble.py
@@ -58,6 +58,7 @@ class XGBRegressor(
     def __init__(
         self,
         num_parallel_tree: int = 1,
+        *,
         booster: Literal["gbtree", "dart"] = "gbtree",
         dart_normalized_type: Literal["tree", "forest"] = "tree",
         tree_method: Literal["auto", "exact", "approx", "hist"] = "auto",
@@ -215,6 +216,7 @@ class XGBClassifier(
     def __init__(
         self,
         num_parallel_tree: int = 1,
+        *,
         booster: Literal["gbtree", "dart"] = "gbtree",
         dart_normalized_type: Literal["tree", "forest"] = "tree",
         tree_method: Literal["auto", "exact", "approx", "hist"] = "auto",
@@ -372,6 +374,7 @@ class RandomForestRegressor(
     def __init__(
         self,
         num_parallel_tree: int = 100,
+        *,
         tree_method: Literal["auto", "exact", "approx", "hist"] = "auto",
         min_tree_child_weight: int = 1,
         colsample_bytree=1.0,
@@ -538,6 +541,7 @@ class RandomForestClassifier(
     def __init__(
         self,
         num_parallel_tree: int = 100,
+        *,
         tree_method: Literal["auto", "exact", "approx", "hist"] = "auto",
         min_tree_child_weight: int = 1,
         colsample_bytree: float = 1.0,

--- a/bigframes/ml/forecasting.py
+++ b/bigframes/ml/forecasting.py
@@ -87,7 +87,7 @@ class ARIMAPlus(base.SupervisedTrainablePredictor):
         )
 
     def predict(
-        self, X=None, horizon: int = 3, confidence_level: float = 0.95
+        self, X=None, *, horizon: int = 3, confidence_level: float = 0.95
     ) -> bpd.DataFrame:
         """Predict the closest cluster for each sample in X.
 

--- a/bigframes/ml/imported.py
+++ b/bigframes/ml/imported.py
@@ -32,15 +32,17 @@ class TensorFlowModel(base.Predictor):
     """Imported TensorFlow model.
 
     Args:
+        model_path (str):
+            GCS path that holds the model files.
         session (BigQuery Session):
             BQ session to create the model
-        model_path (str):
-            GCS path that holds the model files."""
+    """
 
     def __init__(
         self,
+        model_path: str,
+        *,
         session: Optional[bigframes.Session] = None,
-        model_path: Optional[str] = None,
     ):
         self.session = session or bpd.get_global_session()
         self.model_path = model_path
@@ -59,7 +61,7 @@ class TensorFlowModel(base.Predictor):
     ) -> TensorFlowModel:
         assert model.model_type == "TENSORFLOW"
 
-        tf_model = cls(session=session, model_path=None)
+        tf_model = cls(session=session, model_path="")
         tf_model._bqml_model = core.BqmlModel(session, model)
         return tf_model
 
@@ -109,15 +111,17 @@ class ONNXModel(base.Predictor):
     """Imported Open Neural Network Exchange (ONNX) model.
 
     Args:
+        model_path (str):
+            Cloud Storage path that holds the model files.
         session (BigQuery Session):
             BQ session to create the model
-        model_path (str):
-            Cloud Storage path that holds the model files."""
+    """
 
     def __init__(
         self,
+        model_path: str,
+        *,
         session: Optional[bigframes.Session] = None,
-        model_path: Optional[str] = None,
     ):
         self.session = session or bpd.get_global_session()
         self.model_path = model_path
@@ -134,7 +138,7 @@ class ONNXModel(base.Predictor):
     def _from_bq(cls, session: bigframes.Session, model: bigquery.Model) -> ONNXModel:
         assert model.model_type == "ONNX"
 
-        onnx_model = cls(session=session, model_path=None)
+        onnx_model = cls(session=session, model_path="")
         onnx_model._bqml_model = core.BqmlModel(session, model)
         return onnx_model
 
@@ -189,8 +193,8 @@ class XGBoostModel(base.Predictor):
         https://cloud.google.com/bigquery/docs/reference/standard-sql/bigqueryml-syntax-create-xgboost#limitations
 
     Args:
-        session (BigQuery Session):
-            BQ session to create the model
+        model_path (str):
+            Cloud Storage path that holds the model files.
         input (Dict, default None):
             Specify the model input schema information when you
             create the XGBoost model. The input should be the format of
@@ -203,15 +207,17 @@ class XGBoostModel(base.Predictor):
             {field_name: field_type}. Output is optional only if feature_names
             and feature_types are both specified in the model file. Supported types
             are "bool", "string", "int64", "float64", "array<bool>", "array<string>", "array<int64>", "array<float64>".
-        model_path (str):
-            Cloud Storage path that holds the model files."""
+        session (BigQuery Session):
+            BQ session to create the model
+    """
 
     def __init__(
         self,
-        session: Optional[bigframes.Session] = None,
+        model_path: str,
+        *,
         input: Mapping[str, str] = {},
         output: Mapping[str, str] = {},
-        model_path: Optional[str] = None,
+        session: Optional[bigframes.Session] = None,
     ):
         self.session = session or bpd.get_global_session()
         self.model_path = model_path
@@ -248,7 +254,7 @@ class XGBoostModel(base.Predictor):
     ) -> XGBoostModel:
         assert model.model_type == "XGBOOST"
 
-        xgboost_model = cls(session=session, model_path=None)
+        xgboost_model = cls(session=session, model_path="")
         xgboost_model._bqml_model = core.BqmlModel(session, model)
         return xgboost_model
 

--- a/bigframes/ml/linear_model.py
+++ b/bigframes/ml/linear_model.py
@@ -58,6 +58,7 @@ class LinearRegression(
 
     def __init__(
         self,
+        *,
         optimize_strategy: Literal[
             "auto_strategy", "batch_gradient_descent", "normal_equation"
         ] = "normal_equation",
@@ -192,6 +193,7 @@ class LogisticRegression(
     # TODO(ashleyxu) support class_weights in the constructor.
     def __init__(
         self,
+        *,
         fit_intercept: bool = True,
         class_weights: Optional[Union[Literal["balanced"], Dict[str, float]]] = None,
     ):

--- a/bigframes/ml/llm.py
+++ b/bigframes/ml/llm.py
@@ -66,6 +66,7 @@ class PaLM2TextGenerator(base.Predictor):
 
     def __init__(
         self,
+        *,
         model_name: Literal["text-bison", "text-bison-32k"] = "text-bison",
         session: Optional[bigframes.Session] = None,
         connection_name: Optional[str] = None,
@@ -140,6 +141,7 @@ class PaLM2TextGenerator(base.Predictor):
     def predict(
         self,
         X: Union[bpd.DataFrame, bpd.Series],
+        *,
         temperature: float = 0.0,
         max_output_tokens: int = 128,
         top_k: int = 40,
@@ -273,6 +275,7 @@ class PaLM2TextEmbeddingGenerator(base.Predictor):
 
     def __init__(
         self,
+        *,
         model_name: Literal[
             "textembedding-gecko", "textembedding-gecko-multilingual"
         ] = "textembedding-gecko",
@@ -415,6 +418,7 @@ class GeminiTextGenerator(base.Predictor):
 
     def __init__(
         self,
+        *,
         session: Optional[bigframes.Session] = None,
         connection_name: Optional[str] = None,
     ):
@@ -475,6 +479,7 @@ class GeminiTextGenerator(base.Predictor):
     def predict(
         self,
         X: Union[bpd.DataFrame, bpd.Series],
+        *,
         temperature: float = 0.9,
         max_output_tokens: int = 8192,
         top_k: int = 40,

--- a/bigframes/ml/metrics/_metrics.py
+++ b/bigframes/ml/metrics/_metrics.py
@@ -34,6 +34,7 @@ import third_party.bigframes_vendored.sklearn.metrics._regression as vendored_me
 def r2_score(
     y_true: Union[bpd.DataFrame, bpd.Series],
     y_pred: Union[bpd.DataFrame, bpd.Series],
+    *,
     force_finite=True,
 ) -> float:
     y_true_series, y_pred_series = utils.convert_to_series(y_true, y_pred)
@@ -61,6 +62,7 @@ r2_score.__doc__ = inspect.getdoc(vendored_metrics_regression.r2_score)
 def accuracy_score(
     y_true: Union[bpd.DataFrame, bpd.Series],
     y_pred: Union[bpd.DataFrame, bpd.Series],
+    *,
     normalize=True,
 ) -> float:
     # TODO(ashleyxu): support sample_weight as the parameter
@@ -83,6 +85,7 @@ accuracy_score.__doc__ = inspect.getdoc(vendored_mertics_classification.accuracy
 def roc_curve(
     y_true: Union[bpd.DataFrame, bpd.Series],
     y_score: Union[bpd.DataFrame, bpd.Series],
+    *,
     drop_intermediate: bool = True,
 ) -> Tuple[bpd.Series, bpd.Series, bpd.Series]:
     # TODO(bmil): Add multi-class support
@@ -227,6 +230,7 @@ confusion_matrix.__doc__ = inspect.getdoc(
 def recall_score(
     y_true: Union[bpd.DataFrame, bpd.Series],
     y_pred: Union[bpd.DataFrame, bpd.Series],
+    *,
     average: str = "binary",
 ) -> pd.Series:
     # TODO(ashleyxu): support more average type, default to "binary"
@@ -263,6 +267,7 @@ recall_score.__doc__ = inspect.getdoc(vendored_mertics_classification.recall_sco
 def precision_score(
     y_true: Union[bpd.DataFrame, bpd.Series],
     y_pred: Union[bpd.DataFrame, bpd.Series],
+    *,
     average: str = "binary",
 ) -> pd.Series:
     # TODO(ashleyxu): support more average type, default to "binary"
@@ -301,6 +306,7 @@ precision_score.__doc__ = inspect.getdoc(
 def f1_score(
     y_true: Union[bpd.DataFrame, bpd.Series],
     y_pred: Union[bpd.DataFrame, bpd.Series],
+    *,
     average: str = "binary",
 ) -> pd.Series:
     # TODO(ashleyxu): support more average type, default to "binary"

--- a/bigframes/ml/remote.py
+++ b/bigframes/ml/remote.py
@@ -54,6 +54,7 @@ class VertexAIModel(base.BaseEstimator):
         endpoint: str,
         input: Mapping[str, str],
         output: Mapping[str, str],
+        *,
         session: Optional[bigframes.Session] = None,
         connection_name: Optional[str] = None,
     ):


### PR DESCRIPTION
To be more like sklearn, and make API more accurate. Those param shouldn't be called through positions. 
