### PR TITLE
fix: update session metrics in `read_gbq_query`

### DIFF
--- a/bigframes/session/loader.py
+++ b/bigframes/session/loader.py
@@ -527,6 +527,9 @@ class GbqDataLoader:
             configuration=configuration,
         )
 
+        if self._metrics is not None:
+            self._metrics.count_job_stats(query_job)
+
         # If there was no destination table, that means the query must have
         # been DDL or DML. Return some job metadata, instead.
         if not destination:

--- a/tests/system/large/ml/test_core.py
+++ b/tests/system/large/ml/test_core.py
@@ -146,10 +146,14 @@ def test_bqml_standalone_transform(penguins_df_default_index, new_penguins_df):
             "ML.ONE_HOT_ENCODER(species, 'none', 1000000, 0) OVER() AS onehotencoded_species",
         ],
     )
+    start = model.session.slot_millis_sum
+    transformed = model.transform(new_penguins_df)
+    end = model.session.slot_millis_sum
 
-    transformed = model.transform(new_penguins_df).to_pandas()
+    assert end > start
+
     utils.check_pandas_df_schema_and_index(
-        transformed,
+        transformed.to_pandas(),
         columns=["scaled_culmen_length_mm", "onehotencoded_species"],
         index=[1633, 1672, 1690],
         col_exact=False,

--- a/tests/system/large/ml/test_core.py
+++ b/tests/system/large/ml/test_core.py
@@ -146,11 +146,12 @@ def test_bqml_standalone_transform(penguins_df_default_index, new_penguins_df):
             "ML.ONE_HOT_ENCODER(species, 'none', 1000000, 0) OVER() AS onehotencoded_species",
         ],
     )
-    start = model.session.slot_millis_sum
-    transformed = model.transform(new_penguins_df)
-    end = model.session.slot_millis_sum
+    start_execution_count = model.session._metrics.execution_count
 
-    assert end > start
+    transformed = model.transform(new_penguins_df)
+
+    end_execution_count = model.session._metrics.execution_count
+    assert end_execution_count - start_execution_count == 1
 
     utils.check_pandas_df_schema_and_index(
         transformed.to_pandas(),


### PR DESCRIPTION
This change makes sure the session metrics correctly reflect slot milliseconds after ML transform.

Fixes internal issue 372547905 🦕
