### PR TITLE
chore: add guidance for read_parquet using wildcard paths

### DIFF
--- a/bigframes/session/__init__.py
+++ b/bigframes/session/__init__.py
@@ -946,6 +946,14 @@ class Session(
                 path, table, job_config=job_config
             )
         else:
+            if "*" in path:
+                raise ValueError(
+                    "The provided path contains a wildcard character (*), which is not "
+                    "supported by the current engine. To read files from wildcard paths, "
+                    "please use the 'bigquery' engine by setting `engine='bigquery'` in "
+                    "your configuration."
+                )
+
             read_parquet_kwargs: Dict[str, Any] = {}
             if pandas.__version__.startswith("1."):
                 read_parquet_kwargs["use_nullable_dtypes"] = True


### PR DESCRIPTION
This change is mainly adding guidance message when users call read_parquet for wildcard paths with pandas-base engine.
