### PR TITLE
feat: `bigframes.options` and  `bigframes.option_context` now uses thread-local variables to prevent context managers in separate threads from affecting each other

### DIFF
--- a/bigframes/_config/__init__.py
+++ b/bigframes/_config/__init__.py
@@ -48,7 +48,8 @@ class Options:
         """Initialize thread-local options, based on current global options."""
 
         # Already thread-local, so don't reset any options that have been set
-        # already.
+        # already. No locks needed since this only modifies thread-local
+        # variables.
         if self._local.is_bigquery_thread_local:
             return
 

--- a/bigframes/_config/__init__.py
+++ b/bigframes/_config/__init__.py
@@ -44,7 +44,7 @@ class Options:
         self._bigquery_options = bigquery_options.BigQueryOptions()
         self._local.bigquery_options = None
 
-    def _init_biquery_thread_local(self):
+    def _init_bigquery_thread_local(self):
         """Initialize thread-local options, based on current global options."""
 
         # Already thread-local, so don't reset any options that have been set

--- a/bigframes/_config/__init__.py
+++ b/bigframes/_config/__init__.py
@@ -17,6 +17,9 @@ Configuration for BigQuery DataFrames. Do not depend on other parts of BigQuery
 DataFrames from this package.
 """
 
+import copy
+import threading
+
 import bigframes_vendored.pandas._config.config as pandas_config
 
 import bigframes._config.bigquery_options as bigquery_options
@@ -29,44 +32,77 @@ class Options:
     """Global options affecting BigQuery DataFrames behavior."""
 
     def __init__(self):
+        self._local = threading.local()
+        self._local.display_options = display_options.DisplayOptions()
+        self._local.sampling_options = sampling_options.SamplingOptions()
+        self._local.compute_options = compute_options.ComputeOptions()
+
+        # BigQuery options are special because they can only be set once per
+        # session, so we need an indicator as to whether we are using the
+        # thread-local session or the global session.
+        self._local.is_bigquery_thread_local = False
         self._bigquery_options = bigquery_options.BigQueryOptions()
-        self._display_options = display_options.DisplayOptions()
-        self._sampling_options = sampling_options.SamplingOptions()
-        self._compute_options = compute_options.ComputeOptions()
+        self._local.bigquery_options = None
+
+    def _init_biquery_thread_local(self):
+        """Initialize thread-local options, based on current global options."""
+
+        # Already thread-local, so don't reset any options that have been set
+        # already.
+        if self._local.is_bigquery_thread_local:
+            return
+
+        self._local.is_bigquery_thread_local = True
+        self._local.bigquery_options = copy.deepcopy(self._bigquery_options)
+        self._local.bigquery_options._session_started = False
 
     @property
     def bigquery(self) -> bigquery_options.BigQueryOptions:
         """Options to use with the BigQuery engine."""
+        if self._local.is_bigquery_thread_local:
+            return self._local.bigquery_options
+
         return self._bigquery_options
 
     @property
     def display(self) -> display_options.DisplayOptions:
         """Options controlling object representation."""
-        return self._display_options
+        return self._local.display_options
 
     @property
     def sampling(self) -> sampling_options.SamplingOptions:
         """Options controlling downsampling when downloading data
-        to memory. The data will be downloaded into memory explicitly
+        to memory.
+
+        The data can be downloaded into memory explicitly
         (e.g., to_pandas, to_numpy, values) or implicitly (e.g.,
         matplotlib plotting). This option can be overriden by
-        parameters in specific functions."""
-        return self._sampling_options
+        parameters in specific functions.
+        """
+        return self._local.sampling_options
 
     @property
     def compute(self) -> compute_options.ComputeOptions:
-        """Options controlling object computation."""
-        return self._compute_options
+        """Thread-local options controlling object computation."""
+        return self._local.compute_options
+
+    @property
+    def is_bigquery_thread_local(self) -> bool:
+        """Indicator that we're using a thread-local session.
+
+        This is set to True by using `option_context` with a "bigquery" option.
+        """
+        return self._local.is_bigquery_thread_local
 
 
 options = Options()
 """Global options for default session."""
 
+option_context = pandas_config.option_context
+
 
 __all__ = (
     "Options",
     "options",
+    "option_context",
 )
