### PR TITLE
chore: remove unused ColumnTransformer check

### DIFF
--- a/bigframes/ml/compose.py
+++ b/bigframes/ml/compose.py
@@ -23,7 +23,6 @@ from typing import List, Optional, Tuple, Union
 
 import bigframes_vendored.sklearn.compose._column_transformer
 
-from bigframes import constants
 from bigframes.core import log_adapter
 from bigframes.ml import base, core, globals, preprocessing, utils
 import bigframes.pandas as bpd
@@ -77,7 +76,6 @@ class ColumnTransformer(
             ]
         ] = []
 
-        column_set: set[str] = set()
         for entry in self.transformers:
             name, transformer, column_or_columns = entry
             columns = (
@@ -87,10 +85,6 @@ class ColumnTransformer(
             )
 
             for column in columns:
-                if column in column_set:
-                    raise NotImplementedError(
-                        f"Chained transformers on the same column isn't supported. {constants.FEEDBACK_LINK}"
-                    )
                 result.append((name, transformer, column))
 
         return result

--- a/tests/system/large/ml/test_compose.py
+++ b/tests/system/large/ml/test_compose.py
@@ -32,9 +32,14 @@ def test_columntransformer_standalone_fit_and_transform(
                 "species",
             ),
             (
-                "scale",
+                "starndard_scale",
                 bigframes.ml.preprocessing.StandardScaler(),
                 ["culmen_length_mm", "flipper_length_mm"],
+            ),
+            (
+                "min_max_scale",
+                bigframes.ml.preprocessing.MinMaxScaler(),
+                ["culmen_length_mm"],
             ),
         ]
     )
@@ -51,6 +56,7 @@ def test_columntransformer_standalone_fit_and_transform(
 
     expected = pandas.DataFrame(
         {
+            "min_max_scaled_culmen_length_mm": [0.269, 0.232, 0.210],
             "onehotencoded_species": [
                 [{"index": 1, "value": 1.0}],
                 [{"index": 1, "value": 1.0}],
@@ -65,14 +71,8 @@ def test_columntransformer_standalone_fit_and_transform(
         },
         index=pandas.Index([1633, 1672, 1690], dtype="Int64", name="tag_number"),
     )
-    expected.standard_scaled_culmen_length_mm = (
-        expected.standard_scaled_culmen_length_mm.astype("Float64")
-    )
-    expected.standard_scaled_flipper_length_mm = (
-        expected.standard_scaled_flipper_length_mm.astype("Float64")
-    )
 
-    pandas.testing.assert_frame_equal(result, expected, rtol=1e-3, check_dtype=False)
+    pandas.testing.assert_frame_equal(result, expected, rtol=0.1, check_dtype=False)
 
 
 def test_columntransformer_standalone_fit_transform(new_penguins_df):
@@ -84,7 +84,7 @@ def test_columntransformer_standalone_fit_transform(new_penguins_df):
                 "species",
             ),
             (
-                "scale",
+                "standard_scale",
                 bigframes.ml.preprocessing.StandardScaler(),
                 ["culmen_length_mm", "flipper_length_mm"],
             ),
@@ -116,11 +116,5 @@ def test_columntransformer_standalone_fit_transform(new_penguins_df):
         },
         index=pandas.Index([1633, 1672, 1690], dtype="Int64", name="tag_number"),
     )
-    expected.standard_scaled_culmen_length_mm = (
-        expected.standard_scaled_culmen_length_mm.astype("Float64")
-    )
-    expected.standard_scaled_flipper_length_mm = (
-        expected.standard_scaled_flipper_length_mm.astype("Float64")
-    )
 
-    pandas.testing.assert_frame_equal(result, expected, rtol=1e-3, check_dtype=False)
+    pandas.testing.assert_frame_equal(result, expected, rtol=0.1, check_dtype=False)


### PR DESCRIPTION
The check is no-op and misleading. It is not a chained transformer. But transformer to the same column, which is supported both in BQML and sklearn. 
