### PR TITLE
fix: exclude list-like s parameter in plot.scatter

### DIFF
--- a/bigframes/operations/_matplotlib/core.py
+++ b/bigframes/operations/_matplotlib/core.py
@@ -98,6 +98,12 @@ class ScatterPlot(SamplingPlot):
                 f"Only support a single color string or a column name/posision. {constants.FEEDBACK_LINK}"
             )
 
+        s = self.kwargs.get("s", None)
+        if self._is_sequence_arg(s):
+            raise NotImplementedError(
+                f"Only support a single color string or a column name/posision. {constants.FEEDBACK_LINK}"
+            )
+
     def _compute_plot_data(self):
         sample = self._compute_sample_data(self.data)
 

--- a/tests/system/small/operations/test_plotting.py
+++ b/tests/system/small/operations/test_plotting.py
@@ -240,6 +240,22 @@ def test_scatter_args_c(c):
         )
 
 
+@pytest.mark.parametrize(
+    ("arg_name"),
+    [
+        pytest.param("c", marks=pytest.mark.xfail(raises=NotImplementedError)),
+        pytest.param("s", marks=pytest.mark.xfail(raises=NotImplementedError)),
+    ],
+)
+def test_scatter_sequence_arg(arg_name):
+    data = {
+        "a": [1, 2, 3],
+        "b": [1, 2, 3],
+    }
+    arg_value = [3, 3, 1]
+    bpd.DataFrame(data).plot.scatter(x="a", y="b", **{arg_name: arg_value})
+
+
 def test_sampling_plot_args_n():
     df = bpd.DataFrame(np.arange(bf_mpl.DEFAULT_SAMPLING_N * 10), columns=["one"])
     ax = df.plot.line()

--- a/third_party/bigframes_vendored/pandas/plotting/_core.py
+++ b/third_party/bigframes_vendored/pandas/plotting/_core.py
@@ -257,9 +257,6 @@ class PlotAccessor:
 
                 - A string with the name of the column to be used for marker's size.
                 - A single scalar so all points have the same size.
-                - A sequence of scalars, which will be used for each point's size
-                  recursively. For instance, when passing [2,14] all points size
-                  will be either 2 or 14, alternatively.
 
             c (str, int or array-like, optional):
                 The color of each point. Possible values are:


### PR DESCRIPTION
Fixes internal b/329868825 🦕