-
-
-option_context = pandas_config.option_context

--- a/bigframes/core/global_session.py
+++ b/bigframes/core/global_session.py
@@ -63,9 +63,10 @@ def close_session() -> None:
             _global_session_state.thread_local_session = None
 
         # Currently using thread-local options, so no global lock needed.
-        # Don't reset is_bigquery_thread_local, as that's the responsibility
+        # Don't reset options.bigquery, as that's the responsibility
         # of the context manager that started it in the first place. The user
-        # might have explicitly closed the session in the context manager.
+        # might have explicitly closed the session in the context manager and
+        # the thread-locality property needs to be retained.
         bigframes._config.options.bigquery._session_started = False
 
         # Don't close the non-thread-local session.

--- a/bigframes/core/indexes/base.py
+++ b/bigframes/core/indexes/base.py
@@ -239,7 +239,7 @@ class Index(vendored_pandas_index.Index):
         opts = bigframes.options.display
         max_results = opts.max_rows
         if opts.repr_mode == "deferred":
-            return formatter.repr_query_job(self.query_job)
+            return formatter.repr_query_job(self._block._compute_dry_run())
 
         pandas_df, _, query_job = self._block.retrieve_repr_request_results(max_results)
         self._query_job = query_job

--- a/bigframes/dataframe.py
+++ b/bigframes/dataframe.py
@@ -595,7 +595,7 @@ class DataFrame(vendored_pandas_frame.DataFrame):
         opts = bigframes.options.display
         max_results = opts.max_rows
         if opts.repr_mode == "deferred":
-            return formatter.repr_query_job(self.query_job)
+            return formatter.repr_query_job(self._compute_dry_run())
 
         self._cached()
         # TODO(swast): pass max_columns and get the true column count back. Maybe
@@ -634,7 +634,7 @@ class DataFrame(vendored_pandas_frame.DataFrame):
         opts = bigframes.options.display
         max_results = opts.max_rows
         if opts.repr_mode == "deferred":
-            return formatter.repr_query_job_html(self.query_job)
+            return formatter.repr_query_job(self._compute_dry_run())
 
         self._cached()
         # TODO(swast): pass max_columns and get the true column count back. Maybe

