### PR TITLE
fix: remove a usage of the `resource` package when not available, such as on Windows

### DIFF
--- a/bigframes/pandas/__init__.py
+++ b/bigframes/pandas/__init__.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from collections import namedtuple
 from datetime import datetime
 import inspect
-import resource
 import sys
 import typing
 from typing import (
@@ -69,6 +68,13 @@ import bigframes.series
 import bigframes.session
 import bigframes.session._io.bigquery
 import bigframes.session.clients
+
+try:
+    import resource
+except ImportError:
+    # resource is only available on Unix-like systems.
+    # https://docs.python.org/3/library/resource.html
+    resource = None  # type: ignore
 
 
 # Include method definition so that the method appears in our docs for
@@ -808,12 +814,13 @@ reset_session = global_session.close_session
 # https://github.com/python/cpython/issues/112282
 sys.setrecursionlimit(max(10000000, sys.getrecursionlimit()))
 
-soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_STACK)
-if soft_limit < hard_limit or hard_limit == resource.RLIM_INFINITY:
-    try:
-        resource.setrlimit(resource.RLIMIT_STACK, (hard_limit, hard_limit))
-    except Exception:
-        pass
+if resource is not None:
+    soft_limit, hard_limit = resource.getrlimit(resource.RLIMIT_STACK)
+    if soft_limit < hard_limit or hard_limit == resource.RLIM_INFINITY:
+        try:
+            resource.setrlimit(resource.RLIMIT_STACK, (hard_limit, hard_limit))
+        except Exception:
+            pass
 
 # Use __all__ to let type checkers know what is part of the public API.
 __all___ = [


### PR DESCRIPTION
Towards internal issue 339769193.

Note: I'm still working on getting a Windows Python dev environment setup, but this should address at least one known problem. I aim to follow-up with automated tests on Windows, too.

🦕
