### PR TITLE
deps: limit ibis-framework version to 9.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ dependencies = [
     "google-cloud-iam >=2.12.1",
     "google-cloud-resource-manager >=1.10.3",
     "google-cloud-storage >=2.0.0",
-    "ibis-framework[bigquery] >=9.0.0,<=9.3.0",
+    "ibis-framework[bigquery] >=9.0.0,<=9.2.0",
     "jellyfish >=0.8.9",
     "numpy >=1.24.0",
     "pandas >=1.5.3",

--- a/testing/constraints-3.12.txt
+++ b/testing/constraints-3.12.txt
@@ -1,3 +1,0 @@
-# Some internal modules have moved,
-# so make sure we test on all ibis-framework 9.x versions.
-ibis-framework==9.2.0


### PR DESCRIPTION
This change limiting ibis version to 9.2.0 because `testing/constraints-*` settings do not cover ibis 9.3.0 tests.

- [X] Fixes internal issue 350749011
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes internal issue 350749011 🦕