--- a/bigframes/dataframe.py
+++ b/bigframes/dataframe.py
@@ -632,7 +632,7 @@ class DataFrame(vendored_pandas_frame.DataFrame):
         many notebooks are not configured for large tables.
         """
         opts = bigframes.options.display
-        max_results = bigframes.options.display.max_rows
+        max_results = opts.max_rows
         if opts.repr_mode == "deferred":
             return formatter.repr_query_job_html(self.query_job)
 

--- a/bigframes/series.py
+++ b/bigframes/series.py
@@ -282,7 +282,7 @@ class Series(bigframes.operations.base.SeriesMethods, vendored_pandas_series.Ser
         opts = bigframes.options.display
         max_results = opts.max_rows
         if opts.repr_mode == "deferred":
-            return formatter.repr_query_job(self.query_job)
+            return formatter.repr_query_job(self._compute_dry_run())
 
         self._cached()
         pandas_df, _, query_job = self._block.retrieve_repr_request_results(max_results)

--- a/tests/system/small/ml/test_llm.py
+++ b/tests/system/small/ml/test_llm.py
@@ -55,25 +55,28 @@ def test_create_text_generator_model_default_session(
 ):
     import bigframes.pandas as bpd
 
-    bpd.close_session()
-    bpd.options.bigquery.bq_connection = bq_connection
-    bpd.options.bigquery.location = "us"
+    # Note: This starts a thread-local session.
+    with bpd.option_context(
+        "bigquery.bq_connection",
+        bq_connection,
+        "bigquery.location",
+        "US",
+    ):
+        model = llm.PaLM2TextGenerator()
+        assert model is not None
+        assert model._bqml_model is not None
+        assert (
+            model.connection_name.casefold()
+            == f"{bigquery_client.project}.us.bigframes-rf-conn"
+        )
 
-    model = llm.PaLM2TextGenerator()
-    assert model is not None
-    assert model._bqml_model is not None
-    assert (
-        model.connection_name.casefold()
-        == f"{bigquery_client.project}.us.bigframes-rf-conn"
-    )
+        llm_text_df = bpd.read_pandas(llm_text_pandas_df)
 
-    llm_text_df = bpd.read_pandas(llm_text_pandas_df)
-
-    df = model.predict(llm_text_df).to_pandas()
-    assert df.shape == (3, 4)
-    assert "ml_generate_text_llm_result" in df.columns
-    series = df["ml_generate_text_llm_result"]
-    assert all(series.str.len() > 20)
+        df = model.predict(llm_text_df).to_pandas()
+        assert df.shape == (3, 4)
+        assert "ml_generate_text_llm_result" in df.columns
+        series = df["ml_generate_text_llm_result"]
+        assert all(series.str.len() > 20)
 
 
 @pytest.mark.flaky(retries=2)
@@ -82,25 +85,28 @@ def test_create_text_generator_32k_model_default_session(
 ):
     import bigframes.pandas as bpd
 
-    bpd.close_session()
-    bpd.options.bigquery.bq_connection = bq_connection
-    bpd.options.bigquery.location = "us"
+    # Note: This starts a thread-local session.
+    with bpd.option_context(
+        "bigquery.bq_connection",
+        bq_connection,
+        "bigquery.location",
+        "US",
+    ):
+        model = llm.PaLM2TextGenerator(model_name="text-bison-32k")
+        assert model is not None
+        assert model._bqml_model is not None
+        assert (
+            model.connection_name.casefold()
+            == f"{bigquery_client.project}.us.bigframes-rf-conn"
+        )
 
-    model = llm.PaLM2TextGenerator(model_name="text-bison-32k")
-    assert model is not None
-    assert model._bqml_model is not None
-    assert (
-        model.connection_name.casefold()
-        == f"{bigquery_client.project}.us.bigframes-rf-conn"
-    )
+        llm_text_df = bpd.read_pandas(llm_text_pandas_df)
 
-    llm_text_df = bpd.read_pandas(llm_text_pandas_df)
-
-    df = model.predict(llm_text_df).to_pandas()
-    assert df.shape == (3, 4)
-    assert "ml_generate_text_llm_result" in df.columns
-    series = df["ml_generate_text_llm_result"]
-    assert all(series.str.len() > 20)
+        df = model.predict(llm_text_df).to_pandas()
+        assert df.shape == (3, 4)
+        assert "ml_generate_text_llm_result" in df.columns
+        series = df["ml_generate_text_llm_result"]
+        assert all(series.str.len() > 20)
 
 
 @pytest.mark.flaky(retries=2)
@@ -232,27 +238,33 @@ def test_create_embedding_generator_multilingual_model(
 def test_create_text_embedding_generator_model_defaults(bq_connection):
     import bigframes.pandas as bpd
 
-    bpd.close_session()
-    bpd.options.bigquery.bq_connection = bq_connection
-    bpd.options.bigquery.location = "us"
-
-    model = llm.PaLM2TextEmbeddingGenerator()
-    assert model is not None
-    assert model._bqml_model is not None
+    # Note: This starts a thread-local session.
+    with bpd.option_context(
+        "bigquery.bq_connection",
+        bq_connection,
+        "bigquery.location",
+        "US",
+    ):
+        model = llm.PaLM2TextEmbeddingGenerator()
+        assert model is not None
+        assert model._bqml_model is not None
 
 
 def test_create_text_embedding_generator_multilingual_model_defaults(bq_connection):
     import bigframes.pandas as bpd
 
-    bpd.close_session()
-    bpd.options.bigquery.bq_connection = bq_connection
-    bpd.options.bigquery.location = "us"
-
-    model = llm.PaLM2TextEmbeddingGenerator(
-        model_name="textembedding-gecko-multilingual"
-    )
-    assert model is not None
-    assert model._bqml_model is not None
+    # Note: This starts a thread-local session.
+    with bpd.option_context(
+        "bigquery.bq_connection",
+        bq_connection,
+        "bigquery.location",
+        "US",
+    ):
+        model = llm.PaLM2TextEmbeddingGenerator(
+            model_name="textembedding-gecko-multilingual"
+        )
+        assert model is not None
+        assert model._bqml_model is not None
 
 
 @pytest.mark.flaky(retries=2)

--- a/tests/system/small/test_dataframe.py
+++ b/tests/system/small/test_dataframe.py
@@ -142,18 +142,13 @@ def test_df_construct_from_dict():
 def test_df_construct_inline_respects_location():
     import bigframes.pandas as bpd
 
-    bpd.close_session()
-    bpd.options.bigquery.location = "europe-west1"
+    # Note: This starts a thread-local session.
+    with bpd.option_context("bigquery.location", "europe-west1"):
+        df = bpd.DataFrame([[1, 2, 3], [4, 5, 6]])
+        repr(df)
 
-    df = bpd.DataFrame([[1, 2, 3], [4, 5, 6]])
-    repr(df)
-
-    table = bpd.get_global_session().bqclient.get_table(df.query_job.destination)
-    assert table.location == "europe-west1"
-
-    # Reset global session
-    bpd.close_session()
-    bpd.options.bigquery.location = "us"
+        table = bpd.get_global_session().bqclient.get_table(df.query_job.destination)
+        assert table.location == "europe-west1"
 
 
 def test_get_column(scalars_dfs):

--- a/tests/system/small/test_pandas_options.py
+++ b/tests/system/small/test_pandas_options.py
@@ -293,9 +293,19 @@ def test_close_session_after_credentials_need_reauthentication(monkeypatch):
         with pytest.raises(google.auth.exceptions.RefreshError):
             bpd.read_gbq(test_query)
 
-        # Now verify that closing the session works
+        # Now verify that closing the session works. We look at the
+        # thread-local session because of the
+        # reset_default_session_and_location fixture and that this test mutates
+        # state that might otherwise be used by tests running in parallel.
+        assert (
+            bigframes.core.global_session._global_session_state.thread_local_session
+            is not None
+        )
         bpd.close_session()
-        assert bigframes.core.global_session._global_session is None
+        assert (
+            bigframes.core.global_session._global_session_state.thread_local_session
+            is None
+        )
 
     # Now verify that use is able to start over
     df = bpd.read_gbq(test_query)

--- a/tests/system/small/test_progress_bar.py
+++ b/tests/system/small/test_progress_bar.py
@@ -134,11 +134,13 @@ def test_query_job_repr(penguins_df_default_index: bf.dataframe.DataFrame):
         assert string in query_job_repr
 
 
-def test_query_job_dry_run(penguins_df_default_index: bf.dataframe.DataFrame, capsys):
+def test_query_job_dry_run(penguins_df_default_index: bf.dataframe.DataFrame):
+    expected = "Computation deferred. Computation will process"
+
     with bf.option_context("display.repr_mode", "deferred"):
-        repr(penguins_df_default_index)
-        repr(penguins_df_default_index["body_mass_g"])
-        lines = capsys.readouterr().out.split("\n")
-        lines = filter(None, lines)
-        for line in lines:
-            assert "Computation deferred. Computation will process" in line
+        df_result = repr(penguins_df_default_index)
+        assert expected in df_result
+
+    with bf.option_context("display.repr_mode", "deferred"):
+        series_result = repr(penguins_df_default_index["body_mass_g"])
+        assert expected in series_result

--- a/tests/system/small/test_progress_bar.py
+++ b/tests/system/small/test_progress_bar.py
@@ -23,6 +23,7 @@ import bigframes.formatting_helpers as formatting_helpers
 from bigframes.session import MAX_INLINE_DF_BYTES
 
 job_load_message_regex = r"\w+ job [\w-]+ is \w+\."
+EXPECTED_DRY_RUN_MESSAGE = "Computation deferred. Computation will process"
 
 
 def test_progress_bar_dataframe(
@@ -134,13 +135,19 @@ def test_query_job_repr(penguins_df_default_index: bf.dataframe.DataFrame):
         assert string in query_job_repr
 
 
-def test_query_job_dry_run(penguins_df_default_index: bf.dataframe.DataFrame):
-    expected = "Computation deferred. Computation will process"
-
+def test_query_job_dry_run_dataframe(penguins_df_default_index: bf.dataframe.DataFrame):
     with bf.option_context("display.repr_mode", "deferred"):
         df_result = repr(penguins_df_default_index)
-        assert expected in df_result
+        assert EXPECTED_DRY_RUN_MESSAGE in df_result
 
+
+def test_query_job_dry_run_index(penguins_df_default_index: bf.dataframe.DataFrame):
+    with bf.option_context("display.repr_mode", "deferred"):
+        index_result = repr(penguins_df_default_index.index)
+        assert EXPECTED_DRY_RUN_MESSAGE in index_result
+
+
+def test_query_job_dry_run_series(penguins_df_default_index: bf.dataframe.DataFrame):
     with bf.option_context("display.repr_mode", "deferred"):
         series_result = repr(penguins_df_default_index["body_mass_g"])
-        assert expected in series_result
+        assert EXPECTED_DRY_RUN_MESSAGE in series_result

--- a/third_party/bigframes_vendored/pandas/_config/config.py
+++ b/third_party/bigframes_vendored/pandas/_config/config.py
@@ -63,7 +63,7 @@ class option_context(contextlib.ContextDecorator):
 
         # We are now using a thread-specific session.
         if root == "bigquery":
-            bigframes.options._init_biquery_thread_local()
+            bigframes.options._init_bigquery_thread_local()
 
         parent = operator.attrgetter(root)(bigframes.options)
         setattr(parent, attr, val)

--- a/third_party/bigframes_vendored/pandas/_config/config.py
+++ b/third_party/bigframes_vendored/pandas/_config/config.py
@@ -56,7 +56,9 @@ class option_context(contextlib.ContextDecorator):
         # sessions if we allow that.
         if bigframes.options.is_bigquery_thread_local:
             bigframes.close_session()
-            bigframes.options._local.is_bigquery_thread_local = False
+
+            # Reset bigquery_options so that we're no longer thread-local.
+            bigframes.options._local.bigquery_options = None
 
     def _set_option(self, pat, val):
         root, attr = pat.rsplit(".", 1)

--- a/third_party/bigframes_vendored/pandas/_config/config.py
+++ b/third_party/bigframes_vendored/pandas/_config/config.py
@@ -7,9 +7,16 @@ import bigframes
 
 class option_context(contextlib.ContextDecorator):
     """
