### PR TITLE
refactor: remove circular dependencies preventing local doctest runs

### DIFF
--- a/bigframes/bigquery/__init__.py
+++ b/bigframes/bigquery/__init__.py
@@ -23,7 +23,8 @@ from __future__ import annotations
 import typing
 from typing import Literal, Optional, Union
 
-import bigframes.constants as constants
+import bigframes_vendored.constants as constants
+
 import bigframes.core.groupby as groupby
 import bigframes.core.sql
 import bigframes.ml.utils as utils

--- a/bigframes/constants.py
+++ b/bigframes/constants.py
@@ -19,14 +19,6 @@ This module should not depend on any others in the package.
 
 import datetime
 
-import bigframes_vendored.constants
-
-BF_VERSION = bigframes_vendored.constants.BF_VERSION
-FEEDBACK_LINK = bigframes_vendored.constants.FEEDBACK_LINK
-ABSTRACT_METHOD_ERROR_MESSAGE = (
-    bigframes_vendored.constants.ABSTRACT_METHOD_ERROR_MESSAGE
-)
-
 DEFAULT_EXPIRATION = datetime.timedelta(days=7)
 
 # https://cloud.google.com/bigquery/docs/locations

--- a/bigframes/core/block_transforms.py
+++ b/bigframes/core/block_transforms.py
@@ -17,9 +17,10 @@ import functools
 import typing
 from typing import Sequence
 
+import bigframes_vendored.constants as constants
 import pandas as pd
 
-import bigframes.constants as constants
+import bigframes.constants
 import bigframes.core as core
 import bigframes.core.blocks as blocks
 import bigframes.core.expression as ex
@@ -117,7 +118,7 @@ def quantile(
     )
     quantile_cols = []
     labels = []
-    if len(columns) * len(qs) > constants.MAX_COLUMNS:
+    if len(columns) * len(qs) > bigframes.constants.MAX_COLUMNS:
         raise NotImplementedError("Too many aggregates requested.")
     for col in columns:
         for q in qs:

--- a/bigframes/core/blocks.py
+++ b/bigframes/core/blocks.py
@@ -32,13 +32,13 @@ import typing
 from typing import Iterable, List, Literal, Mapping, Optional, Sequence, Tuple, Union
 import warnings
 
+import bigframes_vendored.constants as constants
 import google.cloud.bigquery as bigquery
 import pandas as pd
 import pyarrow as pa
 
 import bigframes._config.sampling_options as sampling_options
 import bigframes.constants
-import bigframes.constants as constants
 import bigframes.core as core
 import bigframes.core.compile.googlesql as googlesql
 import bigframes.core.expression as ex

--- a/bigframes/core/compile/aggregate_compiler.py
+++ b/bigframes/core/compile/aggregate_compiler.py
@@ -15,13 +15,13 @@ import functools
 import typing
 from typing import cast, Optional
 
+import bigframes_vendored.constants as constants
 import bigframes_vendored.ibis.expr.operations as vendored_ibis_ops
 import ibis
 import ibis.expr.datatypes as ibis_dtypes
 import ibis.expr.types as ibis_types
 import pandas as pd
 
-import bigframes.constants as constants
 import bigframes.core.compile.ibis_types as compile_ibis_types
 import bigframes.core.compile.scalar_op_compiler as scalar_compilers
 import bigframes.core.expression as ex

--- a/bigframes/core/compile/ibis_types.py
+++ b/bigframes/core/compile/ibis_types.py
@@ -17,6 +17,7 @@ import textwrap
 from typing import Any, cast, Dict, Iterable, Optional, Tuple, Union
 import warnings
 
+import bigframes_vendored.constants as constants
 import bigframes_vendored.ibis.backends.bigquery.datatypes as third_party_ibis_bqtypes
 import bigframes_vendored.ibis.expr.operations as vendored_ibis_ops
 import geopandas as gpd  # type: ignore
@@ -29,7 +30,6 @@ import numpy as np
 import pandas as pd
 import pyarrow as pa
 
-import bigframes.constants as constants
 import bigframes.dtypes
 
 # Type hints for Ibis data types supported by BigQuery DataFrame

--- a/bigframes/core/compile/scalar_op_compiler.py
+++ b/bigframes/core/compile/scalar_op_compiler.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import functools
 import typing
 
+import bigframes_vendored.constants as constants
 import bigframes_vendored.ibis.expr.operations as vendored_ibis_ops
 import ibis
 import ibis.common.exceptions
