### PR TITLE
chore: update toc entry to properly include summary pages

### DIFF
--- a/docs/templates/toc.yml
+++ b/docs/templates/toc.yml
@@ -4,13 +4,13 @@
   - href: changelog.md
     name: Changelog
   - items:
-    - href: summary_overview.yml
+    - href: summary_overview.html
       name: Overview
-    - href: summary_class.yml
+    - href: summary_class.html
       name: Classes
-    - href: summary_method.yml
+    - href: summary_method.html
       name: Methods
-    - href: summary_property.yml
+    - href: summary_property.html
       name: Properties and Attributes
     name: BigQuery DataFrames API
   - items:


### PR DESCRIPTION
When the files aren't present, docfx does not convert the files from `.yml` extension to `.html`. I've tested this locally to ensure docfx keeps the file extension to `.html` as needed, which we'll need for the new files added for summary pages.

The only entry that should change in the future would be `summary_overview.html` to `summary_overview.md`. Filed googleapis/google-cloud-python#15753  to keep track of that.

🦕
