### PR TITLE
test: disable test_to_pandas_large_table

### DIFF
--- a/tests/system/load/test_large_tables.py
+++ b/tests/system/load/test_large_tables.py
@@ -93,6 +93,7 @@ def test_to_pandas_batches_large_table():
     assert row_count == expected_row_count
 
 
+@pytest.mark.skip(reason="See if it caused kokoro build aborted.")
 def test_to_pandas_large_table():
     df = bpd.read_gbq("load_testing.scalars_10gb")
     # df will be downloaded locally


### PR DESCRIPTION
Try to disable the test to see if it caused kokoro load test aborted failure.