-    Context manager to temporarily set options in the `with` statement context.
+    Context manager to temporarily set thread-local options in the `with`
+    statement context.
 
     You need to invoke as ``option_context(pat, val, [(pat, val), ...])``.
+
+    .. note::
+
+        `"bigquery"` options can't be changed on a running session. Setting any
+        of these options creates a new thread-local session that only lives for
+        the lifetime of the context manager.
 
     **Examples:**
 
@@ -29,7 +36,11 @@ class option_context(contextlib.ContextDecorator):
 
     def __enter__(self) -> None:
         self.undo = [
-            (pat, operator.attrgetter(pat)(bigframes.options)) for pat, val in self.ops
+            (pat, operator.attrgetter(pat)(bigframes.options))
+            for pat, _ in self.ops
+            # Don't try to undo changes to bigquery options. We're starting and
+            # closing a new thread-local session if those are set.
+            if not pat.startswith("bigquery.")
         ]
 
         for pat, val in self.ops:
@@ -40,7 +51,19 @@ class option_context(contextlib.ContextDecorator):
             for pat, val in self.undo:
                 self._set_option(pat, val)
 
+        # TODO(tswast): What to do if someone nests several context managers
+        # with separate "bigquery" options? We might need a "stack" of
+        # sessions if we allow that.
+        if bigframes.options.is_bigquery_thread_local:
+            bigframes.close_session()
+            bigframes.options._local.is_bigquery_thread_local = False
+
     def _set_option(self, pat, val):
         root, attr = pat.rsplit(".", 1)
+
+        # We are now using a thread-specific session.
+        if root == "bigquery":
+            bigframes.options._init_biquery_thread_local()
+
         parent = operator.attrgetter(root)(bigframes.options)
         setattr(parent, attr, val)


### PR DESCRIPTION
In our tests, this allows us to actually test things like `bf.option_context("display.repr_mode", "deferred"):` without always having some other test change the display mode and break the test.

Fixes internal issue 308657813

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
