### PR TITLE
chore: cleanup type errors in tests/system/large/test_remote_function.py and…

### DIFF
--- a/tests/system/small/test_remote_function.py
+++ b/tests/system/small/test_remote_function.py
@@ -658,11 +658,10 @@ def test_read_gbq_function_reads_udfs(session, bigquery_client, dataset_id):
 
         indirect_df = bigframes.dataframe.DataFrame(src)
         indirect_df = indirect_df.assign(y=indirect_df.x.apply(square))
-        # TODO(b/340875260): fix type error
-        indirect_df = indirect_df.to_pandas()  # type: ignore
+        converted_indirect_df = indirect_df.to_pandas()
 
         assert_pandas_df_equal(
-            direct_df, indirect_df, ignore_order=True, check_index_type=False
+            direct_df, converted_indirect_df, ignore_order=True, check_index_type=False
         )
 
 


### PR DESCRIPTION
… tests/system/small/test_remote_function.py

Also, the module import hack seems no longer needed and is removed after the load process updated.


Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
