### PR TITLE
test: Add data file for JSON dtype system tests

### DIFF
--- a/tests/data/json.jsonl
+++ b/tests/data/json.jsonl
@@ -1,0 +1,16 @@
+{"rowindex": 0, "json_col": null}
+{"rowindex": 1, "json_col": true}
+{"rowindex": 2, "json_col": 100}
+{"rowindex": 3, "json_col": 0.98}
+{"rowindex": 4, "json_col": "a string"}
+{"rowindex": 5, "json_col": []}
+{"rowindex": 6, "json_col": [1, 2, 3]}
+{"rowindex": 7, "json_col": [{"a": 1}, {"a": 2}, {"a": null}, {}]}
+{"rowindex": 8, "json_col": {"bool_value": true}}
+{"rowindex": 9, "json_col": {"folat_num": 3.14159}}
+{"rowindex": 10, "json_col": {"date": "2024-07-16"}}
+{"rowindex": 11, "json_col": {"null_filed": null}}
+{"rowindex": 12, "json_col": {"int_value": 2, "null_filed": null}}
+{"rowindex": 13, "json_col": {"list_data": [10, 20, 30]}}
+{"rowindex": 14, "json_col": {"person": {"name": "Alice", "age": 35}}}
+{"rowindex": 15, "json_col": {"order": {"items": ["book", "pen"], "total": 15.99}}}

--- a/tests/data/json_schema.json
+++ b/tests/data/json_schema.json
@@ -1,0 +1,12 @@
+[
+    {
+        "name": "rowindex",
+        "type": "INTEGER",
+        "mode": "REQUIRED"
+    },
+    {
+        "name": "json_col",
+        "type": "JSON",
+        "mode": "NULLABLE"
+    }
+]

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -491,14 +491,13 @@ def repeated_pandas_df() -> pd.DataFrame:
 def json_df(
     json_table_id: str, session: bigframes.Session
 ) -> bigframes.dataframe.DataFrame:
-    """Returns a DataFrame containing columns of list type."""
+    """Returns a DataFrame containing columns of JSON type."""
     return session.read_gbq(json_table_id, index_col="rowindex")
 
 
 @pytest.fixture(scope="session")
 def json_pandas_df() -> pd.DataFrame:
-    """Returns a DataFrame containing columns of list type."""
-
+    """Returns a DataFrame containing columns of JSON type."""
     df = pd.read_json(
         DATA_DIR / "json.jsonl",
         lines=True,

--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -298,6 +298,7 @@ def load_test_data_tables(
         ("nested", "nested_schema.json", "nested.jsonl"),
         ("nested_structs", "nested_structs_schema.json", "nested_structs.jsonl"),
         ("repeated", "repeated_schema.json", "repeated.jsonl"),
+        ("json", "json_schema.json", "json.jsonl"),
         ("penguins", "penguins_schema.json", "penguins.jsonl"),
         ("time_series", "time_series_schema.json", "time_series.jsonl"),
         ("hockey_players", "hockey_players.json", "hockey_players.jsonl"),
@@ -382,6 +383,11 @@ def nested_structs_table_id(test_data_tables) -> str:
 @pytest.fixture(scope="session")
 def repeated_table_id(test_data_tables) -> str:
     return test_data_tables["repeated"]
+
+
+@pytest.fixture(scope="session")
+def json_table_id(test_data_tables) -> str:
+    return test_data_tables["json"]
 
 
 @pytest.fixture(scope="session")
@@ -475,6 +481,26 @@ def repeated_pandas_df() -> pd.DataFrame:
 
     df = pd.read_json(
         DATA_DIR / "repeated.jsonl",
+        lines=True,
+    )
+    df = df.set_index("rowindex")
+    return df
+
+
+@pytest.fixture(scope="session")
+def json_df(
+    json_table_id: str, session: bigframes.Session
+) -> bigframes.dataframe.DataFrame:
+    """Returns a DataFrame containing columns of list type."""
+    return session.read_gbq(json_table_id, index_col="rowindex")
+
+
+@pytest.fixture(scope="session")
+def json_pandas_df() -> pd.DataFrame:
+    """Returns a DataFrame containing columns of list type."""
+
+    df = pd.read_json(
+        DATA_DIR / "json.jsonl",
         lines=True,
     )
     df = df.set_index("rowindex")

--- a/tests/system/small/test_series.py
+++ b/tests/system/small/test_series.py
@@ -278,6 +278,12 @@ def test_get_column(scalars_dfs, col_name, expected_dtype):
     assert series_pandas.shape[0] == scalars_pandas_df.shape[0]
 
 
+def test_get_column_w_json(json_df):
+    series = json_df["json_col"]
+    assert series.dtype == pd.StringDtype(storage="pyarrow")
+    # assert series_pandas.shape[0] == scalars_pandas_df.shape[0]
+
+
 def test_series_get_column_default(scalars_dfs):
     scalars_df, _ = scalars_dfs
     result = scalars_df.get(123123123123123, "default_val")

--- a/tests/system/small/test_series.py
+++ b/tests/system/small/test_series.py
@@ -278,10 +278,11 @@ def test_get_column(scalars_dfs, col_name, expected_dtype):
     assert series_pandas.shape[0] == scalars_pandas_df.shape[0]
 
 
-def test_get_column_w_json(json_df):
+def test_get_column_w_json(json_df, json_pandas_df):
     series = json_df["json_col"]
+    series_pandas = series.to_pandas()
     assert series.dtype == pd.StringDtype(storage="pyarrow")
-    # assert series_pandas.shape[0] == scalars_pandas_df.shape[0]
+    assert series_pandas.shape[0] == json_pandas_df.shape[0]
 
 
 def test_series_get_column_default(scalars_dfs):


### PR DESCRIPTION
Adds a new data file for testing JSON dtype loading in system tests. Currently, the JSON dtype is represented as a `pyarrow string` type. This will be updated to use the `dbjson` extension type in a future change.

Fixes internal issue 377764399🦕
