### PR TITLE
fix: `read_gbq_table` respects primary keys even when `filters` are set

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,8 @@ repos:
     hooks:
     - id: flake8
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.1.1
+    rev: v1.10.0
     hooks:
     -   id: mypy
         additional_dependencies: [types-requests, types-tabulate, pandas-stubs]
+        args: ["--check-untyped-defs", "--explicit-package-bases", '--exclude="^third_party"', "--ignore-missing-imports"]

--- a/bigframes/core/blocks.py
+++ b/bigframes/core/blocks.py
@@ -122,10 +122,10 @@ class Block:
 
         # If no index columns are set, create one.
         #
-        # Note: get_index_cols_and_uniqueness in
+        # Note: get_index_cols in
         # bigframes/session/_io/bigquery/read_gbq_table.py depends on this
         # being as sequential integer index column. If this default behavior
-        # ever changes, please also update get_index_cols_and_uniqueness so
+        # ever changes, please also update get_index_cols so
         # that users who explicitly request a sequential integer index can
         # still get one.
         if len(index_columns) == 0:

--- a/bigframes/pandas/__init__.py
+++ b/bigframes/pandas/__init__.py
@@ -543,6 +543,7 @@ def read_gbq_query(
     max_results: Optional[int] = None,
     use_cache: Optional[bool] = None,
     col_order: Iterable[str] = (),
+    filters: vendored_pandas_gbq.FiltersType = (),
 ) -> bigframes.dataframe.DataFrame:
     _set_default_session_location_if_possible(query)
     return global_session.with_default_session(
@@ -554,6 +555,7 @@ def read_gbq_query(
         max_results=max_results,
         use_cache=use_cache,
         col_order=col_order,
+        filters=filters,
     )
 
 

--- a/bigframes/session/_io/bigquery/__init__.py
+++ b/bigframes/session/_io/bigquery/__init__.py
@@ -336,6 +336,8 @@ def to_query(
     index_cols: Iterable[str],
     columns: Iterable[str],
     filters: third_party_pandas_gbq.FiltersType,
+    max_results: Optional[int],
+    time_travel_timestamp: Optional[datetime.datetime],
 ) -> str:
     """Compile query_or_table with conditions(filters, wildcards) to query."""
     filters = list(filters)
@@ -352,6 +354,14 @@ def to_query(
         select_clause = "SELECT " + ", ".join(f"`{column}`" for column in all_columns)
     else:
         select_clause = "SELECT *"
+
+    time_travel_clause = ""
+    if time_travel_timestamp is not None:
+        time_travel_clause = f" FOR SYSTEM_TIME AS OF TIMESTAMP({repr(time_travel_timestamp.isoformat())})"
+
+    limit_clause = ""
+    if max_results is not None:
+        limit_clause = f" LIMIT {max_results}"
 
     where_clause = ""
     if filters:
@@ -382,7 +392,7 @@ def to_query(
             for filter_item in group:
                 if not isinstance(filter_item, tuple) or (len(filter_item) != 3):
                     raise ValueError(
-                        f"Filter condition should be a tuple of length 3, {filter_item} is not valid."
+                        f"Elements of filters must be tuples of length 3, but got {repr(filter_item)}.",
                     )
 
                 column, operator, value = filter_item
@@ -409,5 +419,9 @@ def to_query(
         if or_expressions:
             where_clause = " WHERE " + " OR ".join(or_expressions)
 
-    full_query = f"{select_clause} FROM {sub_query} AS sub{where_clause}"
+    full_query = (
+        f"{select_clause} "
+        "FROM "
+        f"{sub_query}{time_travel_clause}{where_clause}{limit_clause}"
+    )
     return full_query

--- a/bigframes/session/_io/bigquery/read_gbq_table.py
+++ b/bigframes/session/_io/bigquery/read_gbq_table.py
@@ -20,12 +20,12 @@ from __future__ import annotations
 
 import datetime
 import itertools
-import textwrap
 import typing
 from typing import Dict, Iterable, List, Optional, Tuple
 import warnings
 
 import bigframes_vendored.ibis.expr.operations as vendored_ibis_ops
+import bigframes_vendored.pandas.io.gbq as third_party_pandas_gbq
 import google.api_core.exceptions
 import google.cloud.bigquery as bigquery
 import ibis
@@ -41,7 +41,7 @@ import bigframes.core.compile
 import bigframes.core.guid as guid
 import bigframes.core.ordering as order
 import bigframes.dtypes
-import bigframes.session._io.bigquery.read_gbq_table
+import bigframes.session._io.bigquery
 import bigframes.session.clients
 import bigframes.version
 
@@ -125,32 +125,32 @@ def get_table_metadata(
     return cached_table
 
 
-def _create_time_travel_sql(
-    table_ref: bigquery.TableReference, time_travel_timestamp: datetime.datetime
-) -> str:
-    """Query a table via 'time travel' for consistent reads."""
-    # If we have an anonymous query results table, it can't be modified and
-    # there isn't any BigQuery time travel.
-    if table_ref.dataset_id.startswith("_"):
-        return f"SELECT * FROM `{table_ref.project}`.`{table_ref.dataset_id}`.`{table_ref.table_id}`"
-
-    return textwrap.dedent(
-        f"""
-        SELECT *
-        FROM `{table_ref.project}`.`{table_ref.dataset_id}`.`{table_ref.table_id}`
-        FOR SYSTEM_TIME AS OF TIMESTAMP({repr(time_travel_timestamp.isoformat())})
-        """
-    )
-
-
 def get_ibis_time_travel_table(
     ibis_client: ibis.BaseBackend,
     table_ref: bigquery.TableReference,
-    time_travel_timestamp: datetime.datetime,
+    index_cols: Iterable[str],
+    columns: Iterable[str],
+    filters: third_party_pandas_gbq.FiltersType,
+    time_travel_timestamp: Optional[datetime.datetime],
 ) -> ibis_types.Table:
+    # If we have an anonymous query results table, it can't be modified and
+    # there isn't any BigQuery time travel.
+    if table_ref.dataset_id.startswith("_"):
+        time_travel_timestamp = None
+
     try:
         return ibis_client.sql(
-            _create_time_travel_sql(table_ref, time_travel_timestamp)
+            bigframes.session._io.bigquery.to_query(
+                f"{table_ref.project}.{table_ref.dataset_id}.{table_ref.table_id}",
+                index_cols=index_cols,
+                columns=columns,
+                filters=filters,
+                time_travel_timestamp=time_travel_timestamp,
+                # If we've made it this far, we know we don't have any
+                # max_results to worry about, because in that case we will
+                # have executed a query with a LIMI clause.
+                max_results=None,
+            )
         )
     except google.api_core.exceptions.Forbidden as ex:
         # Ibis does a dry run to get the types of the columns from the SQL.
@@ -159,16 +159,25 @@ def get_ibis_time_travel_table(
         raise
 
 
-def _check_index_uniqueness(
+def are_index_cols_unique(
     bqclient: bigquery.Client,
     ibis_client: ibis.BaseBackend,
-    table: ibis_types.Table,
+    table: bigquery.table.Table,
+    table_expression: ibis_types.Table,
     index_cols: List[str],
     api_name: str,
 ) -> bool:
-    distinct_table = table.select(*index_cols).distinct()
+    # If index_cols contain the primary_keys, the query engine assumes they are
+    # provide a unique index.
+    primary_keys = frozenset(_get_primary_keys(table))
+    if primary_keys <= frozenset(index_cols):
+        return True
+
+    # TODO(b/337925142): Avoid a "SELECT *" subquery here by ensuring
+    # table_expression only selects just index_cols.
+    distinct_table = table_expression.select(*index_cols).distinct()
     is_unique_sql = f"""WITH full_table AS (
-        {ibis_client.compile(table)}
+        {ibis_client.compile(table_expression)}
     ),
     distinct_table AS (
         {ibis_client.compile(distinct_table)}
@@ -228,14 +237,10 @@ def _is_table_clustered_or_partitioned(
     return False
 
 
-def get_index_cols_and_uniqueness(
-    bqclient: bigquery.Client,
-    ibis_client: ibis.BaseBackend,
+def get_index_cols(
     table: bigquery.table.Table,
-    table_expression: ibis_types.Table,
     index_col: Iterable[str] | str | bigframes.enums.DefaultIndexKind,
-    api_name: str,
-) -> Tuple[List[str], bool]:
+) -> List[str]:
     """
     If we can get a total ordering from the table, such as via primary key
     column(s), then return those too so that ordering generation can be
@@ -252,7 +257,7 @@ def get_index_cols_and_uniqueness(
             # Note: This relies on the default behavior of the Block
             # constructor to create a default sequential index. If that ever
             # changes, this logic will need to be revisited.
-            return [], False
+            return []
         else:
             # Note: It's actually quite difficult to mock this out to unit
             # test, as it's not possible to subclass enums in Python. See:
@@ -289,19 +294,8 @@ def get_index_cols_and_uniqueness(
         # columns are unique, even if the constraint is not enforced. We make
         # the same assumption and use these columns as the total ordering keys.
         index_cols = primary_keys
-        is_index_unique = len(index_cols) != 0
-    else:
-        is_index_unique = _check_index_uniqueness(
-            bqclient=bqclient,
-            ibis_client=ibis_client,
-            # TODO(b/337925142): Avoid a "SELECT *" subquery here by using
-            # _create_time_travel_sql with just index_cols.
-            table=table_expression,
-            index_cols=index_cols,
-            api_name=api_name,
-        )
 
-    return index_cols, is_index_unique
+    return index_cols
 
 
 def get_time_travel_datetime_and_table_metadata(

--- a/bigframes/session/_io/bigquery/read_gbq_table.py
+++ b/bigframes/session/_io/bigquery/read_gbq_table.py
@@ -164,7 +164,6 @@ def are_index_cols_unique(
     bqclient: bigquery.Client,
     ibis_client: ibis.BaseBackend,
     table: bigquery.table.Table,
-    table_expression: ibis_types.Table,
     index_cols: List[str],
     api_name: str,
 ) -> bool:

--- a/tests/unit/session/test_io_bigquery.py
+++ b/tests/unit/session/test_io_bigquery.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+import re
 from typing import Iterable
 
 import google.cloud.bigquery as bigquery
@@ -205,19 +206,16 @@ def test_bq_schema_to_sql(schema: Iterable[bigquery.SchemaField], expected: str)
 
 
 @pytest.mark.parametrize(
-    ("query_or_table", "index_cols", "columns", "filters", "expected_output"),
+    (
+        "query_or_table",
+        "index_cols",
+        "columns",
+        "filters",
+        "max_results",
+        "time_travel_timestamp",
+        "expected_output",
+    ),
     [
-        pytest.param(
-            "test_table",
-            [],
-            [],
-            ["date_col", ">", "2022-10-20"],
-            None,
-            marks=pytest.mark.xfail(
-                raises=ValueError,
-            ),
-            id="raise_error",
-        ),
         pytest.param(
             "test_table",
             ["row_index"],
@@ -226,30 +224,42 @@ def test_bq_schema_to_sql(schema: Iterable[bigquery.SchemaField], expected: str)
                 (("rowindex", "not in", [0, 6]),),
                 (("string_col", "in", ["Hello, World!", "こんにちは"]),),
             ],
+            123,  # max_results,
+            datetime.datetime(2024, 5, 14, 12, 42, 36, 125125),
             (
-                "SELECT `row_index`, `string_col` FROM `test_table` AS sub WHERE "
-                "`rowindex` NOT IN (0, 6) OR `string_col` IN ('Hello, World!', "
-                "'こんにちは')"
+                "SELECT `row_index`, `string_col` FROM `test_table` "
+                "FOR SYSTEM_TIME AS OF TIMESTAMP('2024-05-14T12:42:36.125125') "
+                "WHERE `rowindex` NOT IN (0, 6) OR `string_col` IN ('Hello, World!', "
+                "'こんにちは') LIMIT 123"
             ),
             id="table-all_params-filter_or_operation",
         ),
         pytest.param(
-            """SELECT
-                rowindex,
-                string_col,
-            FROM `test_table` AS t
-            """,
+            (
+                """SELECT
+                    rowindex,
+                    string_col,
+                FROM `test_table` AS t
+                """
+            ),
             ["rowindex"],
             ["string_col"],
             [
                 ("rowindex", "<", 4),
                 ("string_col", "==", "Hello, World!"),
             ],
-            """SELECT `rowindex`, `string_col` FROM (SELECT
-                rowindex,
-                string_col,
-            FROM `test_table` AS t
-            ) AS sub WHERE `rowindex` < 4 AND `string_col` = 'Hello, World!'""",
+            123,  # max_results,
+            datetime.datetime(2024, 5, 14, 12, 42, 36, 125125),
+            (
+                """SELECT `rowindex`, `string_col` FROM (SELECT
+                    rowindex,
+                    string_col,
+                FROM `test_table` AS t
+                ) """
+                "FOR SYSTEM_TIME AS OF TIMESTAMP('2024-05-14T12:42:36.125125') "
+                "WHERE `rowindex` < 4 AND `string_col` = 'Hello, World!' "
+                "LIMIT 123"
+            ),
             id="subquery-all_params-filter_and_operation",
         ),
         pytest.param(
@@ -257,7 +267,9 @@ def test_bq_schema_to_sql(schema: Iterable[bigquery.SchemaField], expected: str)
             [],
             ["col_a", "col_b"],
             [],
-            "SELECT `col_a`, `col_b` FROM `test_table` AS sub",
+            None,  # max_results
+            None,  # time_travel_timestampe
+            "SELECT `col_a`, `col_b` FROM `test_table`",
             id="table-columns",
         ),
         pytest.param(
@@ -265,7 +277,9 @@ def test_bq_schema_to_sql(schema: Iterable[bigquery.SchemaField], expected: str)
             [],
             [],
             [("date_col", ">", "2022-10-20")],
-            "SELECT * FROM `test_table` AS sub WHERE `date_col` > '2022-10-20'",
+            None,  # max_results
+            None,  # time_travel_timestampe
+            "SELECT * FROM `test_table` WHERE `date_col` > '2022-10-20'",
             id="table-filter",
         ),
         pytest.param(
@@ -273,7 +287,9 @@ def test_bq_schema_to_sql(schema: Iterable[bigquery.SchemaField], expected: str)
             [],
             [],
             [],
-            "SELECT * FROM `test_table*` AS sub",
+            None,  # max_results
+            None,  # time_travel_timestampe
+            "SELECT * FROM `test_table*`",
             id="wildcard-no_params",
         ),
         pytest.param(
@@ -281,30 +297,49 @@ def test_bq_schema_to_sql(schema: Iterable[bigquery.SchemaField], expected: str)
             [],
             [],
             [("_TABLE_SUFFIX", ">", "2022-10-20")],
-            "SELECT * FROM `test_table*` AS sub WHERE `_TABLE_SUFFIX` > '2022-10-20'",
+            None,  # max_results
+            None,  # time_travel_timestampe
+            "SELECT * FROM `test_table*` WHERE `_TABLE_SUFFIX` > '2022-10-20'",
             id="wildcard-filter",
         ),
     ],
 )
-def test_to_query(query_or_table, index_cols, columns, filters, expected_output):
+def test_to_query(
+    query_or_table,
+    index_cols,
+    columns,
+    filters,
+    max_results,
+    time_travel_timestamp,
+    expected_output,
+):
     query = io_bq.to_query(
         query_or_table,
-        index_cols,
-        columns,
-        filters,
+        index_cols=index_cols,
+        columns=columns,
+        filters=filters,
+        max_results=max_results,
+        time_travel_timestamp=time_travel_timestamp,
     )
     assert query == expected_output
 
 
 @pytest.mark.parametrize(
-    ("query_or_table", "filters", "expected_output"),
-    [],
+    ("filters", "expected_message"),
+    (
+        pytest.param(
+            ["date_col", ">", "2022-10-20"],
+            "Elements of filters must be tuples of length 3, but got 'd'",
+        ),
+    ),
 )
-def test_to_query_with_wildcard_table(query_or_table, filters, expected_output):
-    query = io_bq.to_query(
-        query_or_table,
-        (),  # index_cols
-        (),  # columns
-        filters,
-    )
-    assert query == expected_output
+def test_to_query_fails_with_bad_filters(filters, expected_message):
+    with pytest.raises(ValueError, match=re.escape(expected_message)):
+        io_bq.to_query(
+            "test_table",
+            index_cols=(),
+            columns=(),
+            filters=filters,
+            max_results=None,
+            time_travel_timestamp=None,
+        )

--- a/tests/unit/session/test_read_gbq_table.py
+++ b/tests/unit/session/test_read_gbq_table.py
@@ -20,18 +20,28 @@ import google.cloud.bigquery as bigquery
 
 import bigframes.session._io.bigquery.read_gbq_table as bf_read_gbq_table
 
+from .. import resources
 
-def test_create_snapshot_sql_doesnt_timetravel_anonymous_datasets():
+
+def test_get_ibis_time_travel_table_doesnt_timetravel_anonymous_datasets():
+    bqsession = resources.create_bigquery_session()
+
     table_ref = bigquery.TableReference.from_string(
         "my-test-project._e8166e0cdb.anonbb92cd"
     )
 
-    sql = bf_read_gbq_table._create_time_travel_sql(
-        table_ref, datetime.datetime.now(datetime.timezone.utc)
+    table_expression = bf_read_gbq_table.get_ibis_time_travel_table(
+        bqsession.ibis_client,
+        table_ref,
+        index_cols=(),
+        columns=(),
+        filters=(),
+        time_travel_timestamp=datetime.datetime.now(datetime.timezone.utc),
     )
+    sql = table_expression.compile()
 
     # Anonymous query results tables don't support time travel.
     assert "SYSTEM_TIME" not in sql
 
     # Need fully-qualified table name.
-    assert "`my-test-project`.`_e8166e0cdb`.`anonbb92cd`" in sql
+    assert "my-test-project" in sql

--- a/third_party/bigframes_vendored/pandas/io/gbq.py
+++ b/third_party/bigframes_vendored/pandas/io/gbq.py
@@ -96,7 +96,7 @@ class GBQIOMixin:
         Reading data with `columns` and `filters` parameters:
 
             >>> columns = ['pitcherFirstName', 'pitcherLastName', 'year', 'pitchSpeed']
-            >>> filters = [('year', '==', 2016), ('pitcherFirstName', 'in', ['John', 'Doe']), ('pitcherLastName', 'in', ['Gant'])]
+            >>> filters = [('year', '==', 2016), ('pitcherFirstName', 'in', ['John', 'Doe']), ('pitcherLastName', 'in', ['Gant']), ('pitchSpeed', '>', 94)]
             >>> df = bpd.read_gbq(
             ...             "bigquery-public-data.baseball.games_wide",
             ...             columns=columns,
@@ -104,7 +104,7 @@ class GBQIOMixin:
             ...         )
             >>> df.head(1)
               pitcherFirstName pitcherLastName  year  pitchSpeed
-            0             John            Gant  2016          80
+            0             John            Gant  2016          95
             <BLANKLINE>
             [1 rows x 4 columns]
 

--- a/third_party/bigframes_vendored/pandas/io/gbq.py
+++ b/third_party/bigframes_vendored/pandas/io/gbq.py
@@ -103,8 +103,8 @@ class GBQIOMixin:
             ...             filters=filters,
             ...         )
             >>> df.head(1)
-                     pitcherFirstName	pitcherLastName     year	pitchSpeed
-            0	                 John	           Gant	    2016            82
+              pitcherFirstName pitcherLastName  year  pitchSpeed
+            0             John            Gant  2016          80
             <BLANKLINE>
             [1 rows x 4 columns]
 


### PR DESCRIPTION
Closes internal issues 338039517 (primary key inconsistency), 338037499 (LIMIT for max_results), 340540991 (avoid running query immediately if time travel is supported), 337925142 (push down column filters to when we create the time travel subquery).

feat: `read_gbq_query` supports `filters`
perf: use a `LIMIT` clause when `max_results` is set
perf: don't run query immediately from `read_gbq_table` if `filters` is set

🦕
