### PR TITLE
fix: raise `ValueError` when `read_pandas()` receives a bigframes `DataFrame`

### DIFF
--- a/bigframes/session/__init__.py
+++ b/bigframes/session/__init__.py
@@ -916,6 +916,12 @@ class Session(
     def _read_pandas(
         self, pandas_dataframe: pandas.DataFrame, api_name: str
     ) -> dataframe.DataFrame:
+        if isinstance(pandas_dataframe, dataframe.DataFrame):
+            raise ValueError(
+                "read_pandas() expects a pandas.DataFrame, but got a "
+                "bigframes.pandas.DataFrame."
+            )
+
         if (
             pandas_dataframe.size < MAX_INLINE_DF_SIZE
             # TODO(swast): Workaround data types limitation in inline data.

--- a/tests/unit/session/test_io_pandas.py
+++ b/tests/unit/session/test_io_pandas.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 
 import datetime
+import re
 from typing import Dict, Union
+import unittest.mock as mock
 
 import geopandas  # type: ignore
 import numpy
@@ -24,6 +26,7 @@ import pyarrow  # type: ignore
 import pytest
 
 import bigframes.features
+import bigframes.pandas
 import bigframes.session._io.pandas
 
 _LIST_OF_SCALARS = [
@@ -475,3 +478,12 @@ def test_arrow_to_pandas_wrong_size_dtypes(
 ):
     with pytest.raises(ValueError, match=f"Number of types {len(dtypes)}"):
         bigframes.session._io.pandas.arrow_to_pandas(arrow_table, dtypes)
+
+
+def test_read_pandas_with_bigframes_dataframe():
+    df = mock.create_autospec(bigframes.pandas.DataFrame, instance=True)
+
+    with pytest.raises(
+        ValueError, match=re.escape("read_pandas() expects a pandas.DataFrame")
+    ):
+        bigframes.pandas.read_pandas(df)

--- a/tests/unit/session/test_io_pandas.py
+++ b/tests/unit/session/test_io_pandas.py
@@ -29,6 +29,8 @@ import bigframes.features
 import bigframes.pandas
 import bigframes.session._io.pandas
 
+from .. import resources
+
 _LIST_OF_SCALARS = [
     [1, 2, 3],
     [],
@@ -481,9 +483,10 @@ def test_arrow_to_pandas_wrong_size_dtypes(
 
 
 def test_read_pandas_with_bigframes_dataframe():
+    session = resources.create_bigquery_session()
     df = mock.create_autospec(bigframes.pandas.DataFrame, instance=True)
 
     with pytest.raises(
         ValueError, match=re.escape("read_pandas() expects a pandas.DataFrame")
     ):
-        bigframes.pandas.read_pandas(df)
+        session.read_pandas(df)


### PR DESCRIPTION
This should make debugging easier for users who mix up the type of their DataFrame.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes internal issue 292088543
 🦕
