### PR TITLE
fix: remove unsupported to_json arguments

### DIFF
--- a/bigframes/dataframe.py
+++ b/bigframes/dataframe.py
@@ -2573,11 +2573,7 @@ class DataFrame(vendored_pandas_frame.DataFrame):
     def to_json(
         self,
         path_or_buf: str,
-        orient: Literal[
-            "split", "records", "index", "columns", "values", "table"
-        ] = "columns",
         *,
-        lines: bool = False,
         index: bool = True,
     ) -> None:
         # TODO(swast): Can we support partition columns argument?
@@ -2587,18 +2583,6 @@ class DataFrame(vendored_pandas_frame.DataFrame):
 
         if "*" not in path_or_buf:
             raise NotImplementedError(ERROR_IO_REQUIRES_WILDCARD)
-
-        if lines is True and orient != "records":
-            raise ValueError(
-                "'lines' keyword is only valid when 'orient' is 'records'."
-            )
-
-        # TODO(ashleyxu) Support lines=False for small tables with arrays and TO_JSON_STRING.
-        # See: https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#to_json_string
-        if lines is False:
-            raise NotImplementedError(
-                f"Only newline delimited JSON format is supported. {constants.FEEDBACK_LINK}"
-            )
 
         result_table = self._run_io_query(
             index=index, ordering_id=bigframes.session._io.bigquery.IO_ORDERING_ID

--- a/bigframes/series.py
+++ b/bigframes/series.py
@@ -1403,9 +1403,6 @@ class Series(bigframes.operations.base.SeriesMethods, vendored_pandas_series.Ser
     def to_json(
         self,
         path_or_buf=None,
-        orient: typing.Literal[
-            "split", "records", "index", "columns", "values", "table"
-        ] = "columns",
         **kwargs,
     ) -> typing.Optional[str]:
         # TODO(b/280651142): Implement version that leverages bq export native csv support to bypass local pandas step.

--- a/tests/system/small/test_dataframe_io.py
+++ b/tests/system/small/test_dataframe_io.py
@@ -381,43 +381,7 @@ def test_to_gbq_w_invalid_destination_table(scalars_df_index):
     ("index"),
     [True, False],
 )
-def test_to_json_index_invalid_orient(
-    scalars_dfs: Tuple[bigframes.dataframe.DataFrame, pd.DataFrame],
-    gcs_folder: str,
-    index: bool,
-):
-    scalars_df, scalars_pandas_df = scalars_dfs
-    if scalars_df.index.name is not None:
-        path = gcs_folder + f"test_index_df_to_json_index_{index}*.jsonl"
-    else:
-        path = gcs_folder + f"test_default_index_df_to_json_index_{index}*.jsonl"
-    with pytest.raises(ValueError):
-        scalars_df.to_json(path, index=index, lines=True)
-
-
-@pytest.mark.parametrize(
-    ("index"),
-    [True, False],
-)
-def test_to_json_index_invalid_lines(
-    scalars_dfs: Tuple[bigframes.dataframe.DataFrame, pd.DataFrame],
-    gcs_folder: str,
-    index: bool,
-):
-    scalars_df, scalars_pandas_df = scalars_dfs
-    if scalars_df.index.name is not None:
-        path = gcs_folder + f"test_index_df_to_json_index_{index}.jsonl"
-    else:
-        path = gcs_folder + f"test_default_index_df_to_json_index_{index}.jsonl"
-    with pytest.raises(NotImplementedError):
-        scalars_df.to_json(path, index=index)
-
-
-@pytest.mark.parametrize(
-    ("index"),
-    [True, False],
-)
-def test_to_json_index_records_orient(
+def test_to_json(
     scalars_dfs: Tuple[bigframes.dataframe.DataFrame, pd.DataFrame],
     gcs_folder: str,
     index: bool,
@@ -429,8 +393,7 @@ def test_to_json_index_records_orient(
     else:
         path = gcs_folder + f"test_default_index_df_to_json_index_{index}*.jsonl"
 
-    """ Test the `to_json` API with `orient` is `records` and `lines` is True"""
-    scalars_df.to_json(path, index=index, orient="records", lines=True)
+    scalars_df.to_json(path, index=index)
 
     gcs_df = pd.read_json(path, lines=True, convert_dates=["datetime_col"])
     convert_pandas_dtypes(gcs_df, bytes_col=True)

--- a/third_party/bigframes_vendored/pandas/core/generic.py
+++ b/third_party/bigframes_vendored/pandas/core/generic.py
@@ -1,7 +1,7 @@
 # Contains code from https://github.com/pandas-dev/pandas/blob/main/pandas/core/generic.py
 from __future__ import annotations
 
-from typing import Iterator, Literal, Optional
+from typing import Iterator, Optional
 
 from bigframes_vendored.pandas.core import indexing
 
@@ -173,20 +173,14 @@ class NDFrame(indexing.IndexingMixin):
     def to_json(
         self,
         path_or_buf: str,
-        orient: Literal[
-            "split", "records", "index", "columns", "values", "table"
-        ] = "columns",
         *,
         index: bool = True,
-        lines: bool = False,
-    ) -> str | None:
-        """Convert the object to a JSON string, written to Cloud Storage.
-
-        Note NaN's and None will be converted to null and datetime objects
-        will be converted to UNIX timestamps.
+    ) -> None:
+        """Write object to a line-delimited JSON file on Cloud Storage.
 
         .. note::
-            Only ``orient='records'`` and ``lines=True`` is supported so far.
+            NaN's and None will be converted to null and datetime objects
+            will be converted to UNIX timestamps.
 
         Args:
             path_or_buf (str):
@@ -199,38 +193,8 @@ class NDFrame(indexing.IndexingMixin):
                 varies.
 
                 None, file-like objects or local file paths not yet supported.
-            orient ({`split`, `records`, `index`, `columns`, `values`, `table`}, default 'columns):
-                Indication of expected JSON string format.
-
-                * Series:
-
-                    - default is 'index'
-                    - allowed values are: {{'split', 'records', 'index', 'table'}}.
-
-                * DataFrame:
-
-                    - default is 'columns'
-                    - allowed values are: {{'split', 'records', 'index', 'columns',
-                      'values', 'table'}}.
-
-                * The format of the JSON string:
-
-                    - 'split' : dict like {{'index' -> [index], 'columns' -> [columns],
-                      'data' -> [values]}}
-                    - 'records' : list like [{{column -> value}}, ... , {{column -> value}}]
-                    - 'index' : dict like {{index -> {{column -> value}}}}
-                    - 'columns' : dict like {{column -> {{index -> value}}}}
-                    - 'values' : just the values array
-                    - 'table' : dict like {{'schema': {{schema}}, 'data': {{data}}}}
-
-                    Describing the data, where data component is like ``orient='records'``.
             index (bool, default True):
                 If True, write row names (index).
-
-            lines (bool, default False):
-                If 'orient' is 'records' write out line-delimited json format. Will
-                throw ValueError if incorrect 'orient' since others are not
-                list-like.
 
         Returns:
             None: String output not yet supported.

--- a/third_party/bigframes_vendored/pandas/core/generic.py
+++ b/third_party/bigframes_vendored/pandas/core/generic.py
@@ -175,7 +175,7 @@ class NDFrame(indexing.IndexingMixin):
         path_or_buf: str,
         *,
         index: bool = True,
-    ) -> None:
+    ) -> str | None:
         """Write object to a line-delimited JSON file on Cloud Storage.
 
         .. note::

--- a/third_party/bigframes_vendored/pandas/core/series.py
+++ b/third_party/bigframes_vendored/pandas/core/series.py
@@ -538,9 +538,6 @@ class Series(NDFrame):  # type: ignore[misc]
     def to_json(
         self,
         path_or_buf=None,
-        orient: Literal[
-            "split", "records", "index", "columns", "values", "table"
-        ] = "columns",
         **kwarg,
     ) -> str | None:
         """
@@ -554,15 +551,6 @@ class Series(NDFrame):  # type: ignore[misc]
                 String, path object (implementing os.PathLike[str]), or file-like
                 object implementing a write() function. If None, the result is
                 returned as a string.
-            orient ({"split", "records", "index", "columns", "values", "table"}, default "columns"):
-                Indication of expected JSON string format.
-                'split' : dict like {{'index' -> [index], 'columns' -> [columns],'data' -> [values]}}
-                'records' : list like [{{column -> value}}, ... , {{column -> value}}]
-                'index' : dict like {{index -> {{column -> value}}}}
-                'columns' : dict like {{column -> {{index -> value}}}}
-                'values' : just the values array
-                'table' : dict like {{'schema': {{schema}}, 'data': {{data}}}}
-                Describing the data, where data component is like ``orient='records'``.
 
         Returns:
             None or str: If path_or_buf is None, returns the resulting json format as a


### PR DESCRIPTION
BREAKING CHANGE: This change is removing unused `orient` and `lines` arguments from `DataFrame.to_json` method. Only `orient='records'` and `lines=True` is supported so far, and the default arguments is not supported. For better user experience, this change is removing these parameters for now. 

Fixes internal issue b/329531924 🦕
