### PR TITLE
fix: set `@bpd.remote_function`s `input_types` and `output_types` default to `None` to allow omitting them when type annotations are present

### DIFF
--- a/bigframes/constants.py
+++ b/bigframes/constants.py
@@ -12,19 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import datetime
-
 """Constants used across BigQuery DataFrames.
 
 This module should not depend on any others in the package.
 """
 
-FEEDBACK_LINK = (
-    "Share your usecase with the BigQuery DataFrames team at the "
-    "https://bit.ly/bigframes-feedback survey."
-)
+import datetime
 
-ABSTRACT_METHOD_ERROR_MESSAGE = f"Abstract method. You have likely encountered a bug. Please share this stacktrace and how you reached it with the BigQuery DataFrames team. {FEEDBACK_LINK}"
+import bigframes_vendored.constants
+
+FEEDBACK_LINK = bigframes_vendored.constants.FEEDBACK_LINK
+ABSTRACT_METHOD_ERROR_MESSAGE = (
+    bigframes_vendored.constants.ABSTRACT_METHOD_ERROR_MESSAGE
+)
 
 DEFAULT_EXPIRATION = datetime.timedelta(days=7)
 

--- a/bigframes/pandas/__init__.py
+++ b/bigframes/pandas/__init__.py
@@ -652,8 +652,8 @@ read_parquet.__doc__ = inspect.getdoc(bigframes.session.Session.read_parquet)
 
 
 def remote_function(
-    input_types: Union[type, Sequence[type]],
-    output_type: type,
+    input_types: Union[None, type, Sequence[type]] = None,
+    output_type: Optional[type] = None,
     dataset: Optional[str] = None,
     bigquery_connection: Optional[str] = None,
     reuse: bool = True,

--- a/bigframes/session/__init__.py
+++ b/bigframes/session/__init__.py
@@ -1549,8 +1549,8 @@ class Session(
 
     def remote_function(
         self,
-        input_types: Union[type, Sequence[type]],
-        output_type: type,
+        input_types: Union[None, type, Sequence[type]] = None,
+        output_type: Optional[type] = None,
         dataset: Optional[str] = None,
         bigquery_connection: Optional[str] = None,
         reuse: bool = True,

--- a/third_party/bigframes_vendored/constants.py
+++ b/third_party/bigframes_vendored/constants.py
@@ -1,0 +1,29 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Constants used across BigQuery DataFrames and bigframes_vendored.
+
+This module should not depend on any others in the package.
+"""
+
+FEEDBACK_LINK = (
+    "Share your usecase with the BigQuery DataFrames team at the "
+    "https://bit.ly/bigframes-feedback survey."
+)
+
+ABSTRACT_METHOD_ERROR_MESSAGE = (
+    "Abstract method. You have likely encountered a bug. "
+    "Please share this stacktrace and how you reached it with the BigQuery DataFrames team. "
+    f"{FEEDBACK_LINK}"
+)

--- a/third_party/bigframes_vendored/pandas/core/frame.py
+++ b/third_party/bigframes_vendored/pandas/core/frame.py
@@ -13,11 +13,10 @@ from __future__ import annotations
 
 from typing import Hashable, Iterable, Literal, Mapping, Optional, Sequence, Union
 
+from bigframes_vendored import constants
 import bigframes_vendored.pandas.core.generic as generic
 import numpy as np
 import pandas as pd
-
-from bigframes import constants
 
 # -----------------------------------------------------------------------
 # DataFrame class

--- a/third_party/bigframes_vendored/pandas/core/generic.py
+++ b/third_party/bigframes_vendored/pandas/core/generic.py
@@ -3,10 +3,9 @@ from __future__ import annotations
 
 from typing import Callable, Iterator, Literal, Optional, TYPE_CHECKING
 
+import bigframes_vendored.constants as constants
 from bigframes_vendored.pandas.core import indexing
 import bigframes_vendored.pandas.core.common as common
-
-import bigframes.constants as constants
 
 if TYPE_CHECKING:
     from bigframes_vendored.pandas.pandas._typing import T

--- a/third_party/bigframes_vendored/pandas/core/indexing.py
+++ b/third_party/bigframes_vendored/pandas/core/indexing.py
@@ -1,6 +1,6 @@
 # Contains code from https://github.com/pandas-dev/pandas/blob/main/pandas/core/indexing.py
 
-import bigframes.constants as constants
+import bigframes_vendored.constants as constants
 
 
 class IndexingMixin:


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
fix: set `bpd.remote_function()`s `input_types` and `output_types` default to `None` to allow omitting them when type annotations are present (#729)
END_COMMIT_OVERRIDE

Follow-up to https://github.com/googleapis/python-bigquery-dataframes/pull/717 which made these parameters optional but forgot to add default values.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes internal issue 343447415
🦕
