### PR TITLE
feat: bigframes.bigquery.array_agg(SeriesGroupBy|DataFrameGroupby)

### DIFF
--- a/bigframes/bigquery/__init__.py
+++ b/bigframes/bigquery/__init__.py
@@ -96,7 +96,7 @@ def array_agg(
         >>> df = bpd.DataFrame(l, columns=["a", "b", "c"])
         >>> bbq.array_agg(df.groupby(by=["b"]))
                  a      c
-        b                
+        b
         1.0    [2]    [3]
         2.0  [1 1]  [3 2]
         <BLANKLINE>

--- a/bigframes/bigquery/__init__.py
+++ b/bigframes/bigquery/__init__.py
@@ -22,7 +22,9 @@ from __future__ import annotations
 
 import typing
 
+import bigframes.core.groupby as groupby
 import bigframes.operations as ops
+import bigframes.operations.aggregations as agg_ops
 
 if typing.TYPE_CHECKING:
     import bigframes.series as series
@@ -58,3 +60,7 @@ def array_length(series: series.Series) -> series.Series:
 
     """
     return series._apply_unary_op(ops.len_op)
+
+
+def array_agg(groupby_series: groupby.SeriesGroupBy) -> series.Series:
+    return groupby_series._aggregate(agg_ops.ArrayAggOp())

--- a/bigframes/bigquery/__init__.py
+++ b/bigframes/bigquery/__init__.py
@@ -22,11 +22,13 @@ from __future__ import annotations
 
 import typing
 
+import bigframes.constants as constants
 import bigframes.core.groupby as groupby
 import bigframes.operations as ops
 import bigframes.operations.aggregations as agg_ops
 
 if typing.TYPE_CHECKING:
+    import bigframes.dataframe as dataframe
     import bigframes.series as series
 
 
@@ -54,6 +56,10 @@ def array_length(series: series.Series) -> series.Series:
         2    2
         dtype: Int64
 
+    Args:
+        series (bigframes.series.Series):
+                A Series with array columns.
+
     Returns:
         bigframes.series.Series: A Series of integer values indicating
             the length of each element in the Series.
@@ -62,5 +68,53 @@ def array_length(series: series.Series) -> series.Series:
     return series._apply_unary_op(ops.len_op)
 
 
-def array_agg(groupby_series: groupby.SeriesGroupBy) -> series.Series:
-    return groupby_series._aggregate(agg_ops.ArrayAggOp())
+def array_agg(
+    obj: groupby.SeriesGroupBy | groupby.DataFrameGroupBy,
+) -> series.Series | dataframe.DataFrame:
+    """Group data and create arrays from selected columns, omitting NULLs to avoid
+    BigQuery errors (NULLs not allowed in arrays).
+
+    **Examples:**
+
+        >>> import bigframes.pandas as bpd
+        >>> import bigframes.bigquery as bbq
+        >>> bpd.options.display.progress_bar = None
+
+    For a SeriesGroupBy object:
+
+        >>> lst = ['a', 'a', 'b', 'b', 'a']
+        >>> s = bpd.Series([1, 2, 3, 4, np.nan], index=lst)
+        >>> bbq.array_agg(s.groupby(level=0))
+        a    [1. 2.]
+        b    [3. 4.]
+        dtype: list<item: double>[pyarrow]
+
+    For a DataFrameGroupBy object:
+
+        >>> l = [[1, 2, 3], [1, None, 4], [2, 1, 3], [1, 2, 2]]
+        >>> df = bpd.DataFrame(l, columns=["a", "b", "c"])
+        >>> bbq.array_agg(df.groupby(by=["b"]))
+        b		a	c
+        1.0	[2]	[3]
+        2.0	[1 1]	[3 2]
+        2 rows × 2 columns
+
+        [2 rows x 2 columns in total]
+
+    Args:
+        obj (groupby.SeriesGroupBy | groupby.DataFrameGroupBy):
+                A GroupBy object to be applied the function.
+
+    Returns:
+        bigframes.series.Series | bigframes.dataframe.DataFrame: A Series or
+            DataFrame containing aggregated array columns, and indexed by the
+            original group columns.
+    """
+    if isinstance(obj, groupby.SeriesGroupBy):
+        return obj._aggregate(agg_ops.ArrayAggOp())
+    elif isinstance(obj, groupby.DataFrameGroupBy):
+        return obj._aggregate_all(agg_ops.ArrayAggOp(), numeric_only=False)
+    else:
+        raise ValueError(
+            f"Unsupported type {type(obj)} to apply `array_agg` function. {constants.FEEDBACK_LINK}"
+        )

--- a/bigframes/bigquery/__init__.py
+++ b/bigframes/bigquery/__init__.py
@@ -78,6 +78,7 @@ def array_agg(
 
         >>> import bigframes.pandas as bpd
         >>> import bigframes.bigquery as bbq
+        >>> import numpy as np
         >>> bpd.options.display.progress_bar = None
 
     For a SeriesGroupBy object:
@@ -94,12 +95,12 @@ def array_agg(
         >>> l = [[1, 2, 3], [1, None, 4], [2, 1, 3], [1, 2, 2]]
         >>> df = bpd.DataFrame(l, columns=["a", "b", "c"])
         >>> bbq.array_agg(df.groupby(by=["b"]))
-        b		a	c
-        1.0	[2]	[3]
-        2.0	[1 1]	[3 2]
-        2 rows × 2 columns
-
-        [2 rows x 2 columns in total]
+                 a      c
+        b                
+        1.0    [2]    [3]
+        2.0  [1 1]  [3 2]
+        <BLANKLINE>
+        [2 rows x 2 columns]
 
     Args:
         obj (groupby.SeriesGroupBy | groupby.DataFrameGroupBy):

--- a/bigframes/core/compile/aggregate_compiler.py
+++ b/bigframes/core/compile/aggregate_compiler.py
@@ -38,7 +38,9 @@ def compile_aggregate(
 ) -> ibis_types.Value:
     if isinstance(aggregate, ex.UnaryAggregation):
         input = scalar_compiler.compile_expression(aggregate.arg, bindings=bindings)
-        return compile_unary_agg(aggregate.op, input, order_by=order_by)
+        return compile_unary_agg(
+            aggregate.op, input, order_by=order_by if aggregate.op.can_order_by else []
+        )
     elif isinstance(aggregate, ex.BinaryAggregation):
         left = scalar_compiler.compile_expression(aggregate.left, bindings=bindings)
         right = scalar_compiler.compile_expression(aggregate.right, bindings=bindings)

--- a/bigframes/core/compile/aggregate_compiler.py
+++ b/bigframes/core/compile/aggregate_compiler.py
@@ -34,13 +34,11 @@ scalar_compiler = scalar_compilers.scalar_op_compiler
 def compile_aggregate(
     aggregate: ex.Aggregation,
     bindings: typing.Dict[str, ibis_types.Value],
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.Value:
     if isinstance(aggregate, ex.UnaryAggregation):
         input = scalar_compiler.compile_expression(aggregate.arg, bindings=bindings)
-        return compile_unary_agg(
-            aggregate.op,
-            input,
-        )
+        return compile_unary_agg(aggregate.op, input, agg_order_by=agg_order_by)
     elif isinstance(aggregate, ex.BinaryAggregation):
         left = scalar_compiler.compile_expression(aggregate.left, bindings=bindings)
         right = scalar_compiler.compile_expression(aggregate.right, bindings=bindings)
@@ -54,6 +52,7 @@ def compile_analytic(
     window: window_spec.WindowSpec,
     bindings: typing.Dict[str, ibis_types.Value],
 ) -> ibis_types.Value:
+    # TODO: check how to trigger here!
     if isinstance(aggregate, ex.UnaryAggregation):
         input = scalar_compiler.compile_expression(aggregate.arg, bindings=bindings)
         return compile_unary_agg(aggregate.op, input, window)
@@ -77,13 +76,19 @@ def compile_unary_agg(
     op: agg_ops.WindowOp,
     input: ibis_types.Column,
     window: Optional[window_spec.WindowSpec] = None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.Value:
     raise ValueError(f"Can't compile unrecognized operation: {op}")
 
 
 def numeric_op(operation):
     @functools.wraps(operation)
-    def constrained_op(op, column: ibis_types.Column, window=None):
+    def constrained_op(
+        op,
+        column: ibis_types.Column,
+        window=None,
+        agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    ):
         if column.type().is_boolean():
             column = typing.cast(
                 ibis_types.NumericColumn, column.cast(ibis_dtypes.int64)
@@ -104,7 +109,10 @@ def numeric_op(operation):
 @compile_unary_agg.register
 @numeric_op
 def _(
-    op: agg_ops.SumOp, column: ibis_types.NumericColumn, window=None
+    op: agg_ops.SumOp,
+    column: ibis_types.NumericColumn,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.NumericValue:
     # Will be null if all inputs are null. Pandas defaults to zero sum though.
     bq_sum = _apply_window_if_present(column.sum(), window)
@@ -116,7 +124,10 @@ def _(
 @compile_unary_agg.register
 @numeric_op
 def _(
-    op: agg_ops.MedianOp, column: ibis_types.NumericColumn, window=None
+    op: agg_ops.MedianOp,
+    column: ibis_types.NumericColumn,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.NumericValue:
     # PERCENTILE_CONT has very few allowed windows. For example, "window
     # framing clause is not allowed for analytic function percentile_cont".
@@ -134,7 +145,10 @@ def _(
 @compile_unary_agg.register
 @numeric_op
 def _(
-    op: agg_ops.ApproxQuartilesOp, column: ibis_types.NumericColumn, window=None
+    op: agg_ops.ApproxQuartilesOp,
+    column: ibis_types.NumericColumn,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.NumericValue:
     # PERCENTILE_CONT has very few allowed windows. For example, "window
     # framing clause is not allowed for analytic function percentile_cont".
@@ -151,7 +165,10 @@ def _(
 @compile_unary_agg.register
 @numeric_op
 def _(
-    op: agg_ops.QuantileOp, column: ibis_types.NumericColumn, window=None
+    op: agg_ops.QuantileOp,
+    column: ibis_types.NumericColumn,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.NumericValue:
     return _apply_window_if_present(column.quantile(op.q), window)
 
@@ -159,7 +176,10 @@ def _(
 @compile_unary_agg.register
 @numeric_op
 def _(
-    op: agg_ops.MeanOp, column: ibis_types.NumericColumn, window=None
+    op: agg_ops.MeanOp,
+    column: ibis_types.NumericColumn,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.NumericValue:
     return _apply_window_if_present(column.mean(), window)
 
@@ -167,7 +187,10 @@ def _(
 @compile_unary_agg.register
 @numeric_op
 def _(
-    op: agg_ops.ProductOp, column: ibis_types.NumericColumn, window=None
+    op: agg_ops.ProductOp,
+    column: ibis_types.NumericColumn,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.NumericValue:
     # Need to short-circuit as log with zeroes is illegal sql
     is_zero = cast(ibis_types.BooleanColumn, (column == 0))
@@ -202,30 +225,55 @@ def _(
 
 
 @compile_unary_agg.register
-def _(op: agg_ops.MaxOp, column: ibis_types.Column, window=None) -> ibis_types.Value:
+def _(
+    op: agg_ops.MaxOp,
+    column: ibis_types.Column,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+) -> ibis_types.Value:
     return _apply_window_if_present(column.max(), window)
 
 
 @compile_unary_agg.register
-def _(op: agg_ops.MinOp, column: ibis_types.Column, window=None) -> ibis_types.Value:
+def _(
+    op: agg_ops.MinOp,
+    column: ibis_types.Column,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+) -> ibis_types.Value:
     return _apply_window_if_present(column.min(), window)
 
 
 @compile_unary_agg.register
 @numeric_op
-def _(op: agg_ops.StdOp, x: ibis_types.Column, window=None) -> ibis_types.Value:
+def _(
+    op: agg_ops.StdOp,
+    x: ibis_types.Column,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+) -> ibis_types.Value:
     return _apply_window_if_present(cast(ibis_types.NumericColumn, x).std(), window)
 
 
 @compile_unary_agg.register
 @numeric_op
-def _(op: agg_ops.VarOp, x: ibis_types.Column, window=None) -> ibis_types.Value:
+def _(
+    op: agg_ops.VarOp,
+    x: ibis_types.Column,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+) -> ibis_types.Value:
     return _apply_window_if_present(cast(ibis_types.NumericColumn, x).var(), window)
 
 
 @compile_unary_agg.register
 @numeric_op
-def _(op: agg_ops.PopVarOp, x: ibis_types.Column, window=None) -> ibis_types.Value:
+def _(
+    op: agg_ops.PopVarOp,
+    x: ibis_types.Column,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+) -> ibis_types.Value:
     return _apply_window_if_present(
         cast(ibis_types.NumericColumn, x).var(how="pop"), window
     )
@@ -233,13 +281,46 @@ def _(op: agg_ops.PopVarOp, x: ibis_types.Column, window=None) -> ibis_types.Val
 
 @compile_unary_agg.register
 def _(
-    op: agg_ops.CountOp, column: ibis_types.Column, window=None
+    op: agg_ops.CountOp,
+    column: ibis_types.Column,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.IntegerValue:
     return _apply_window_if_present(column.count(), window)
 
 
 @compile_unary_agg.register
-def _(op: agg_ops.CutOp, x: ibis_types.Column, window=None):
+def _(
+    op: agg_ops.ArrayAggOp,
+    column: ibis_types.Column,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+) -> ibis_types.ArrayValue:
+    # BigQuery doesn't currently support using ARRAY_AGG with both window and aggregate
+    # functions simultaneously. Some aggregate functions (or its equivalent syntax)
+    # are more important, such as:
+    #    - `IGNORE NULLS` are required to avoid an raised error if the final result
+    #      contains a NULL element.
+    #    - `ORDER BY` are required for the default ordering mode.
+    # To keep things simpler, windowing support is skipped for now.
+    if window is not None:
+        raise NotImplementedError(
+            f"ArrayAgg with windowing is not supported. {constants.FEEDBACK_LINK}"
+        )
+
+    return vendored_ibis_ops.ArrayAggregate(
+        column,
+        order_by_columns=agg_order_by,
+    ).to_expr()
+
+
+@compile_unary_agg.register
+def _(
+    op: agg_ops.CutOp,
+    x: ibis_types.Column,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+):
     out = ibis.case()
     if isinstance(op.bins, int):
         col_min = _apply_window_if_present(x.min(), window)
@@ -292,7 +373,10 @@ def _(op: agg_ops.CutOp, x: ibis_types.Column, window=None):
 @compile_unary_agg.register
 @numeric_op
 def _(
-    self: agg_ops.QcutOp, column: ibis_types.Column, window=None
+    self: agg_ops.QcutOp,
+    column: ibis_types.Column,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.IntegerValue:
     if isinstance(self.quantiles, int):
         quantiles_ibis = dtypes.literal_to_ibis_scalar(self.quantiles)
@@ -322,21 +406,30 @@ def _(
 
 @compile_unary_agg.register
 def _(
-    op: agg_ops.NuniqueOp, column: ibis_types.Column, window=None
+    op: agg_ops.NuniqueOp,
+    column: ibis_types.Column,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.IntegerValue:
     return _apply_window_if_present(column.nunique(), window)
 
 
 @compile_unary_agg.register
 def _(
-    op: agg_ops.AnyValueOp, column: ibis_types.Column, window=None
+    op: agg_ops.AnyValueOp,
+    column: ibis_types.Column,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.IntegerValue:
     return _apply_window_if_present(column.arbitrary(), window)
 
 
 @compile_unary_agg.register
 def _(
-    op: agg_ops.RankOp, column: ibis_types.Column, window=None
+    op: agg_ops.RankOp,
+    column: ibis_types.Column,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.IntegerValue:
     # Ibis produces 0-based ranks, while pandas creates 1-based ranks
     return _apply_window_if_present(ibis.rank(), window) + 1
@@ -344,7 +437,10 @@ def _(
 
 @compile_unary_agg.register
 def _(
-    op: agg_ops.DenseRankOp, column: ibis_types.Column, window=None
+    op: agg_ops.DenseRankOp,
+    column: ibis_types.Column,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.IntegerValue:
     # Ibis produces 0-based ranks, while pandas creates 1-based ranks
     return _apply_window_if_present(column.dense_rank(), window) + 1
@@ -357,7 +453,10 @@ def _(op: agg_ops.FirstOp, column: ibis_types.Column, window=None) -> ibis_types
 
 @compile_unary_agg.register
 def _(
-    op: agg_ops.FirstNonNullOp, column: ibis_types.Column, window=None
+    op: agg_ops.FirstNonNullOp,
+    column: ibis_types.Column,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.Value:
     return _apply_window_if_present(
         vendored_ibis_ops.FirstNonNullValue(column).to_expr(), window  # type: ignore
@@ -365,13 +464,21 @@ def _(
 
 
 @compile_unary_agg.register
-def _(op: agg_ops.LastOp, column: ibis_types.Column, window=None) -> ibis_types.Value:
+def _(
+    op: agg_ops.LastOp,
+    column: ibis_types.Column,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+) -> ibis_types.Value:
     return _apply_window_if_present(column.last(), window)
 
 
 @compile_unary_agg.register
 def _(
-    op: agg_ops.LastNonNullOp, column: ibis_types.Column, window=None
+    op: agg_ops.LastNonNullOp,
+    column: ibis_types.Column,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.Value:
     return _apply_window_if_present(
         vendored_ibis_ops.LastNonNullValue(column).to_expr(), window  # type: ignore
@@ -379,7 +486,12 @@ def _(
 
 
 @compile_unary_agg.register
-def _(op: agg_ops.ShiftOp, column: ibis_types.Column, window=None) -> ibis_types.Value:
+def _(
+    op: agg_ops.ShiftOp,
+    column: ibis_types.Column,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+) -> ibis_types.Value:
     if op.periods == 0:  # No-op
         return column
     if op.periods > 0:
@@ -388,7 +500,12 @@ def _(op: agg_ops.ShiftOp, column: ibis_types.Column, window=None) -> ibis_types
 
 
 @compile_unary_agg.register
-def _(op: agg_ops.DiffOp, column: ibis_types.Column, window=None) -> ibis_types.Value:
+def _(
+    op: agg_ops.DiffOp,
+    column: ibis_types.Column,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+) -> ibis_types.Value:
     shifted = compile_unary_agg(agg_ops.ShiftOp(op.periods), column, window)
     if column.type().is_boolean():
         return cast(ibis_types.BooleanColumn, column) != cast(
@@ -404,7 +521,10 @@ def _(op: agg_ops.DiffOp, column: ibis_types.Column, window=None) -> ibis_types.
 
 @compile_unary_agg.register
 def _(
-    op: agg_ops.AllOp, column: ibis_types.Column, window=None
+    op: agg_ops.AllOp,
+    column: ibis_types.Column,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.BooleanValue:
     # BQ will return null for empty column, result would be true in pandas.
     result = _is_true(column).all()
@@ -416,7 +536,10 @@ def _(
 
 @compile_unary_agg.register
 def _(
-    op: agg_ops.AnyOp, column: ibis_types.Column, window=None
+    op: agg_ops.AnyOp,
+    column: ibis_types.Column,
+    window=None,
+    agg_order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.BooleanValue:
     # BQ will return null for empty column, result would be false in pandas.
     result = _is_true(column).any()

--- a/bigframes/core/compile/aggregate_compiler.py
+++ b/bigframes/core/compile/aggregate_compiler.py
@@ -52,7 +52,6 @@ def compile_analytic(
     window: window_spec.WindowSpec,
     bindings: typing.Dict[str, ibis_types.Value],
 ) -> ibis_types.Value:
-    # TODO: check how to trigger here!
     if isinstance(aggregate, ex.UnaryAggregation):
         input = scalar_compiler.compile_expression(aggregate.arg, bindings=bindings)
         return compile_unary_agg(aggregate.op, input, window)

--- a/bigframes/core/compile/aggregate_compiler.py
+++ b/bigframes/core/compile/aggregate_compiler.py
@@ -34,11 +34,11 @@ scalar_compiler = scalar_compilers.scalar_op_compiler
 def compile_aggregate(
     aggregate: ex.Aggregation,
     bindings: typing.Dict[str, ibis_types.Value],
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.Value:
     if isinstance(aggregate, ex.UnaryAggregation):
         input = scalar_compiler.compile_expression(aggregate.arg, bindings=bindings)
-        return compile_unary_agg(aggregate.op, input, agg_order_by=agg_order_by)
+        return compile_unary_agg(aggregate.op, input, order_by=order_by)
     elif isinstance(aggregate, ex.BinaryAggregation):
         left = scalar_compiler.compile_expression(aggregate.left, bindings=bindings)
         right = scalar_compiler.compile_expression(aggregate.right, bindings=bindings)
@@ -76,7 +76,7 @@ def compile_unary_agg(
     op: agg_ops.WindowOp,
     input: ibis_types.Column,
     window: Optional[window_spec.WindowSpec] = None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.Value:
     raise ValueError(f"Can't compile unrecognized operation: {op}")
 
@@ -87,7 +87,7 @@ def numeric_op(operation):
         op,
         column: ibis_types.Column,
         window=None,
-        agg_order_by: typing.Sequence[ibis_types.Value] = [],
+        order_by: typing.Sequence[ibis_types.Value] = [],
     ):
         if column.type().is_boolean():
             column = typing.cast(
@@ -112,7 +112,7 @@ def _(
     op: agg_ops.SumOp,
     column: ibis_types.NumericColumn,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.NumericValue:
     # Will be null if all inputs are null. Pandas defaults to zero sum though.
     bq_sum = _apply_window_if_present(column.sum(), window)
@@ -127,7 +127,7 @@ def _(
     op: agg_ops.MedianOp,
     column: ibis_types.NumericColumn,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.NumericValue:
     # PERCENTILE_CONT has very few allowed windows. For example, "window
     # framing clause is not allowed for analytic function percentile_cont".
@@ -148,7 +148,7 @@ def _(
     op: agg_ops.ApproxQuartilesOp,
     column: ibis_types.NumericColumn,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.NumericValue:
     # PERCENTILE_CONT has very few allowed windows. For example, "window
     # framing clause is not allowed for analytic function percentile_cont".
@@ -168,7 +168,7 @@ def _(
     op: agg_ops.QuantileOp,
     column: ibis_types.NumericColumn,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.NumericValue:
     return _apply_window_if_present(column.quantile(op.q), window)
 
@@ -179,7 +179,7 @@ def _(
     op: agg_ops.MeanOp,
     column: ibis_types.NumericColumn,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.NumericValue:
     return _apply_window_if_present(column.mean(), window)
 
@@ -190,7 +190,7 @@ def _(
     op: agg_ops.ProductOp,
     column: ibis_types.NumericColumn,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.NumericValue:
     # Need to short-circuit as log with zeroes is illegal sql
     is_zero = cast(ibis_types.BooleanColumn, (column == 0))
@@ -229,7 +229,7 @@ def _(
     op: agg_ops.MaxOp,
     column: ibis_types.Column,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.Value:
     return _apply_window_if_present(column.max(), window)
 
@@ -239,7 +239,7 @@ def _(
     op: agg_ops.MinOp,
     column: ibis_types.Column,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.Value:
     return _apply_window_if_present(column.min(), window)
 
@@ -250,7 +250,7 @@ def _(
     op: agg_ops.StdOp,
     x: ibis_types.Column,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.Value:
     return _apply_window_if_present(cast(ibis_types.NumericColumn, x).std(), window)
 
@@ -261,7 +261,7 @@ def _(
     op: agg_ops.VarOp,
     x: ibis_types.Column,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.Value:
     return _apply_window_if_present(cast(ibis_types.NumericColumn, x).var(), window)
 
@@ -272,7 +272,7 @@ def _(
     op: agg_ops.PopVarOp,
     x: ibis_types.Column,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.Value:
     return _apply_window_if_present(
         cast(ibis_types.NumericColumn, x).var(how="pop"), window
@@ -284,7 +284,7 @@ def _(
     op: agg_ops.CountOp,
     column: ibis_types.Column,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.IntegerValue:
     return _apply_window_if_present(column.count(), window)
 
@@ -294,7 +294,7 @@ def _(
     op: agg_ops.ArrayAggOp,
     column: ibis_types.Column,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.ArrayValue:
     # BigQuery doesn't currently support using ARRAY_AGG with both window and aggregate
     # functions simultaneously. Some aggregate functions (or its equivalent syntax)
@@ -310,7 +310,7 @@ def _(
 
     return vendored_ibis_ops.ArrayAggregate(
         column,
-        order_by_columns=agg_order_by,
+        order_by=order_by,
     ).to_expr()
 
 
@@ -319,7 +319,7 @@ def _(
     op: agg_ops.CutOp,
     x: ibis_types.Column,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ):
     out = ibis.case()
     if isinstance(op.bins, int):
@@ -376,7 +376,7 @@ def _(
     self: agg_ops.QcutOp,
     column: ibis_types.Column,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.IntegerValue:
     if isinstance(self.quantiles, int):
         quantiles_ibis = dtypes.literal_to_ibis_scalar(self.quantiles)
@@ -409,7 +409,7 @@ def _(
     op: agg_ops.NuniqueOp,
     column: ibis_types.Column,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.IntegerValue:
     return _apply_window_if_present(column.nunique(), window)
 
@@ -419,7 +419,7 @@ def _(
     op: agg_ops.AnyValueOp,
     column: ibis_types.Column,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.IntegerValue:
     return _apply_window_if_present(column.arbitrary(), window)
 
@@ -429,7 +429,7 @@ def _(
     op: agg_ops.RankOp,
     column: ibis_types.Column,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.IntegerValue:
     # Ibis produces 0-based ranks, while pandas creates 1-based ranks
     return _apply_window_if_present(ibis.rank(), window) + 1
@@ -440,7 +440,7 @@ def _(
     op: agg_ops.DenseRankOp,
     column: ibis_types.Column,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.IntegerValue:
     # Ibis produces 0-based ranks, while pandas creates 1-based ranks
     return _apply_window_if_present(column.dense_rank(), window) + 1
@@ -456,7 +456,7 @@ def _(
     op: agg_ops.FirstNonNullOp,
     column: ibis_types.Column,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.Value:
     return _apply_window_if_present(
         vendored_ibis_ops.FirstNonNullValue(column).to_expr(), window  # type: ignore
@@ -468,7 +468,7 @@ def _(
     op: agg_ops.LastOp,
     column: ibis_types.Column,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.Value:
     return _apply_window_if_present(column.last(), window)
 
@@ -478,7 +478,7 @@ def _(
     op: agg_ops.LastNonNullOp,
     column: ibis_types.Column,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.Value:
     return _apply_window_if_present(
         vendored_ibis_ops.LastNonNullValue(column).to_expr(), window  # type: ignore
@@ -490,7 +490,7 @@ def _(
     op: agg_ops.ShiftOp,
     column: ibis_types.Column,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.Value:
     if op.periods == 0:  # No-op
         return column
@@ -504,7 +504,7 @@ def _(
     op: agg_ops.DiffOp,
     column: ibis_types.Column,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.Value:
     shifted = compile_unary_agg(agg_ops.ShiftOp(op.periods), column, window)
     if column.type().is_boolean():
@@ -524,7 +524,7 @@ def _(
     op: agg_ops.AllOp,
     column: ibis_types.Column,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.BooleanValue:
     # BQ will return null for empty column, result would be true in pandas.
     result = _is_true(column).all()
@@ -539,7 +539,7 @@ def _(
     op: agg_ops.AnyOp,
     column: ibis_types.Column,
     window=None,
-    agg_order_by: typing.Sequence[ibis_types.Value] = [],
+    order_by: typing.Sequence[ibis_types.Value] = [],
 ) -> ibis_types.BooleanValue:
     # BQ will return null for empty column, result would be false in pandas.
     result = _is_true(column).any()

--- a/bigframes/core/compile/compiled.py
+++ b/bigframes/core/compile/compiled.py
@@ -169,7 +169,7 @@ class BaseIbisIR(abc.ABC):
             bigframes.dtypes.ibis_dtype_to_bigframes_dtype(ibis_type),
         )
 
-    def _aggregate_helper(
+    def _aggregate_base(
         self,
         table: ibis_types.Table,
         order_by: typing.Sequence[ibis_types.Value] = [],
@@ -376,7 +376,7 @@ class UnorderedIR(BaseIbisIR):
               information.
         """
         table = self._to_ibis_expr()
-        return self._aggregate_helper(
+        return self._aggregate_base(
             table, aggregations=aggregations, by_column_ids=by_column_ids, dropna=dropna
         )
 
@@ -659,7 +659,7 @@ class OrderedIR(BaseIbisIR):
         """
         table = self._to_ibis_expr(ordering_mode="unordered", expose_hidden_cols=True)
         order_by = self._ibis_order
-        return self._aggregate_helper(
+        return self._aggregate_base(
             table,
             order_by=order_by,
             aggregations=aggregations,

--- a/bigframes/core/compile/compiled.py
+++ b/bigframes/core/compile/compiled.py
@@ -346,7 +346,7 @@ class UnorderedIR(BaseIbisIR):
                 ordering_value_columns=tuple([]),
                 total_ordering_columns=frozenset([]),
             )
-            return UnorderedIR(
+            return OrderedIR(
                 result,
                 columns=[result[col_id] for col_id in [*stats.keys()]],
                 hidden_ordering_columns=[result[ORDER_ID_COLUMN]],

--- a/bigframes/core/compile/compiled.py
+++ b/bigframes/core/compile/compiled.py
@@ -312,7 +312,8 @@ class UnorderedIR(BaseIbisIR):
             aggregations: input_column_id, operation, output_column_id tuples
             by_column_id: column id of the aggregation key, this is preserved through the transform
             dropna: whether null keys should be dropped
-        TODO: test UnorderedIR
+        Returns:
+            UnorderedIR
         """
         table = self._to_ibis_expr()
         bindings = {col: table[col] for col in self.column_ids}

--- a/bigframes/core/compile/compiled.py
+++ b/bigframes/core/compile/compiled.py
@@ -608,10 +608,9 @@ class OrderedIR(BaseIbisIR):
         """
         table = self._to_ibis_expr(ordering_mode="unordered", expose_hidden_cols=True)
         bindings = {col: table[col] for col in self.column_ids}
-        agg_order_by = [table[col] for col in self._hidden_ordering_column_names]
         stats = {
             col_out: agg_compiler.compile_aggregate(
-                aggregate, bindings, agg_order_by=agg_order_by
+                aggregate, bindings, order_by=self._ibis_order
             )
             for aggregate, col_out in aggregations
         }

--- a/bigframes/core/compile/compiler.py
+++ b/bigframes/core/compile/compiler.py
@@ -155,10 +155,14 @@ def compile_rowcount(node: nodes.RowCountNode, ordered: bool = True):
 
 @_compile_node.register
 def compile_aggregate(node: nodes.AggregateNode, ordered: bool = True):
-    result = compile_unordered_ir(node.child).aggregate(
-        node.aggregations, node.by_column_ids, node.dropna
-    )
-    return result if ordered else result.to_unordered()
+    if ordered:
+        return compile_ordered_ir(node.child).aggregate(
+            node.aggregations, node.by_column_ids, node.dropna
+        )
+    else:
+        return compile_unordered_ir(node.child).aggregate(
+            node.aggregations, node.by_column_ids, node.dropna
+        )
 
 
 @_compile_node.register
@@ -180,10 +184,10 @@ def compile_reproject(node: nodes.ReprojectOpNode, ordered: bool = True):
 
 
 @_compile_node.register
-def compiler_explode(node: nodes.ExplodeNode, ordered: bool = True):
+def compile_explode(node: nodes.ExplodeNode, ordered: bool = True):
     return compile_node(node.child, ordered).explode(node.column_ids)
 
 
 @_compile_node.register
-def compiler_random_sample(node: nodes.RandomSampleNode, ordered: bool = True):
+def compile_random_sample(node: nodes.RandomSampleNode, ordered: bool = True):
     return compile_node(node.child, ordered)._uniform_sampling(node.fraction)

--- a/bigframes/core/compile/compiler.py
+++ b/bigframes/core/compile/compiler.py
@@ -155,10 +155,10 @@ def compile_rowcount(node: nodes.RowCountNode, ordered: bool = True):
 
 @_compile_node.register
 def compile_aggregate(node: nodes.AggregateNode, ordered: bool = True):
-    has_orderred_aggregation_ops = any(
+    has_ordered_aggregation_ops = any(
         aggregate.op.can_order_by for aggregate, _ in node.aggregations
     )
-    if ordered and has_orderred_aggregation_ops:
+    if ordered and has_ordered_aggregation_ops:
         return compile_ordered_ir(node.child).aggregate(
             node.aggregations, node.by_column_ids, node.dropna
         )

--- a/bigframes/core/compile/compiler.py
+++ b/bigframes/core/compile/compiler.py
@@ -155,14 +155,18 @@ def compile_rowcount(node: nodes.RowCountNode, ordered: bool = True):
 
 @_compile_node.register
 def compile_aggregate(node: nodes.AggregateNode, ordered: bool = True):
-    if ordered:
+    has_orderred_aggregation_ops = any(
+        aggregate.op.can_order_by for aggregate, _ in node.aggregations
+    )
+    if ordered and has_orderred_aggregation_ops:
         return compile_ordered_ir(node.child).aggregate(
             node.aggregations, node.by_column_ids, node.dropna
         )
     else:
-        return compile_unordered_ir(node.child).aggregate(
+        result = compile_unordered_ir(node.child).aggregate(
             node.aggregations, node.by_column_ids, node.dropna
-        ).to_unordered()
+        )
+        return result if ordered else result.to_unordered()
 
 
 @_compile_node.register

--- a/bigframes/core/compile/compiler.py
+++ b/bigframes/core/compile/compiler.py
@@ -162,7 +162,7 @@ def compile_aggregate(node: nodes.AggregateNode, ordered: bool = True):
     else:
         return compile_unordered_ir(node.child).aggregate(
             node.aggregations, node.by_column_ids, node.dropna
-        )
+        ).to_unordered()
 
 
 @_compile_node.register

--- a/bigframes/operations/aggregations.py
+++ b/bigframes/operations/aggregations.py
@@ -38,6 +38,10 @@ class WindowOp:
         """Whether the operator needs total row ordering. (eg. lead, lag, array_agg)"""
         return False
 
+    @property
+    def can_order_by(self):
+        return False
+
     @abc.abstractmethod
     def output_type(self, *input_types: dtypes.ExpressionType) -> dtypes.ExpressionType:
         ...
@@ -51,10 +55,6 @@ class UnaryWindowOp(WindowOp):
 
     def output_type(self, *input_types: dtypes.ExpressionType) -> dtypes.ExpressionType:
         return input_types[0]
-
-    @property
-    def can_order_by(self):
-        return False
 
 
 @dataclasses.dataclass(frozen=True)

--- a/bigframes/operations/aggregations.py
+++ b/bigframes/operations/aggregations.py
@@ -52,6 +52,10 @@ class UnaryWindowOp(WindowOp):
     def output_type(self, *input_types: dtypes.ExpressionType) -> dtypes.ExpressionType:
         return input_types[0]
 
+    @property
+    def can_order_by(self):
+        return False
+
 
 @dataclasses.dataclass(frozen=True)
 class AggregateOp(WindowOp):
@@ -225,6 +229,10 @@ class CountOp(UnaryAggregateOp):
 @dataclasses.dataclass(frozen=True)
 class ArrayAggOp(UnaryAggregateOp):
     name: ClassVar[str] = "arrayagg"
+
+    @property
+    def can_order_by(self):
+        return True
 
     @property
     def skips_nulls(self):

--- a/bigframes/operations/aggregations.py
+++ b/bigframes/operations/aggregations.py
@@ -115,7 +115,7 @@ class QuantileOp(UnaryAggregateOp):
 
     @property
     def name(self):
-        return f"{int(self.q*100)}%"
+        return f"{int(self.q * 100)}%"
 
     def output_type(self, *input_types: dtypes.ExpressionType) -> dtypes.ExpressionType:
         return signatures.UNARY_REAL_NUMERIC.output_type(input_types[0])
@@ -127,7 +127,7 @@ class ApproxQuartilesOp(UnaryAggregateOp):
 
     @property
     def name(self):
-        return f"{self.quartile*25}%"
+        return f"{self.quartile * 25}%"
 
     def output_type(self, *input_types: dtypes.ExpressionType) -> dtypes.ExpressionType:
         if not dtypes.is_orderable(input_types[0]):
@@ -220,6 +220,20 @@ class CountOp(UnaryAggregateOp):
         return signatures.FixedOutputType(
             lambda x: True, dtypes.INT_DTYPE, ""
         ).output_type(input_types[0])
+
+
+@dataclasses.dataclass(frozen=True)
+class ArrayAggOp(UnaryAggregateOp):
+    name: ClassVar[str] = "arrayagg"
+
+    @property
+    def skips_nulls(self):
+        return True
+
+    def output_type(self, *input_types: dtypes.ExpressionType) -> dtypes.ExpressionType:
+        return pd.ArrowDtype(
+            pa.list_(dtypes.bigframes_dtype_to_arrow_dtype(input_types[0]))
+        )
 
 
 @dataclasses.dataclass(frozen=True)

--- a/tests/system/small/bigquery/test_array.py
+++ b/tests/system/small/bigquery/test_array.py
@@ -14,6 +14,7 @@
 
 import numpy as np
 import pandas as pd
+import pytest
 
 import bigframes.bigquery as bbq
 import bigframes.pandas as bpd
@@ -23,10 +24,76 @@ def test_array_length():
     series = bpd.Series([["A", "AA", "AAA"], ["BB", "B"], np.nan, [], ["C"]])
     # TODO(b/336880368): Allow for NULL values to be input for ARRAY columns.
     # Once we actually store NULL values, this will be NULL where the input is NULL.
-    expected = pd.Series([3, 2, 0, 0, 1])
+    expected = bpd.Series([3, 2, 0, 0, 1])
     pd.testing.assert_series_equal(
         bbq.array_length(series).to_pandas(),
-        expected,
-        check_dtype=False,
-        check_index_type=False,
+        expected.to_pandas(),
+    )
+
+
+@pytest.mark.parametrize(
+    ("input_data", "output_data"),
+    [
+        pytest.param([1, 2, 3, 4, 5], [[1, 2], [3, 4], [5]], id="ints"),
+        pytest.param(
+            ["e", "d", "c", "b", "a"],
+            [["e", "d"], ["c", "b"], ["a"]],
+            id="reverse_strings",
+        ),
+        pytest.param(
+            [1.0, 2.0, np.nan, np.nan, np.nan], [[1.0, 2.0], [], []], id="nans"
+        ),
+        pytest.param(
+            [{"A": {"x": 1.0}}, {"A": {"z": 4.0}}, {}, {"B": "b"}, np.nan],
+            [[{"A": {"x": 1.0}}, {"A": {"z": 4.0}}], [{}, {"B": "b"}], []],
+            id="structs",
+        ),
+    ],
+)
+def test_array_agg_w_series(input_data, output_data):
+    input_index = ["a", "a", "b", "b", "c"]
+    series = bpd.Series(input_data, index=input_index)
+    result = bbq.array_agg(series.groupby(level=0))
+
+    expected = bpd.Series(output_data, index=["a", "b", "c"])
+    pd.testing.assert_series_equal(
+        result.to_pandas(),
+        expected.to_pandas(),
+    )
+
+
+def test_array_agg_w_dataframe():
+    data = {
+        "a": [1, 1, 2, 1],
+        "b": [2, None, 1, 2],
+        "c": [3, 4, 3, 2],
+    }
+    df = bpd.DataFrame(data)
+    result = bbq.array_agg(df.groupby(by=["b"]))
+
+    expected_data = {
+        "b": [1.0, 2.0],
+        "a": [[2], [1, 1]],
+        "c": [[3], [3, 2]],
+    }
+    expected = bpd.DataFrame(expected_data).set_index("b")
+
+    pd.testing.assert_frame_equal(
+        result.to_pandas(),
+        expected.to_pandas(),
+    )
+
+def assert_array_agg_matches_after_explode():
+    data = {
+        "index": np.arange(10),
+        "a": [np.random.randint(0, 10, 10) for _ in range(10)],
+        "b": [np.random.randint(0, 10, 10) for _ in range(10)],
+    }
+    df = bpd.DataFrame(data).set_index("index")
+    result = bbq.array_agg(df.explode(["a", "b"]).groupby(level=0))
+    result.index.name = "index"
+
+    pd.testing.assert_frame_equal(
+        result.to_pandas(),
+        df.to_pandas(),
     )

--- a/tests/system/small/bigquery/test_array.py
+++ b/tests/system/small/bigquery/test_array.py
@@ -50,7 +50,7 @@ def test_array_length():
         ),
     ],
 )
-def test_array_agg_w_series(input_data, output_data):
+def test_array_agg_w_series_groupby(input_data, output_data):
     input_index = ["a", "a", "b", "b", "c"]
     series = bpd.Series(input_data, index=input_index)
     result = bbq.array_agg(series.groupby(level=0))
@@ -62,7 +62,7 @@ def test_array_agg_w_series(input_data, output_data):
     )
 
 
-def test_array_agg_w_dataframe():
+def test_array_agg_w_dataframe_groupby():
     data = {
         "a": [1, 1, 2, 1],
         "b": [2, None, 1, 2],
@@ -82,6 +82,12 @@ def test_array_agg_w_dataframe():
         result.to_pandas(),
         expected.to_pandas(),
     )
+
+
+def test_array_agg_w_series():
+    series = bpd.Series([1, 2, 3, 4, 5], index=["a", "a", "b", "b", "c"])
+    with pytest.raises(ValueError):
+        bbq.array_agg(series)
 
 
 @pytest.mark.parametrize(

--- a/tests/system/small/bigquery/test_array.py
+++ b/tests/system/small/bigquery/test_array.py
@@ -57,7 +57,7 @@ def test_array_agg_w_series_groupby(input_data, output_data):
 
     expected = bpd.Series(output_data, index=["a", "b", "c"])
     pd.testing.assert_series_equal(
-        result.to_pandas(),
+        result.to_pandas(),  # type: ignore
         expected.to_pandas(),
     )
 
@@ -79,15 +79,17 @@ def test_array_agg_w_dataframe_groupby():
     expected = bpd.DataFrame(expected_data).set_index("b")
 
     pd.testing.assert_frame_equal(
-        result.to_pandas(),
+        result.to_pandas(),  # type: ignore
         expected.to_pandas(),
     )
 
 
 def test_array_agg_w_series():
     series = bpd.Series([1, 2, 3, 4, 5], index=["a", "a", "b", "b", "c"])
+    # Mypy error expected: array_agg currently incompatible with Series.
+    # Test for coverage.
     with pytest.raises(ValueError):
-        bbq.array_agg(series)
+        bbq.array_agg(series)  # type: ignore
 
 
 @pytest.mark.parametrize(
@@ -118,7 +120,7 @@ def test_array_agg_reserve_order(ascending, expected_b, expected_c):
     expected = bpd.DataFrame(expected_data).set_index("a")
 
     pd.testing.assert_frame_equal(
-        result.to_pandas(),
+        result.to_pandas(),  # type: ignore
         expected.to_pandas(),
     )
 
@@ -134,6 +136,6 @@ def test_array_agg_matches_after_explode():
     result.index.name = "index"
 
     pd.testing.assert_frame_equal(
-        result.to_pandas(),
+        result.to_pandas(),  # type: ignore
         df.to_pandas(),
     )

--- a/tests/system/small/bigquery/test_array.py
+++ b/tests/system/small/bigquery/test_array.py
@@ -83,6 +83,40 @@ def test_array_agg_w_dataframe():
         expected.to_pandas(),
     )
 
+
+@pytest.mark.parametrize(
+    ("ascending", "expected_b", "expected_c"),
+    [
+        pytest.param(
+            True, [["a", "b"], ["e", "d", "c"]], [[4, 5], [1, 2, 3]], id="asc"
+        ),
+        pytest.param(
+            False, [["b", "a"], ["c", "d", "e"]], [[5, 4], [3, 2, 1]], id="des"
+        ),
+    ],
+)
+def test_array_agg_reserve_order(ascending, expected_b, expected_c):
+    data = {
+        "a": [1, 1, 2, 2, 2],
+        "b": ["a", "b", "c", "d", "e"],
+        "c": [4, 5, 3, 2, 1],
+    }
+    df = bpd.DataFrame(data)
+
+    result = bbq.array_agg(df.sort_values("c", ascending=ascending).groupby(by=["a"]))
+    expected_data = {
+        "a": [1, 2],
+        "b": expected_b,
+        "c": expected_c,
+    }
+    expected = bpd.DataFrame(expected_data).set_index("a")
+
+    pd.testing.assert_frame_equal(
+        result.to_pandas(),
+        expected.to_pandas(),
+    )
+
+
 def assert_array_agg_matches_after_explode():
     data = {
         "index": np.arange(10),

--- a/tests/system/small/bigquery/test_array.py
+++ b/tests/system/small/bigquery/test_array.py
@@ -123,7 +123,7 @@ def test_array_agg_reserve_order(ascending, expected_b, expected_c):
     )
 
 
-def assert_array_agg_matches_after_explode():
+def test_array_agg_matches_after_explode():
     data = {
         "index": np.arange(10),
         "a": [np.random.randint(0, 10, 10) for _ in range(10)],

--- a/third_party/bigframes_vendored/ibis/backends/bigquery/registry.py
+++ b/third_party/bigframes_vendored/ibis/backends/bigquery/registry.py
@@ -44,6 +44,10 @@ def _quantile(translator, op: ibis_reductions.Quantile):
 
 
 def _array_aggregate(translator, op: vendored_ibis_ops.ArrayAggregate):
+    """This method provides the same functionality as the collect() method in Ibis, with
+    the added capability of ordering the results using order_by.
+    https://github.com/ibis-project/ibis/issues/9170
+    """
     arg = translator.translate(op.arg)
 
     order_by_sql = ""

--- a/third_party/bigframes_vendored/ibis/backends/bigquery/registry.py
+++ b/third_party/bigframes_vendored/ibis/backends/bigquery/registry.py
@@ -47,11 +47,9 @@ def _array_aggregate(translator, op: vendored_ibis_ops.ArrayAggregate):
     arg = translator.translate(op.arg)
 
     order_by_sql = ""
-    if len(op.order_by_columns) > 0:
-        order_by_columns = ", ".join(
-            [translator.translate(column) for column in op.order_by_columns]
-        )
-        order_by_sql = f"ORDER BY {order_by_columns}"
+    if len(op.order_by) > 0:
+        order_by = ", ".join([translator.translate(column) for column in op.order_by])
+        order_by_sql = f"ORDER BY {order_by}"
 
     return f"ARRAY_AGG({arg} IGNORE NULLS {order_by_sql})"
 

--- a/third_party/bigframes_vendored/ibis/backends/bigquery/registry.py
+++ b/third_party/bigframes_vendored/ibis/backends/bigquery/registry.py
@@ -43,6 +43,19 @@ def _quantile(translator, op: ibis_reductions.Quantile):
     return f"PERCENTILE_CONT({arg}, {quantile})"
 
 
+def _array_aggregate(translator, op: vendored_ibis_ops.ArrayAggregate):
+    arg = translator.translate(op.arg)
+
+    order_by_sql = ""
+    if len(op.order_by_columns) > 0:
+        order_by_columns = ", ".join(
+            [translator.translate(column) for column in op.order_by_columns]
+        )
+        order_by_sql = f"ORDER BY {order_by_columns}"
+
+    return f"ARRAY_AGG({arg} IGNORE NULLS {order_by_sql})"
+
+
 patched_ops = {
     vendored_ibis_ops.ApproximateMultiQuantile: _approx_quantiles,  # type:ignore
     vendored_ibis_ops.FirstNonNullValue: _first_non_null_value,  # type:ignore
@@ -51,6 +64,7 @@ patched_ops = {
     vendored_ibis_ops.GenerateArray: _generate_array,  # type:ignore
     vendored_ibis_ops.SafeCastToDatetime: _safe_cast_to_datetime,  # type:ignore
     ibis_reductions.Quantile: _quantile,  # type:ignore
+    vendored_ibis_ops.ArrayAggregate: _array_aggregate,  # type:ignore
 }
 
 OPERATION_REGISTRY.update(patched_ops)

--- a/third_party/bigframes_vendored/ibis/expr/operations/__init__.py
+++ b/third_party/bigframes_vendored/ibis/expr/operations/__init__.py
@@ -2,6 +2,6 @@
 from __future__ import annotations
 
 from bigframes_vendored.ibis.expr.operations.analytic import *  # noqa: F401 F403
-from bigframes_vendored.ibis.expr.operations.generic import *  # noqa: F401 F403
+from bigframes_vendored.ibis.expr.operations.arrays import *  # noqa: F401 F403
 from bigframes_vendored.ibis.expr.operations.json import *  # noqa: F401 F403
 from bigframes_vendored.ibis.expr.operations.reductions import *  # noqa: F401 F403

--- a/third_party/bigframes_vendored/ibis/expr/operations/arrays.py
+++ b/third_party/bigframes_vendored/ibis/expr/operations/arrays.py
@@ -1,4 +1,4 @@
-# Contains code from https://github.com/ibis-project/ibis/blob/master/ibis/expr/operations/generic.py
+# Contains code from https://github.com/ibis-project/ibis/blob/master/ibis/expr/operations/arrays.py
 from __future__ import annotations
 
 import ibis.expr.datatypes as dt
@@ -6,6 +6,11 @@ from ibis.expr.operations.core import Unary
 
 
 class GenerateArray(Unary):
+    """
+    Generates an array of values, similar to ibis.range(), but with simpler and
+    more efficient SQL generation.
+    """
+
     dtype = dt.Array(dt.int64)
 
 

--- a/third_party/bigframes_vendored/ibis/expr/operations/reductions.py
+++ b/third_party/bigframes_vendored/ibis/expr/operations/reductions.py
@@ -27,7 +27,7 @@ class ArrayAggregate(Filterable, Reduction):
     """
 
     arg: ibis_ops_core.Column
-    order_by_columns: VarTuple[ibis_ops_core.Value] = ()
+    order_by: VarTuple[ibis_ops_core.Value] = ()
 
     @ibis_annotations.attribute
     def dtype(self):

--- a/third_party/bigframes_vendored/ibis/expr/operations/reductions.py
+++ b/third_party/bigframes_vendored/ibis/expr/operations/reductions.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import ibis.common.annotations as ibis_annotations
+from ibis.common.typing import VarTuple
 import ibis.expr.datatypes as dt
 import ibis.expr.operations.core as ibis_ops_core
 from ibis.expr.operations.reductions import Filterable, Reduction
@@ -18,6 +20,18 @@ class ApproximateMultiQuantile(Filterable, Reduction):
     dtype = dt.Array(dt.float64)
 
 
-__all__ = [
-    "ApproximateMultiQuantile",
-]
+class ArrayAggregate(Filterable, Reduction):
+    """
+    Collects the elements of this expression into an ordered array. Similar to
+    the ibis `ArrayCollect`, but adds `order_by_*` and `distinct_only` parameters.
+    """
+
+    arg: ibis_ops_core.Column
+    order_by_columns: VarTuple[ibis_ops_core.Value] = ()
+
+    @ibis_annotations.attribute
+    def dtype(self):
+        return dt.Array(self.arg.dtype)
+
+
+__all__ = ["ApproximateMultiQuantile", "ArrayAggregate"]


### PR DESCRIPTION
This change introduces the `bigframes.bigquery.array_agg` method for `SeriesGroupBy` and `DataFrameGroupby`. By default, aggregated arrays are ordered by the underlying sorting columns. Additionally, `array_agg` is the inverse operation of `(Series|Dataframe).explode()`.

Fixes internal bug: 338232748🦕
