### PR TITLE
chore: remove pandas version limit from test `test_getitem_w_struct_array`

### DIFF
--- a/tests/system/small/operations/test_strings.py
+++ b/tests/system/small/operations/test_strings.py
@@ -641,9 +641,6 @@ def test_getitem_w_array(index, column_name, repeated_df, repeated_pandas_df):
 
 
 def test_getitem_w_struct_array():
-    if packaging.version.Version(pd.__version__) <= packaging.version.Version("1.5.3"):
-        pytest.skip("https://github.com/googleapis/python-bigquery/issues/1992")
-
     pa_struct = pa.struct(
         [
             ("name", pa.string()),

--- a/tests/system/small/operations/test_strings.py
+++ b/tests/system/small/operations/test_strings.py
@@ -14,7 +14,6 @@
 
 import re
 
-import packaging.version
 import pandas as pd
 import pyarrow as pa
 import pytest


### PR DESCRIPTION
BigFrame now requires minimum pandas version 1.5.3 to support Ibis 9.2.0 . Therefore, the ChunkedArray bug googleapis/python-bigquery#1992 can no longer be triggered in future releases.
