### PR TITLE
chore: make doctest tests less parallel

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -304,6 +304,7 @@ def run_system(
     print_duration=False,
     extra_pytest_options=(),
     timeout_seconds=900,
+    num_workers=20,
 ):
     """Run the system test suite."""
     constraints_path = str(
@@ -323,7 +324,7 @@ def run_system(
     pytest_cmd = [
         "py.test",
         "--quiet",
-        "-n=20",
+        f"-n={num_workers}",
         # Any individual test taking longer than 15 mins will be terminated.
         f"--timeout={timeout_seconds}",
         # Log 20 slowest tests
@@ -387,6 +388,7 @@ def doctest(session: nox.sessions.Session):
         extra_pytest_options=("--doctest-modules", "third_party"),
         test_folder="bigframes",
         check_cov=True,
+        num_workers=5,
     )
 
 


### PR DESCRIPTION
Parallel test runs contribute
to them running into request rate limiting quota issue with cloud functions and cloud front door. Currently doctest nox session is running in about 9 minutes, while presubmit is running in 45 minutes. This gives us some leeway in making doctest less parallel to reduce the likelihood of running into rate quota issue without comprimising the overall PR merge readiness turnaround.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes (partially) internal issue 356217175 🦕
