### PR TITLE
fix: remove pre-caching of remote function results

### DIFF
--- a/bigframes/dataframe.py
+++ b/bigframes/dataframe.py
@@ -3567,11 +3567,7 @@ class DataFrame(vendored_pandas_frame.DataFrame):
                     ops.NaryRemoteFunctionOp(func=func), series_list[1:]
                 )
             result_series.name = None
-
-            # Return Series with materialized result so that any error in the remote
-            # function is caught early
-            materialized_series = result_series.cache()
-            return materialized_series
+            return result_series
 
         # Per-column apply
         results = {name: func(col, *args, **kwargs) for name, col in self.items()}

--- a/bigframes/series.py
+++ b/bigframes/series.py
@@ -1475,10 +1475,7 @@ class Series(bigframes.operations.base.SeriesMethods, vendored_pandas_series.Ser
             ops.RemoteFunctionOp(func=func, apply_on_null=True)
         )
 
-        # return Series with materialized result so that any error in the remote
-        # function is caught early
-        materialized_series = result_series._cached(session_aware=False)
-        return materialized_series
+        return result_series
 
     def combine(
         self,
@@ -1506,10 +1503,7 @@ class Series(bigframes.operations.base.SeriesMethods, vendored_pandas_series.Ser
             other, ops.BinaryRemoteFunctionOp(func=func)
         )
 
-        # return Series with materialized result so that any error in the remote
-        # function is caught early
-        materialized_series = result_series._cached()
-        return materialized_series
+        return result_series
 
     @validations.requires_index
     def add_prefix(self, prefix: str, axis: int | str | None = None) -> Series:


### PR DESCRIPTION
This will save redundant remote function execution as reported in b/370088754. The trade-off is that any remote function integration issues will be caughts only at a later point through a usage triggered sql execution. Why the caching is not working as indended in the reported use case in the bug? as per TrevorBergeron@ "the cached execution is useless when it is implicitly joined back to the base dataframe"

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes internal issue 370088754 🦕