@@ -26,7 +27,6 @@ import ibis.expr.types as ibis_types
 import numpy as np
 import pandas as pd
 
-import bigframes.constants as constants
 import bigframes.core.compile.ibis_types
 import bigframes.core.expression as ex
 import bigframes.dtypes

--- a/bigframes/core/groupby/__init__.py
+++ b/bigframes/core/groupby/__init__.py
@@ -17,10 +17,10 @@ from __future__ import annotations
 import typing
 from typing import Sequence, Union
 
+import bigframes_vendored.constants as constants
 import bigframes_vendored.pandas.core.groupby as vendored_pandas_groupby
 import pandas as pd
 
-import bigframes.constants as constants
 from bigframes.core import log_adapter
 import bigframes.core as core
 import bigframes.core.block_transforms as block_ops

--- a/bigframes/core/indexers.py
+++ b/bigframes/core/indexers.py
@@ -17,10 +17,10 @@ from __future__ import annotations
 import typing
 from typing import Tuple, Union
 
+import bigframes_vendored.constants as constants
 import ibis
 import pandas as pd
 
-import bigframes.constants as constants
 import bigframes.core.blocks
 import bigframes.core.expression as ex
 import bigframes.core.guid as guid

--- a/bigframes/core/indexes/base.py
+++ b/bigframes/core/indexes/base.py
@@ -19,12 +19,12 @@ from __future__ import annotations
 import typing
 from typing import Hashable, Optional, Sequence, Union
 
+import bigframes_vendored.constants as constants
 import bigframes_vendored.pandas.core.indexes.base as vendored_pandas_index
 import google.cloud.bigquery as bigquery
 import numpy as np
 import pandas
 
-import bigframes.constants as constants
 import bigframes.core.block_transforms as block_ops
 import bigframes.core.blocks as blocks
 import bigframes.core.expression as ex

--- a/bigframes/core/reshape/__init__.py
+++ b/bigframes/core/reshape/__init__.py
@@ -16,9 +16,9 @@ from __future__ import annotations
 import typing
 from typing import Iterable, Literal, Optional, Union
 
+import bigframes_vendored.constants as constants
 import pandas as pd
 
-import bigframes.constants as constants
 import bigframes.core.expression as ex
 import bigframes.core.ordering as order
 import bigframes.core.utils as utils

--- a/bigframes/core/tools/datetimes.py
+++ b/bigframes/core/tools/datetimes.py
@@ -16,10 +16,10 @@ from collections.abc import Mapping
 from datetime import datetime
 from typing import Optional, Union
 
+import bigframes_vendored.constants as constants
 import bigframes_vendored.pandas.core.tools.datetimes as vendored_pandas_datetimes
 import pandas as pd
 
-import bigframes.constants as constants
 import bigframes.dataframe
 import bigframes.dtypes
 import bigframes.operations as ops

--- a/bigframes/core/validations.py
+++ b/bigframes/core/validations.py
@@ -19,7 +19,8 @@ from __future__ import annotations
 import functools
 from typing import Optional, Protocol, TYPE_CHECKING, Union
 
-import bigframes.constants
+import bigframes_vendored.constants as constants
+
 import bigframes.exceptions
 
 if TYPE_CHECKING:
@@ -72,9 +73,9 @@ def enforce_ordered(
     if not session._allows_ambiguity:
         suggestion_substr = suggestion + " " if suggestion else ""
         raise bigframes.exceptions.OrderRequiredError(
-            f"Op {opname} not supported when strict ordering is disabled. {suggestion_substr}{bigframes.constants.FEEDBACK_LINK}"
+            f"Op {opname} not supported when strict ordering is disabled. {suggestion_substr}{constants.FEEDBACK_LINK}"
         )
     if not object._block.explicitly_ordered:
         raise bigframes.exceptions.OrderRequiredError(
-            f"Op {opname} requires an ordering. Use .sort_values or .sort_index to provide an ordering. {bigframes.constants.FEEDBACK_LINK}"
+            f"Op {opname} requires an ordering. Use .sort_values or .sort_index to provide an ordering. {constants.FEEDBACK_LINK}"
         )

--- a/bigframes/dataframe.py
+++ b/bigframes/dataframe.py
@@ -36,6 +36,7 @@ from typing import (
 )
 import warnings
 
+import bigframes_vendored.constants as constants
 import bigframes_vendored.pandas.core.frame as vendored_pandas_frame
 import bigframes_vendored.pandas.pandas._typing as vendored_pandas_typing
 import google.api_core.exceptions
@@ -49,7 +50,6 @@ import tabulate
 import bigframes
 import bigframes._config.display_options as display_options
 import bigframes.constants
-import bigframes.constants as constants
 import bigframes.core
 from bigframes.core import log_adapter
 import bigframes.core.block_transforms as block_ops
@@ -3106,7 +3106,7 @@ class DataFrame(vendored_pandas_frame.DataFrame):
                 self._session.bqclient,
                 temp_table_ref,
                 datetime.datetime.now(datetime.timezone.utc)
-                + constants.DEFAULT_EXPIRATION,
+                + bigframes.constants.DEFAULT_EXPIRATION,
             )
 
         if len(labels) != 0:

