### PR TITLE
chore: fix the test cover workflow

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -30,6 +30,7 @@ jobs:
       with:
         name: coverage-artifact-${{ matrix.python }}
         path: .coverage-${{ matrix.python }}
+        include-hidden-files: true
 
   cover:
     runs-on: ubuntu-latest

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -30,8 +30,6 @@ jobs:
       with:
         name: coverage-artifact-${{ matrix.python }}
         path: .coverage-${{ matrix.python }}
-        if-no-files-found: error
-        include-hidden-files: true
 
   cover:
     runs-on: ubuntu-latest

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -22,15 +22,16 @@ jobs:
         python -m pip install nox
     - name: Run unit tests
       env:
-        COVERAGE_FILE: /tmp/.coverage-${{ matrix.python }}
+        COVERAGE_FILE: .coverage-${{ matrix.python }}
       run: |
         nox -s unit-${{ matrix.python }}
     - name: Upload coverage results
-      uses: actions/upload-artifact@v4.3.5
+      uses: actions/upload-artifact@v4
       with:
         name: coverage-artifact-${{ matrix.python }}
-        path: /tmp/.coverage-${{ matrix.python }}
+        path: .coverage-${{ matrix.python }}
         if-no-files-found: error
+        include-hidden-files: true
 
   cover:
     runs-on: ubuntu-latest

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -22,14 +22,14 @@ jobs:
         python -m pip install nox
     - name: Run unit tests
       env:
-        COVERAGE_FILE: .coverage-${{ matrix.python }}
+        COVERAGE_FILE: .coverage-unit-${{ matrix.python }}
       run: |
         nox -s unit-${{ matrix.python }}
     - name: Upload coverage results
       uses: actions/upload-artifact@v4
       with:
         name: coverage-artifact-${{ matrix.python }}
-        path: .coverage-${{ matrix.python }}
+        path: .coverage-unit-${{ matrix.python }}
 
   cover:
     runs-on: ubuntu-latest
@@ -53,5 +53,5 @@ jobs:
     - name: Report coverage results
       run: |
         find .coverage-results -type f -name '*.zip' -exec unzip {} \;
-        coverage combine .coverage-results/**/.coverage*
+        coverage combine .coverage-results/**/.coverage-unit*
         coverage report --show-missing --fail-under=35

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -26,10 +26,11 @@ jobs:
       run: |
         nox -s unit-${{ matrix.python }}
     - name: Upload coverage results
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v4.3.5
       with:
         name: coverage-artifact-${{ matrix.python }}
         path: /tmp/.coverage-${{ matrix.python }}
+        if-no-files-found: error
 
   cover:
     runs-on: ubuntu-latest

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -22,14 +22,14 @@ jobs:
         python -m pip install nox
     - name: Run unit tests
       env:
-        COVERAGE_FILE: .coverage-unit-${{ matrix.python }}
+        COVERAGE_FILE: /tmp/.coverage-${{ matrix.python }}
       run: |
         nox -s unit-${{ matrix.python }}
     - name: Upload coverage results
       uses: actions/upload-artifact@v4
       with:
         name: coverage-artifact-${{ matrix.python }}
-        path: .coverage-unit-${{ matrix.python }}
+        path: /tmp/.coverage-${{ matrix.python }}
 
   cover:
     runs-on: ubuntu-latest
@@ -53,5 +53,5 @@ jobs:
     - name: Report coverage results
       run: |
         find .coverage-results -type f -name '*.zip' -exec unzip {} \;
-        coverage combine .coverage-results/**/.coverage-unit*
+        coverage combine .coverage-results/**/.coverage*
         coverage report --show-missing --fail-under=35

--- a/owlbot.py
+++ b/owlbot.py
@@ -49,6 +49,7 @@ s.move(
         "README.rst",
         "CONTRIBUTING.rst",
         ".github/release-trigger.yml",
+        ".github/workflows/unittest.yml",
         # BigQuery DataFrames manages its own Kokoro cluster for presubmit & continuous tests.
         ".kokoro/build.sh",
         ".kokoro/continuous/common.cfg",


### PR DESCRIPTION
This change is fixing a regression of the `cover` workflow. The `upload-artifact` excludes hidden files by default [here](https://github.com/actions/upload-artifact/commit/50769540e7f4bd5e21e526ee35c689e35e0d6874).
