### PR TITLE
chore: make `cleanup_cloud_functions` test fixture more robust to flakiness

### DIFF
--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -1129,7 +1129,9 @@ def cleanup_cloud_functions(session, cloudfunctions_client, dataset_id_permanent
             # successfully, while the other instance will run into this
             # exception. Ignore this exception.
             pass
-        except google.api_core.exceptions.ResourceExhausted:
+        except Exception:
+            # Don't fail the tests for unknown exceptions.
+            #
             # This can happen if we are hitting GCP limits, e.g.
             # google.api_core.exceptions.ResourceExhausted: 429 Quota exceeded
             # for quota metric 'Per project mutation requests' and limit
@@ -1137,5 +1139,10 @@ def cleanup_cloud_functions(session, cloudfunctions_client, dataset_id_permanent
             # 'cloudfunctions.googleapis.com' for consumer
             # 'project_number:1084210331973'.
             # [reason: "RATE_LIMIT_EXCEEDED" domain: "googleapis.com" ...
+            #
+            # It can also happen occasionally with
+            # google.api_core.exceptions.ServiceUnavailable when there is some
+            # backend flakiness.
+            #
             # Let's stop further clean up and leave it to later.
             break

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -1146,7 +1146,5 @@ def cleanup_cloud_functions(session, cloudfunctions_client, dataset_id_permanent
             # backend flakiness.
             #
             # Let's stop further clean up and leave it to later.
-            warnings.warn(
-                f"Cloud functions cleanup failed: {str(exc)}"
-            )
+            warnings.warn(f"Cloud functions cleanup failed: {str(exc)}")
             break

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -20,6 +20,7 @@ import pathlib
 import textwrap
 import typing
 from typing import Dict, Generator, Optional
+import warnings
 
 import google.api_core.exceptions
 import google.cloud.bigquery as bigquery
@@ -1129,7 +1130,7 @@ def cleanup_cloud_functions(session, cloudfunctions_client, dataset_id_permanent
             # successfully, while the other instance will run into this
             # exception. Ignore this exception.
             pass
-        except Exception:
+        except Exception as exc:
             # Don't fail the tests for unknown exceptions.
             #
             # This can happen if we are hitting GCP limits, e.g.
@@ -1145,4 +1146,7 @@ def cleanup_cloud_functions(session, cloudfunctions_client, dataset_id_permanent
             # backend flakiness.
             #
             # Let's stop further clean up and leave it to later.
+            warnings.warn(
+                f"Cloud functions cleanup failed: {str(exc)}"
+            )
             break


### PR DESCRIPTION
In response to a recent test failure in load test session just because this optional cleanup code failed.

```
________________ ERROR at setup of test_llm_palm_configure_fit _________________
[gw8] linux -- Python 3.12.0 /tmpfs/src/github/python-bigquery-dataframes/.nox/load/bin/python

args = (name: "projects/bigframes-load-testing/locations/us-central1/functions/bigframes-ab103e98fa51cfc67a56d754b7e5068e-8fxaur1s"
,)
kwargs = {'metadata': [('x-goog-request-params', 'name=projects/bigframes-load-testing/locations/us-central1/functions/bigframe...6d754b7e5068e-8fxaur1s'), ('x-goog-api-client', 'bigframes/1.7.0 ibis/8.0.0 gl-python/3.12.0 grpc/1.64.0 gax/2.19.0')]}

    @functools.wraps(callable_)
    def error_remapped_callable(*args, **kwargs):
        try:
>           return callable_(*args, **kwargs)

.nox/load/lib/python3.12/site-packages/google/api_core/grpc_helpers.py:76:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.nox/load/lib/python3.12/site-packages/grpc/_channel.py:1181: in __call__
    return _end_unary_response_blocking(state, call, False, None)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

state = <grpc._channel._RPCState object at 0x150b45fd76b0>
call = <grpc._cython.cygrpc.SegregatedCall object at 0x150b45ffd700>
with_call = False, deadline = None

    def _end_unary_response_blocking(
        state: _RPCState,
        call: cygrpc.SegregatedCall,
        with_call: bool,
        deadline: Optional[float],
    ) -> Union[ResponseType, Tuple[ResponseType, grpc.Call]]:
        if state.code is grpc.StatusCode.OK:
            if with_call:
                rendezvous = _MultiThreadedRendezvous(state, call, None, deadline)
                return state.response, rendezvous
            else:
                return state.response
        else:
>           raise _InactiveRpcError(state)  # pytype: disable=not-instantiable
E           grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
E           	status = StatusCode.UNAVAILABLE
E           	details = "502:Bad Gateway"
E           	debug_error_string = "UNKNOWN:Error received from peer  {created_time:"2024-05-23T01:46:52.145312629+00:00", grpc_status:14, grpc_message:"502:Bad Gateway"}"
E           >

.nox/load/lib/python3.12/site-packages/grpc/_channel.py:1006: _InactiveRpcError

The above exception was the direct cause of the following exception:

session = <bigframes.session.Session object at 0x150b45fb3dd0>
cloudfunctions_client = <google.cloud.functions_v2.services.function_service.client.FunctionServiceClient object at 0x150b45fd7500>
dataset_id_permanent = 'bigframes-load-testing.bigframes_testing'

    @pytest.fixture(scope="session", autouse=True)
    def cleanup_cloud_functions(session, cloudfunctions_client, dataset_id_permanent):
        """Clean up stale cloud functions."""
        permanent_endpoints = tests.system.utils.get_remote_function_endpoints(
            session.bqclient, dataset_id_permanent
        )
        delete_count = 0
        for cloud_function in tests.system.utils.get_cloud_functions(
            cloudfunctions_client,
            session.bqclient.project,
            session.bqclient.location,
            name_prefix="bigframes-",
        ):
            # Ignore bigframes cloud functions referred by the remote functions in
            # the permanent dataset
            if cloud_function.service_config.uri in permanent_endpoints:
                continue

            # Ignore the functions less than one day old
            age = datetime.now() - datetime.fromtimestamp(
                cloud_function.update_time.timestamp()
            )
            if age.days <= 0:
                continue

            # Go ahead and delete
            try:
>               tests.system.utils.delete_cloud_function(
                    cloudfunctions_client, cloud_function.name
                )

tests/system/conftest.py:1119:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/system/utils.py:349: in delete_cloud_function
    operation = functions_client.delete_function(request=request)
.nox/load/lib/python3.12/site-packages/google/cloud/functions_v2/services/function_service/client.py:1499: in delete_function
    response = rpc(
.nox/load/lib/python3.12/site-packages/google/api_core/gapic_v1/method.py:131: in __call__
    return wrapped_func(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

args = (name: "projects/bigframes-load-testing/locations/us-central1/functions/bigframes-ab103e98fa51cfc67a56d754b7e5068e-8fxaur1s"
,)
kwargs = {'metadata': [('x-goog-request-params', 'name=projects/bigframes-load-testing/locations/us-central1/functions/bigframe...6d754b7e5068e-8fxaur1s'), ('x-goog-api-client', 'bigframes/1.7.0 ibis/8.0.0 gl-python/3.12.0 grpc/1.64.0 gax/2.19.0')]}

    @functools.wraps(callable_)
    def error_remapped_callable(*args, **kwargs):
        try:
            return callable_(*args, **kwargs)
        except grpc.RpcError as exc:
>           raise exceptions.from_grpc_error(exc) from exc
E           google.api_core.exceptions.ServiceUnavailable: 503 502:Bad Gateway

.nox/load/lib/python3.12/site-packages/google/api_core/grpc_helpers.py:78: ServiceUnavailable
____________ ERROR at setup of test_read_gbq_sql_large_results[1gb] ____________
[gw1] linux -- Python 3.12.0 /tmpfs/src/github/python-bigquery-dataframes/.nox/load/bin/python

args = (name: "projects/bigframes-load-testing/locations/us-central1/functions/bigframes-ab103e98fa51cfc67a56d754b7e5068e-u8owkeqc"
,)
kwargs = {'metadata': [('x-goog-request-params', 'name=projects/bigframes-load-testing/locations/us-central1/functions/bigframe...6d754b7e5068e-u8owkeqc'), ('x-goog-api-client', 'bigframes/1.7.0 ibis/8.0.0 gl-python/3.12.0 grpc/1.64.0 gax/2.19.0')]}

    @functools.wraps(callable_)
    def error_remapped_callable(*args, **kwargs):
        try:
>           return callable_(*args, **kwargs)

.nox/load/lib/python3.12/site-packages/google/api_core/grpc_helpers.py:76:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
.nox/load/lib/python3.12/site-packages/grpc/_channel.py:1181: in __call__
    return _end_unary_response_blocking(state, call, False, None)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

state = <grpc._channel._RPCState object at 0x14b4a01dac00>
call = <grpc._cython.cygrpc.SegregatedCall object at 0x14b4a0378e00>
with_call = False, deadline = None

    def _end_unary_response_blocking(
        state: _RPCState,
        call: cygrpc.SegregatedCall,
        with_call: bool,
        deadline: Optional[float],
    ) -> Union[ResponseType, Tuple[ResponseType, grpc.Call]]:
        if state.code is grpc.StatusCode.OK:
            if with_call:
                rendezvous = _MultiThreadedRendezvous(state, call, None, deadline)
                return state.response, rendezvous
            else:
                return state.response
        else:
>           raise _InactiveRpcError(state)  # pytype: disable=not-instantiable
E           grpc._channel._InactiveRpcError: <_InactiveRpcError of RPC that terminated with:
E           	status = StatusCode.UNAVAILABLE
E           	details = "502:Bad Gateway"
E           	debug_error_string = "UNKNOWN:Error received from peer  {created_time:"2024-05-23T01:46:52.511901766+00:00", grpc_status:14, grpc_message:"502:Bad Gateway"}"
E           >

.nox/load/lib/python3.12/site-packages/grpc/_channel.py:1006: _InactiveRpcError

The above exception was the direct cause of the following exception:

session = <bigframes.session.Session object at 0x14b4a033e180>
cloudfunctions_client = <google.cloud.functions_v2.services.function_service.client.FunctionServiceClient object at 0x14b4a01d9280>
dataset_id_permanent = 'bigframes-load-testing.bigframes_testing'

    @pytest.fixture(scope="session", autouse=True)
    def cleanup_cloud_functions(session, cloudfunctions_client, dataset_id_permanent):
        """Clean up stale cloud functions."""
        permanent_endpoints = tests.system.utils.get_remote_function_endpoints(
            session.bqclient, dataset_id_permanent
        )
        delete_count = 0
        for cloud_function in tests.system.utils.get_cloud_functions(
            cloudfunctions_client,
            session.bqclient.project,
            session.bqclient.location,
            name_prefix="bigframes-",
        ):
            # Ignore bigframes cloud functions referred by the remote functions in
            # the permanent dataset
            if cloud_function.service_config.uri in permanent_endpoints:
                continue

            # Ignore the functions less than one day old
            age = datetime.now() - datetime.fromtimestamp(
                cloud_function.update_time.timestamp()
            )
            if age.days <= 0:
                continue

            # Go ahead and delete
            try:
>               tests.system.utils.delete_cloud_function(
                    cloudfunctions_client, cloud_function.name
                )

tests/system/conftest.py:1119:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
tests/system/utils.py:349: in delete_cloud_function
    operation = functions_client.delete_function(request=request)
.nox/load/lib/python3.12/site-packages/google/cloud/functions_v2/services/function_service/client.py:1499: in delete_function
    response = rpc(
.nox/load/lib/python3.12/site-packages/google/api_core/gapic_v1/method.py:131: in __call__
    return wrapped_func(*args, **kwargs)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

args = (name: "projects/bigframes-load-testing/locations/us-central1/functions/bigframes-ab103e98fa51cfc67a56d754b7e5068e-u8owkeqc"
,)
kwargs = {'metadata': [('x-goog-request-params', 'name=projects/bigframes-load-testing/locations/us-central1/functions/bigframe...6d754b7e5068e-u8owkeqc'), ('x-goog-api-client', 'bigframes/1.7.0 ibis/8.0.0 gl-python/3.12.0 grpc/1.64.0 gax/2.19.0')]}

    @functools.wraps(callable_)
    def error_remapped_callable(*args, **kwargs):
        try:
            return callable_(*args, **kwargs)
        except grpc.RpcError as exc:
>           raise exceptions.from_grpc_error(exc) from exc
E           google.api_core.exceptions.ServiceUnavailable: 503 502:Bad Gateway

.nox/load/lib/python3.12/site-packages/google/api_core/grpc_helpers.py:78: ServiceUnavailable
```

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
