### PR TITLE
test: explicitly use US location for session in tests

### DIFF
--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -128,7 +128,10 @@ def resourcemanager_client(
 
 @pytest.fixture(scope="session")
 def session() -> bigframes.Session:
-    return bigframes.Session()
+    context = bigframes.BigQueryOptions(
+        location="US",
+    )
+    return bigframes.Session(context=context)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
This avoids some warnings we see and ignore in our tests.

It might also address some flakiness in
`tests/system/small/ml/test_llm.py::test_create_text_generator_model` and
`tests/system/small/ml/test_llm.py::test_create_text_generator_32k_model`, but the root cause of that flakiness is still TBD.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