--- a/bigframes/dtypes.py
+++ b/bigframes/dtypes.py
@@ -20,13 +20,12 @@ import decimal
 import typing
 from typing import Dict, Literal, Union
 
+import bigframes_vendored.constants as constants
 import geopandas as gpd  # type: ignore
 import google.cloud.bigquery
 import numpy as np
 import pandas as pd
 import pyarrow as pa
-
-import bigframes.constants as constants
 
 # Type hints for Pandas dtypes supported by BigQuery DataFrame
 Dtype = Union[

--- a/bigframes/formatting_helpers.py
+++ b/bigframes/formatting_helpers.py
@@ -19,14 +19,13 @@ import datetime
 import random
 from typing import Any, Optional, Union
 
+import bigframes_vendored.constants as constants
 import google.api_core.exceptions as api_core_exceptions
 import google.cloud.bigquery as bigquery
 import humanize
 import IPython
 import IPython.display as display
 import ipywidgets as widgets
-
-import bigframes.constants as constants
 
 GenericJob = Union[
     bigquery.LoadJob, bigquery.ExtractJob, bigquery.QueryJob, bigquery.CopyJob

--- a/bigframes/functions/_remote_function_client.py
+++ b/bigframes/functions/_remote_function_client.py
@@ -25,9 +25,9 @@ import sys
 import tempfile
 from typing import cast, Tuple, TYPE_CHECKING
 
+from bigframes_vendored import constants
 import requests
 
-from bigframes import constants
 import bigframes.functions.remote_function_template
 
 if TYPE_CHECKING:

--- a/bigframes/functions/_remote_function_session.py
+++ b/bigframes/functions/_remote_function_session.py
@@ -22,6 +22,7 @@ import threading
 from typing import Any, cast, Dict, Mapping, Optional, Sequence, TYPE_CHECKING, Union
 import warnings
 
+import bigframes_vendored.constants as constants
 import cloudpickle
 import google.api_core.exceptions
 from google.cloud import (
@@ -31,7 +32,7 @@ from google.cloud import (
     resourcemanager_v3,
 )
 
-from bigframes import clients, constants
+from bigframes import clients
 
 if TYPE_CHECKING:
     from bigframes.session import Session

--- a/bigframes/functions/remote_function.py
+++ b/bigframes/functions/remote_function.py
@@ -24,12 +24,12 @@ import ibis
 if TYPE_CHECKING:
     from bigframes.session import Session
 
+import bigframes_vendored.constants as constants
 import google.api_core.exceptions
 import google.api_core.retry
 from google.cloud import bigquery
 import google.iam.v1
 
-import bigframes.constants as constants
 import bigframes.core.compile.ibis_types
 import bigframes.dtypes
 import bigframes.functions.remote_function_template

--- a/bigframes/ml/compose.py
+++ b/bigframes/ml/compose.py
@@ -23,10 +23,10 @@ import types
 import typing
 from typing import cast, Iterable, List, Optional, Set, Tuple, Union
 
+from bigframes_vendored import constants
 import bigframes_vendored.sklearn.compose._column_transformer
 from google.cloud import bigquery
 
-from bigframes import constants
 from bigframes.core import log_adapter
 from bigframes.ml import base, core, globals, impute, preprocessing, utils
 import bigframes.pandas as bpd

--- a/bigframes/ml/linear_model.py
+++ b/bigframes/ml/linear_model.py
@@ -19,12 +19,12 @@ from __future__ import annotations
 
 from typing import Dict, List, Literal, Optional, Union
 
+import bigframes_vendored.constants as constants
 import bigframes_vendored.sklearn.linear_model._base
 import bigframes_vendored.sklearn.linear_model._logistic
 from google.cloud import bigquery
 
 import bigframes
-import bigframes.constants as constants
 from bigframes.core import log_adapter
 from bigframes.ml import base, core, globals, utils
 import bigframes.pandas as bpd

--- a/bigframes/ml/llm.py
+++ b/bigframes/ml/llm.py
@@ -19,10 +19,11 @@ from __future__ import annotations
 from typing import cast, Literal, Optional, Union
 import warnings
 
+import bigframes_vendored.constants as constants
 from google.cloud import bigquery
 
 import bigframes
-from bigframes import clients, constants
+from bigframes import clients
 from bigframes.core import blocks, log_adapter
 from bigframes.ml import base, core, globals, utils
 import bigframes.pandas as bpd

--- a/bigframes/ml/loader.py
+++ b/bigframes/ml/loader.py
@@ -17,10 +17,10 @@ from __future__ import annotations
 from types import MappingProxyType
 from typing import Union
 
+import bigframes_vendored.constants as constants
 from google.cloud import bigquery
 
 import bigframes
-import bigframes.constants as constants
 from bigframes.ml import (
     cluster,
     compose,

--- a/bigframes/ml/metrics/_metrics.py
+++ b/bigframes/ml/metrics/_metrics.py
@@ -19,6 +19,7 @@ import inspect
 import typing
 from typing import Tuple, Union
 
+import bigframes_vendored.constants as constants
 import bigframes_vendored.sklearn.metrics._classification as vendored_metrics_classification
 import bigframes_vendored.sklearn.metrics._ranking as vendored_metrics_ranking
 import bigframes_vendored.sklearn.metrics._regression as vendored_metrics_regression
@@ -26,7 +27,6 @@ import numpy as np
 import pandas as pd
 import sklearn.metrics as sklearn_metrics  # type: ignore
 
-import bigframes.constants as constants
 from bigframes.ml import utils
 import bigframes.pandas as bpd
 

--- a/bigframes/ml/pipeline.py
+++ b/bigframes/ml/pipeline.py
@@ -20,11 +20,11 @@ from __future__ import annotations
 
 from typing import List, Optional, Tuple, Union
 
+import bigframes_vendored.constants as constants
 import bigframes_vendored.sklearn.pipeline
 from google.cloud import bigquery
 
 import bigframes
-import bigframes.constants as constants
 from bigframes.core import log_adapter
 from bigframes.ml import (
     base,

--- a/bigframes/ml/sql.py
+++ b/bigframes/ml/sql.py
@@ -18,9 +18,8 @@ Generates SQL queries needed for BigQuery DataFrames ML
 
 from typing import Iterable, Literal, Mapping, Optional, Union
 
+import bigframes_vendored.constants as constants
 import google.cloud.bigquery
-
-import bigframes.constants as constants
 
 
 # TODO: Add proper escaping logic from core/compile module

--- a/bigframes/ml/utils.py
+++ b/bigframes/ml/utils.py
@@ -15,9 +15,9 @@
 import typing
 from typing import Any, Iterable, Literal, Mapping, Optional, Union
 
+import bigframes_vendored.constants as constants
 from google.cloud import bigquery
 
-import bigframes.constants as constants
 from bigframes.core import blocks
 import bigframes.pandas as bpd
 

--- a/bigframes/operations/_matplotlib/core.py
+++ b/bigframes/operations/_matplotlib/core.py
@@ -15,9 +15,9 @@
 import abc
 import typing
 
+import bigframes_vendored.constants as constants
 import pandas as pd
 
-import bigframes.constants as constants
 import bigframes.dtypes as dtypes
 
 DEFAULT_SAMPLING_N = 1000

--- a/bigframes/operations/_matplotlib/hist.py
+++ b/bigframes/operations/_matplotlib/hist.py
@@ -15,10 +15,10 @@
 import itertools
 from typing import Literal
 
+import bigframes_vendored.constants as constants
 import numpy as np
 import pandas as pd
 
-import bigframes.constants as constants
 import bigframes.operations._matplotlib.core as bfplt
 
 

--- a/bigframes/operations/base.py
+++ b/bigframes/operations/base.py
@@ -17,10 +17,10 @@ from __future__ import annotations
 import typing
 from typing import List, Sequence
 
+import bigframes_vendored.constants as constants
 import bigframes_vendored.pandas.pandas._typing as vendored_pandas_typing
 import pandas as pd
 
-import bigframes.constants as constants
 import bigframes.core.blocks as blocks
 import bigframes.core.convert
 import bigframes.core.expression as ex

--- a/bigframes/operations/plotting.py
+++ b/bigframes/operations/plotting.py
@@ -14,9 +14,9 @@
 
 import typing
 
+import bigframes_vendored.constants as constants
 import bigframes_vendored.pandas.plotting._core as vendordt
 
-import bigframes.constants as constants
 import bigframes.operations._matplotlib as bfplt
 
 

--- a/bigframes/operations/strings.py
+++ b/bigframes/operations/strings.py
@@ -17,9 +17,9 @@ from __future__ import annotations
 import re
 from typing import cast, Literal, Optional, Union
 
+import bigframes_vendored.constants as constants
 import bigframes_vendored.pandas.core.strings.accessor as vendorstr
 
-import bigframes.constants as constants
 from bigframes.core import log_adapter
 import bigframes.dataframe as df
 import bigframes.operations as ops

--- a/bigframes/pandas/__init__.py
+++ b/bigframes/pandas/__init__.py
@@ -36,6 +36,7 @@ from typing import (
     Union,
 )
 
+import bigframes_vendored.constants as constants
 import bigframes_vendored.pandas.core.reshape.concat as vendored_pandas_concat
 import bigframes_vendored.pandas.core.reshape.encoding as vendored_pandas_encoding
 import bigframes_vendored.pandas.core.reshape.merge as vendored_pandas_merge
@@ -53,7 +54,6 @@ from pandas._typing import (
 )
 
 import bigframes._config as config
-import bigframes.constants as constants
 import bigframes.core.blocks
 import bigframes.core.expression as ex
 import bigframes.core.global_session as global_session

--- a/bigframes/series.py
+++ b/bigframes/series.py
@@ -24,6 +24,7 @@ import textwrap
 import typing
 from typing import Any, cast, Literal, Mapping, Optional, Sequence, Tuple, Union
 
+import bigframes_vendored.constants as constants
 import bigframes_vendored.pandas.core.series as vendored_pandas_series
 import google.cloud.bigquery as bigquery
 import numpy
@@ -31,7 +32,6 @@ import pandas
 import pandas.core.dtypes.common
 import typing_extensions
 
-import bigframes.constants as constants
 import bigframes.core
 from bigframes.core import log_adapter
 import bigframes.core.block_transforms as block_ops

--- a/bigframes/session/__init__.py
+++ b/bigframes/session/__init__.py
@@ -37,6 +37,7 @@ from typing import (
 import warnings
 import weakref
 
+import bigframes_vendored.constants as constants
 import bigframes_vendored.ibis.backends.bigquery  # noqa
 import bigframes_vendored.pandas.io.gbq as third_party_pandas_gbq
 import bigframes_vendored.pandas.io.parquet as third_party_pandas_parquet
@@ -58,7 +59,6 @@ import pyarrow as pa
 
 import bigframes._config.bigquery_options as bigquery_options
 import bigframes.clients
-import bigframes.constants as constants
 import bigframes.core as core
 import bigframes.core.blocks as blocks
 import bigframes.core.compile

--- a/bigframes/session/_io/bigquery/read_gbq_table.py
+++ b/bigframes/session/_io/bigquery/read_gbq_table.py
@@ -23,12 +23,12 @@ import typing
 from typing import Dict, Iterable, List, Optional, Sequence, Tuple
 import warnings
 
+import bigframes_vendored.constants as constants
 import google.api_core.exceptions
 import google.cloud.bigquery as bigquery
 
 import bigframes
 import bigframes.clients
-import bigframes.constants
 import bigframes.core.compile
 import bigframes.core.compile.default_ordering
 import bigframes.core.sql
@@ -241,7 +241,7 @@ def get_index_cols(
             # test, as it's not possible to subclass enums in Python. See:
             # https://stackoverflow.com/a/33680021/101923
             raise NotImplementedError(
-                f"Got unexpected index_col {repr(index_col)}. {bigframes.constants.FEEDBACK_LINK}"
+                f"Got unexpected index_col {repr(index_col)}. {constants.FEEDBACK_LINK}"
             )
     elif isinstance(index_col, str):
         index_cols: List[str] = [index_col]

--- a/bigframes/session/_io/pandas.py
+++ b/bigframes/session/_io/pandas.py
@@ -14,6 +14,7 @@
 
 from typing import Dict, Union
 
+import bigframes_vendored.constants as constants
 import geopandas  # type: ignore
 import pandas
 import pandas.arrays
@@ -21,7 +22,6 @@ import pyarrow  # type: ignore
 import pyarrow.compute  # type: ignore
 import pyarrow.types  # type: ignore
 
-import bigframes.constants
 import bigframes.features
 
 
@@ -54,7 +54,7 @@ def arrow_to_pandas(
     if len(dtypes) != arrow_table.num_columns:
         raise ValueError(
             f"Number of types {len(dtypes)} doesn't match number of columns "
-            f"{arrow_table.num_columns}. {bigframes.constants.FEEDBACK_LINK}"
+            f"{arrow_table.num_columns}. {constants.FEEDBACK_LINK}"
         )
 
     serieses = {}

--- a/bigframes/session/loader.py
+++ b/bigframes/session/loader.py
@@ -22,6 +22,7 @@ import os
 import typing
 from typing import Dict, Hashable, IO, Iterable, List, Optional, Sequence, Tuple, Union
 
+import bigframes_vendored.constants as constants
 import bigframes_vendored.pandas.io.gbq as third_party_pandas_gbq
 import google.api_core.exceptions
 import google.auth.credentials
@@ -36,7 +37,7 @@ import numpy as np
 import pandas
 
 import bigframes.clients
-import bigframes.constants as constants
+import bigframes.constants
 import bigframes.core as core
 import bigframes.core.blocks as blocks
 import bigframes.core.compile
@@ -444,7 +445,8 @@ class GbqDataLoader:
         # hours of the anonymous dataset.
         table_expiration = bigquery.Table(table_id)
         table_expiration.expires = (
-            datetime.datetime.now(datetime.timezone.utc) + constants.DEFAULT_EXPIRATION
+            datetime.datetime.now(datetime.timezone.utc)
+            + bigframes.constants.DEFAULT_EXPIRATION
         )
         self._bqclient.update_table(table_expiration, ["expires"])
 

--- a/tests/unit/test_formatting_helpers.py
+++ b/tests/unit/test_formatting_helpers.py
@@ -14,12 +14,13 @@
 
 import unittest.mock as mock
 
+import bigframes_vendored.constants as constants
 import google.api_core.exceptions as api_core_exceptions
 import google.cloud.bigquery as bigquery
 import pytest
 
-import bigframes.constants as constants
 import bigframes.formatting_helpers as formatting_helpers
+import bigframes.version
 
 
 def test_wait_for_query_job_error_includes_feedback_link():
@@ -54,4 +55,4 @@ def test_wait_for_job_error_includes_version():
         formatting_helpers.wait_for_job(mock_job)
 
     cap_exc.match("Test message 123.")
-    cap_exc.match(constants.BF_VERSION)
+    cap_exc.match(bigframes.version.__version__)

--- a/third_party/bigframes_vendored/constants.py
+++ b/third_party/bigframes_vendored/constants.py
@@ -16,14 +16,12 @@
 
 This module should not depend on any others in the package.
 """
-import bigframes.version
-
-BF_VERSION = bigframes.version.__version__
+import bigframes_vendored.version
 
 FEEDBACK_LINK = (
     "Share your usecase with the BigQuery DataFrames team at the "
     "https://bit.ly/bigframes-feedback survey."
-    f"You are currently running BigFrames version {BF_VERSION}"
+    f"You are currently running BigFrames version {bigframes_vendored.version.__version__}"
 )
 
 ABSTRACT_METHOD_ERROR_MESSAGE = (

--- a/third_party/bigframes_vendored/version.py
+++ b/third_party/bigframes_vendored/version.py
@@ -1,4 +1,4 @@
-# Copyright 2023 Google LLC
+# Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,12 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import bigframes_vendored.constants
-
-import bigframes.version
-
-
-def test_feedback_link_includes_version():
-    version = bigframes.version.__version__
-    assert len(version) > 0
-    assert version in bigframes_vendored.constants.FEEDBACK_LINK
+__version__ = "1.17.0"


### PR DESCRIPTION
With this change I can once again run

```
pytest --doctest-modules third_party/bigframes_vendored/pandas/core/frame.py
```

Note: having multiple `version.py` files should be fine. release-please will update all such files it finds.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
