### PR TITLE
fix: plot.scatter s parameter cannot accept float-like column

### DIFF
--- a/bigframes/operations/_matplotlib/core.py
+++ b/bigframes/operations/_matplotlib/core.py
@@ -115,6 +115,18 @@ class ScatterPlot(SamplingPlot):
         if self._is_column_name(c, sample) and sample[c].dtype == dtypes.STRING_DTYPE:
             sample[c] = sample[c].astype("object")
 
+        # To avoid Matplotlib's automatic conversion of `Float64` or `Int64` columns
+        # to `object` types (which breaks float-like behavior), this code proactively
+        # converts the column to a compatible format."
+        s = self.kwargs.get("s", None)
+        if pd.core.dtypes.common.is_integer(s):
+            s = self.data.columns[s]
+        if self._is_column_name(s, sample):
+            if sample[s].dtype == dtypes.INT_DTYPE:
+                sample[s] = sample[s].astype("int64")
+            elif sample[s].dtype == dtypes.FLOAT_DTYPE:
+                sample[s] = sample[s].astype("float64")
+
         return sample
 
     def _is_sequence_arg(self, arg):
@@ -130,9 +142,3 @@ class ScatterPlot(SamplingPlot):
             and pd.core.dtypes.common.is_hashable(arg)
             and arg in data.columns
         )
-
-    def _generate_new_column_name(self, data):
-        col_name = None
-        while col_name is None or col_name in data.columns:
-            col_name = f"plot_temp_{str(uuid.uuid4())[:8]}"
-        return col_name

--- a/bigframes/operations/_matplotlib/core.py
+++ b/bigframes/operations/_matplotlib/core.py
@@ -116,7 +116,7 @@ class ScatterPlot(SamplingPlot):
 
         # To avoid Matplotlib's automatic conversion of `Float64` or `Int64` columns
         # to `object` types (which breaks float-like behavior), this code proactively
-        # converts the column to a compatible format."
+        # converts the column to a compatible format.
         s = self.kwargs.get("s", None)
         if pd.core.dtypes.common.is_integer(s):
             s = self.data.columns[s]

--- a/bigframes/operations/_matplotlib/core.py
+++ b/bigframes/operations/_matplotlib/core.py
@@ -14,7 +14,6 @@
 
 import abc
 import typing
-import uuid
 
 import pandas as pd
 

--- a/tests/system/small/operations/test_plotting.py
+++ b/tests/system/small/operations/test_plotting.py
@@ -281,6 +281,7 @@ def test_scatter_sequence_arg(arg_name):
     arg_value = [3, 3, 1]
     bpd.DataFrame(data).plot.scatter(x="a", y="b", **{arg_name: arg_value})
 
+
 def test_sampling_plot_args_n():
     df = bpd.DataFrame(np.arange(bf_mpl.DEFAULT_SAMPLING_N * 10), columns=["one"])
     ax = df.plot.line()

--- a/tests/system/small/operations/test_plotting.py
+++ b/tests/system/small/operations/test_plotting.py
@@ -241,6 +241,32 @@ def test_scatter_args_c(c):
 
 
 @pytest.mark.parametrize(
+    ("s"),
+    [
+        pytest.param([10, 34, 50], id="int"),
+        pytest.param([1.0, 3.4, 5.0], id="float"),
+        pytest.param(
+            [True, True, False], id="bool", marks=pytest.mark.xfail(raises=ValueError)
+        ),
+    ],
+)
+def test_scatter_args_s(s):
+    data = {
+        "a": [1, 2, 3],
+        "b": [1, 2, 3],
+    }
+    data["s"] = s
+    df = bpd.DataFrame(data)
+    pd_df = pd.DataFrame(data)
+
+    ax = df.plot.scatter(x="a", y="b", s="s")
+    pd_ax = pd_df.plot.scatter(x="a", y="b", s="s")
+    tm.assert_numpy_array_equal(
+        ax.collections[0].get_sizes(), pd_ax.collections[0].get_sizes()
+    )
+
+
+@pytest.mark.parametrize(
     ("arg_name"),
     [
         pytest.param("c", marks=pytest.mark.xfail(raises=NotImplementedError)),
@@ -254,7 +280,6 @@ def test_scatter_sequence_arg(arg_name):
     }
     arg_value = [3, 3, 1]
     bpd.DataFrame(data).plot.scatter(x="a", y="b", **{arg_name: arg_value})
-
 
 def test_sampling_plot_args_n():
     df = bpd.DataFrame(np.arange(bf_mpl.DEFAULT_SAMPLING_N * 10), columns=["one"])


### PR DESCRIPTION
Fixes internal b/330574847 🦕
