### PR TITLE
deps: Update minimum support to Pandas 1.5.3 and Pyarrow 10.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,8 @@ dependencies = [
     "ibis-framework[bigquery] >=8.0.0,<9.0.0dev",
     "jellyfish >=0.8.9",
     "numpy >=1.24.0",
-    # TODO: Relax upper bound once we have fixed `system_prerelease` tests.
-    "pandas >=1.5.0",
-    "pyarrow >=8.0.0",
+    "pandas >=1.5.3",
+    "pyarrow >=10.0.1",
     "pydata-google-auth >=1.8.2",
     "requests >=2.27.1",
     "scikit-learn >=1.2.2",

--- a/testing/constraints-3.10.txt
+++ b/testing/constraints-3.10.txt
@@ -3,10 +3,10 @@ google-auth==2.27.0
 ipykernel==5.5.6
 ipython==7.34.0
 notebook==6.5.5
-pandas==2.0.3
-pandas-stubs==2.0.3.230814
+pandas==2.1.4
+pandas-stubs==2.1.4.231227
 portpicker==1.5.2
-requests==2.31.0
+requests==2.32.3
 tornado==6.3.3
 absl-py==1.4.0
 debugpy==1.6.6

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -15,8 +15,8 @@ google-cloud-storage==2.0.0
 ibis-framework==8.0.0
 jellyfish==0.8.9
 numpy==1.24.0
-pandas==1.5.0
-pyarrow==8.0.0
+pandas==1.5.3
+pyarrow==10.0.1
 pydata-google-auth==1.8.2
 requests==2.27.1
 scikit-learn==1.2.2

--- a/tests/system/small/operations/test_strings.py
+++ b/tests/system/small/operations/test_strings.py
@@ -634,7 +634,7 @@ def test_getitem_w_array(index):
 
 
 def test_getitem_w_struct_array():
-    if packaging.version.Version(pd.__version__) <= packaging.version.Version("1.5.0"):
+    if packaging.version.Version(pd.__version__) <= packaging.version.Version("1.5.3"):
         pytest.skip("https://github.com/googleapis/python-bigquery/issues/1992")
 
     pa_struct = pa.struct(


### PR DESCRIPTION
This change upgrades minimum support to Pandas 1.5.3 and Pyarrow 10.0.1. That's required for coming Ibis v9.0+ upgrades. 

- [X] Fixes internal issue (350749011).
- [X] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes internal issue 350749011 🦕
