### PR TITLE
feat!: automatically register the BigQuery magics when bigframes is imported

### DIFF
--- a/bigframes/__init__.py
+++ b/bigframes/__init__.py
@@ -14,6 +14,8 @@
 
 """BigQuery DataFrames provides a DataFrame API scaled by the BigQuery engine."""
 
+import IPython
+
 from bigframes._config import option_context, options
 from bigframes._config.bigquery_options import BigQueryOptions
 from bigframes.core.global_session import close_session, get_global_session
@@ -21,6 +23,20 @@ import bigframes.enums as enums
 import bigframes.exceptions as exceptions
 from bigframes.session import connect, Session
 from bigframes.version import __version__
+
+
+def load_ipython_extension(ipython):
+    """Called by IPython when this module is loaded as an IPython extension."""
+    # Import here to avoid circular imports.
+    import bigframes.magics
+
+    if ipython is not None:
+        bigframes.magics.load_ipython_extension(ipython)
+
+
+# Automatically load the extension, to make the magics easier to discover.
+load_ipython_extension(IPython.get_ipython())
+
 
 __all__ = [
     "options",

--- a/bigframes/magics.py
+++ b/bigframes/magics.py
@@ -12,14 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import bigquery_magics  # type: ignore
+import bigquery_magics.config  # type: ignore
+
 
 def load_ipython_extension(ipython):
     """Called by IPython when this module is loaded as an IPython extension."""
-    # Import here to avoid circular imports.
-    import bigquery_magics
-
     bigquery_magics.load_ipython_extension(ipython)
 
     if bigquery_magics.context.credentials is not None:
-        # TODO: warning about possible breaking changes.
+        # The %%bigquery magics must have been run before BigQuery DataFrames
+        # was imported. In this case, we don't want to break any existing
+        # notebooks, so don't make any BigQuery DataFrames changes to the
+        # magics.
+        return
+
+    bigquery_magics.context = Context()
+
+
+class Context(bigquery_magics.config.Context):
+    """A provider for bigquery-magics configuration, derived from bigframes
+    global options and global default session.
+    """
+
+    def __init__(self):
         pass

--- a/bigframes/magics.py
+++ b/bigframes/magics.py
@@ -1,0 +1,25 @@
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+def load_ipython_extension(ipython):
+    """Called by IPython when this module is loaded as an IPython extension."""
+    # Import here to avoid circular imports.
+    import bigquery_magics
+
+    bigquery_magics.load_ipython_extension(ipython)
+
+    if bigquery_magics.context.credentials is not None:
+        # TODO: warning about possible breaking changes.
+        pass

--- a/notebooks/getting_started/bq_dataframes_template.ipynb
+++ b/notebooks/getting_started/bq_dataframes_template.ipynb
@@ -1,1848 +1,765 @@
 {
-  "cells": [
-    {
-      "cell_type": "code",
-      "execution_count": 1,
-      "metadata": {
-        "id": "ur8xi4C7S06n"
-      },
-      "outputs": [],
-      "source": [
-        "# Copyright 2023 Google LLC\n",
-        "#\n",
-        "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
-        "# you may not use this file except in compliance with the License.\n",
-        "# You may obtain a copy of the License at\n",
-        "#\n",
-        "#     https://www.apache.org/licenses/LICENSE-2.0\n",
-        "#\n",
-        "# Unless required by applicable law or agreed to in writing, software\n",
-        "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
-        "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
-        "# See the License for the specific language governing permissions and\n",
-        "# limitations under the License."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "JAPoU8Sm5E6e"
-      },
-      "source": [
-        "# Get started with BigQuery DataFrames\n",
-        "\n",
-        "<table align=\"left\">\n",
-        "\n",
-        "  <td>\n",
-        "    <a href=\"https://colab.research.google.com/github/googleapis/python-bigquery-dataframes/blob/main/notebooks/getting_started/bq_dataframes_template.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://github.com/googleapis/python-bigquery-dataframes/blob/main/notebooks/getting_started/bq_dataframes_template.ipynb\">\n",
-        "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
-        "      View on GitHub\n",
-        "    </a>\n",
-        "  </td>\n",
-        "  <td>\n",
-        "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/googleapis/python-bigquery-dataframes/blob/main/notebooks/getting_started/bq_dataframes_template.ipynb\">\n",
-        "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
-        "      Open in Vertex AI Workbench\n",
-        "    </a>\n",
-        "  </td>                                                                                               \n",
-        "</table>"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "24743cf4a1e1"
-      },
-      "source": [
-        "**_NOTE_**: This notebook has been tested in the following environment:\n",
-        "\n",
-        "* Python version = 3.10"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "tvgnzT1CKxrO"
-      },
-      "source": [
-        "## Overview\n",
-        "\n",
-        "BigQuery DataFrames (also known as BigFrames) provides a Pythonic DataFrame and machine learning (ML) API powered by the BigQuery engine.\n",
-        "\n",
-        "* `bigframes.pandas` provides a pandas-like API for analytics.\n",
-        "* `bigframes.ml` provides a scikit-learn-like API for ML.\n",
-        "* `bigframes.ml.llm` provides API for large language models including Gemini.\n",
-        "\n",
-        "You can learn more about [BigQuery DataFrames](https://cloud.google.com/bigquery/docs/bigquery-dataframes-introduction) and its [API reference](https://cloud.google.com/python/docs/reference/bigframes/latest).\n",
-        "\n",
-        "For any issues or feedback please reach out to bigframes-feedback@google.com."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "BF1j6f9HApxa"
-      },
-      "source": [
-        "## Before you begin\n",
-        "\n",
-        "Complete the tasks in this section to set up your environment."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "Yq7zKYWelRQP"
-      },
-      "source": [
-        "### Install the python package\n",
-        "\n",
-        "You need the [bigframes](https://pypi.org/project/bigframes/) python package to be installed. If you don't have that, uncomment and run the following cell and *restart the kernel*."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "#%pip install  --upgrade"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "WReHDGG5g0XY"
-      },
-      "source": [
-        "### Set your project id and location\n",
-        "\n",
-        "Following are some quick references:\n",
-        "\n",
-        "* Google Cloud Project: https://cloud.google.com/resource-manager/docs/creating-managing-projects.\n",
-        "* BigQuery Location: https://cloud.google.com/bigquery/docs/locations."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 2,
-      "metadata": {
-        "id": "oM1iC_MfAts1"
-      },
-      "outputs": [],
-      "source": [
-        "PROJECT_ID = \"\"  # @param {type: \"string\"}\n",
-        "LOCATION = \"US\"  # @param {type: \"string\"}"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "960505627ddf"
-      },
-      "source": [
-        "### Import library"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 3,
-      "metadata": {
-        "id": "PyQmSRbKA8r-"
-      },
-      "outputs": [],
-      "source": [
-        "import bigframes.pandas as bpd"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "init_aip:mbsdk,all"
-      },
-      "source": [
-        "\n",
-        "### Set BigQuery DataFrames options"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 4,
-      "metadata": {
-        "id": "NPPMuw2PXGeo"
-      },
-      "outputs": [],
-      "source": [
-        "# Note: The project option is not required in all environments.\n",
-        "# On BigQuery Studio, the project ID is automatically detected.\n",
-        "bpd.options.bigquery.project = PROJECT_ID\n",
-        "\n",
-        "# Note: The location option is not required.\n",
-        "# It defaults to the location of the first table or query\n",
-        "# passed to read_gbq(). For APIs where a location can't be\n",
-        "# auto-detected, the location defaults to the \"US\" location.\n",
-        "bpd.options.bigquery.location = LOCATION\n",
-        "\n",
-        "# Note: BigQuery DataFrames objects are by default fully ordered like Pandas.\n",
-        "# If ordering is not important for you, you can uncomment the following\n",
-        "# expression to run BigQuery DataFrames in partial ordering mode.\n",
-        "#bpd.options.bigquery.ordering_mode = \"partial\""
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "pDfrKwMKE_dK"
-      },
-      "source": [
-        "If you want to reset the project and/or location of the created DataFrame or Series objects, reset the session by executing `bpd.close_session()`. After that, you can redo the above steps."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "9EMAqR37AfLS"
-      },
-      "source": [
-        "## Create a BigQuery DataFrames DataFrame\n",
-        "\n",
-        "You can create a BigQuery DataFrames DataFrame by reading data from any of the\n",
-        "following locations:\n",
-        "\n",
-        "* A local data file\n",
-        "* Data stored in a BigQuery table\n",
-        "* A data file stored in Cloud Storage\n",
-        "* An in-memory pandas DataFrame\n",
-        "\n",
-        "Note that the DataFrame does not copy the data to the local memory, instead\n",
-        "keeps the underlying data in a BigQuery table during read and analysis. That's\n",
-        "how it can handle really large size of data (at BigQuery Scale) independent of\n",
-        "the local memory.\n",
-        "\n",
-        "For simplicity, speed and cost efficiency, this tutorial uses the\n",
-        "[`penguins`](https://pantheon.corp.google.com/bigquery?ws=!1m5!1m4!4m3!1sbigquery-public-data!2sml_datasets!3spenguins)\n",
-        "table from BigQuery public data, which contains 27 KB data about a set of\n",
-        "penguins - species, island of residence, culmen length and depth, flipper length\n",
-        "and sex. There is a version of this data in the Cloud Storage\n",
-        "[cloud samples data](https://pantheon.corp.google.com/storage/browser/_details/cloud-samples-data/vertex-ai/bigframe/penguins.csv)\n",
-        "as well."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 5,
-      "metadata": {
-        "id": "Vyex9BQI-BNa"
-      },
-      "outputs": [],
-      "source": [
-        "# This is how you read a BigQuery table\n",
-        "df = bpd.read_gbq(\"bigquery-public-data.ml_datasets.penguins\")\n",
-        "\n",
-        "# This is how you would read a csv from the Cloud Storage\n",
-        "#df = bpd.read_csv(\"gs://cloud-samples-data/vertex-ai/bigframe/penguins.csv\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "We can use `peek` to preview a few rows (selected arbitrarily) from the dataframes:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 23,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "Query job bbb5d053-39a1-4542-83e1-f8c86ba93e0e is DONE. 28.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:bbb5d053-39a1-4542-83e1-f8c86ba93e0e&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job 099f1e48-07b6-481d-95af-e6d6811a54f4 is DONE. 31.7 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:099f1e48-07b6-481d-95af-e6d6811a54f4&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>species</th>\n",
-              "      <th>island</th>\n",
-              "      <th>culmen_length_mm</th>\n",
-              "      <th>culmen_depth_mm</th>\n",
-              "      <th>flipper_length_mm</th>\n",
-              "      <th>body_mass_g</th>\n",
-              "      <th>sex</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>104</th>\n",
-              "      <td>Chinstrap penguin (Pygoscelis antarctica)</td>\n",
-              "      <td>Dream</td>\n",
-              "      <td>52.7</td>\n",
-              "      <td>19.8</td>\n",
-              "      <td>197.0</td>\n",
-              "      <td>3725.0</td>\n",
-              "      <td>MALE</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>271</th>\n",
-              "      <td>Gentoo penguin (Pygoscelis papua)</td>\n",
-              "      <td>Biscoe</td>\n",
-              "      <td>59.6</td>\n",
-              "      <td>17.0</td>\n",
-              "      <td>230.0</td>\n",
-              "      <td>6050.0</td>\n",
-              "      <td>MALE</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>146</th>\n",
-              "      <td>Gentoo penguin (Pygoscelis papua)</td>\n",
-              "      <td>Biscoe</td>\n",
-              "      <td>46.6</td>\n",
-              "      <td>14.2</td>\n",
-              "      <td>210.0</td>\n",
-              "      <td>4850.0</td>\n",
-              "      <td>FEMALE</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>278</th>\n",
-              "      <td>Adelie Penguin (Pygoscelis adeliae)</td>\n",
-              "      <td>Torgersen</td>\n",
-              "      <td>44.1</td>\n",
-              "      <td>18.0</td>\n",
-              "      <td>210.0</td>\n",
-              "      <td>4000.0</td>\n",
-              "      <td>MALE</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>337</th>\n",
-              "      <td>Adelie Penguin (Pygoscelis adeliae)</td>\n",
-              "      <td>Biscoe</td>\n",
-              "      <td>38.2</td>\n",
-              "      <td>20.0</td>\n",
-              "      <td>190.0</td>\n",
-              "      <td>3900.0</td>\n",
-              "      <td>MALE</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>"
-            ],
-            "text/plain": [
-              "                                       species     island  culmen_length_mm  \\\n",
-              "104  Chinstrap penguin (Pygoscelis antarctica)      Dream              52.7   \n",
-              "271          Gentoo penguin (Pygoscelis papua)     Biscoe              59.6   \n",
-              "146          Gentoo penguin (Pygoscelis papua)     Biscoe              46.6   \n",
-              "278        Adelie Penguin (Pygoscelis adeliae)  Torgersen              44.1   \n",
-              "337        Adelie Penguin (Pygoscelis adeliae)     Biscoe              38.2   \n",
-              "\n",
-              "     culmen_depth_mm  flipper_length_mm  body_mass_g     sex  \n",
-              "104             19.8              197.0       3725.0    MALE  \n",
-              "271             17.0              230.0       6050.0    MALE  \n",
-              "146             14.2              210.0       4850.0  FEMALE  \n",
-              "278             18.0              210.0       4000.0    MALE  \n",
-              "337             20.0              190.0       3900.0    MALE  "
-            ]
-          },
-          "execution_count": 23,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "df.peek()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "gE6CEALjDZZV"
-      },
-      "source": [
-        "We just created a DataFrame, `df`, refering to the entirety of the source table data, without downloading it to the local machine."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "rwPLjqW2Ajzh"
-      },
-      "source": [
-        "## Inspect and manipulate data in BigQuery DataFrames"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "bExmYlL_ELtV"
-      },
-      "source": [
-        "### Using pandas API\n",
-        "\n",
-        "You can use pandas API on the BigQuery DataFrames DataFrame as you normally would in Pandas, but computation happens in the BigQuery query engine instead of your local environment."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "EJIZJaNXFQzh"
-      },
-      "source": [
-        "Let's compute the mean of the `body_mass_g` series:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 24,
-      "metadata": {
-        "id": "YKwCW7Nsavap"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "Query job 747e82a9-d9f9-4448-ab8c-a8ea75e6417d is DONE. 2.7 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:747e82a9-d9f9-4448-ab8c-a8ea75e6417d&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "average_body_mass: 4201.75438596491\n"
-          ]
-        }
-      ],
-      "source": [
-        "average_body_mass = df[\"body_mass_g\"].mean()\n",
-        "print(f\"average_body_mass: {average_body_mass}\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "DSs1cnca-MOU"
-      },
-      "source": [
-        "Calculate the mean `body_mass_g` by `species` using the `groupby` operation:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 25,
-      "metadata": {
-        "id": "4PyKMR61-Mjy"
-      },
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "Query job 505bd504-f1fb-4d23-bad4-5f9f69164fec is DONE. 15.6 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:505bd504-f1fb-4d23-bad4-5f9f69164fec&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job 4fb709da-21b5-462e-8df5-394e14470f89 is DONE. 163 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:4fb709da-21b5-462e-8df5-394e14470f89&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>body_mass_g</th>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>species</th>\n",
-              "      <th></th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>Adelie Penguin (Pygoscelis adeliae)</th>\n",
-              "      <td>3700.662252</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>Chinstrap penguin (Pygoscelis antarctica)</th>\n",
-              "      <td>3733.088235</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>Gentoo penguin (Pygoscelis papua)</th>\n",
-              "      <td>5076.01626</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "<p>3 rows × 1 columns</p>\n",
-              "</div>[3 rows x 1 columns in total]"
-            ],
-            "text/plain": [
-              "                                           body_mass_g\n",
-              "species                                               \n",
-              "Adelie Penguin (Pygoscelis adeliae)        3700.662252\n",
-              "Chinstrap penguin (Pygoscelis antarctica)  3733.088235\n",
-              "Gentoo penguin (Pygoscelis papua)           5076.01626\n",
-              "\n",
-              "[3 rows x 1 columns]"
-            ]
-          },
-          "execution_count": 25,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "df[[\"species\", \"body_mass_g\"]].groupby(by=df[\"species\"]).mean(numeric_only=True)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "6sf9kZ2C9Ixe"
-      },
-      "source": [
-        "You can confirm that the calculations were run in BigQuery by clicking \"Open job\" from the previous cells' output. This takes you to the BigQuery console to view the SQL statement and job details."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Visualize data"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### First party visualizations\n",
-        "\n",
-        "BigQuery DataFrames provides a number of visualizations via the `plot` method and [accessor](https://cloud.google.com/python/docs/reference/bigframes/latest/bigframes.operations.plotting.PlotAccessor) on the DataFrame and Series objects."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 50,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "Query job 33027eda-7ca4-4b39-8618-b211d8fe3ee8 is DONE. 28.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:33027eda-7ca4-4b39-8618-b211d8fe3ee8&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/plain": [
-              "<Axes: title={'center': 'Numeric features'}>"
-            ]
-          },
-          "execution_count": 50,
-          "metadata": {},
-          "output_type": "execute_result"
-        },
-        {
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjAAAAGzCAYAAAAxPS2EAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/H5lhTAAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOxdd5gURfp+u3tmNu+SliVIjiuKCihiROXEO/SUUzHCqZhBRU9RPANnBrNi5E5QfpjvxASY8TwjYjgEBURgyXHZvDsz3f37Y7qqq6qre3pmZ5eF6/d5eNiZ6a6uTlVfvd/7fZ9imqaJAAECBAgQIECAvQjqnu5AgAABAgQIECBAqggMmAABAgQIECDAXofAgAkQIECAAAEC7HUIDJgAAQIECBAgwF6HwIAJECBAgAABAux1CAyYAAECBAgQIMBeh8CACRAgQIAAAQLsdQgMmAABAgQIECDAXofAgAkQIECAAAEC7HUIDJgAAQLsUSiKgqlTp2akrerqalx88cXo0KEDFEXBpEmTMtJugAABWh4CAyZAgBaM2bNnQ1EUZGdnY+PGjY7fhw8fjgMOOGAP9Kxl4p577sHs2bNxxRVXYM6cORg7dmyTHOfJJ5/E7Nmzm6TtAAEC+ENoT3cgQIAAydHQ0ID77rsPjz/++J7uSsZRV1eHUCgzQ9HHH3+Mww8/HLfffntG2nPDk08+iXbt2uGCCy5o0uMECBDAHQEDEyDAXoCDDz4YM2fOxKZNm/Z0VzICwzBQX18PAMjOzs6YAbNt2za0atUqI201N0zTRF1d3Z7uRoAAew0CAyZAgL0AN998M3Rdx3333ee53dq1a6EoitS9IWpNpk6dCkVRsHLlSpx//vkoKipCcXExbr31VpimifXr1+PUU09FYWEhOnTogAcffNDRZkNDA26//Xb07t0bWVlZ6NKlCyZPnoyGhgbHsSdOnIi5c+diwIAByMrKwsKFC6X9AoCNGzdi/Pjx6NSpE7KystCjRw9cccUViEaj0vNetGgRFEXBmjVr8O6770JRFCiKgrVr16bUz1mzZuH4449H+/btkZWVhf333x9PPfUUt0337t2xbNkyfPrpp/Q4w4cP566pCOIKJP0h7Zx88sl47733MGTIEOTk5OCZZ54BAOzevRuTJk1Cly5dkJWVhd69e2PatGkwDINr9+WXX8bgwYNRUFCAwsJCHHjggXj00Uel1yhAgH0NgQspQIC9AD169MC4ceMwc+ZM3HTTTejUqVPG2j7rrLNQWlqK++67D++++y7uuusutGnTBs888wyOP/54TJs2DXPnzsX111+PQw89FMcccwyABIvyxz/+Ef/5z39w6aWXorS0FEuXLsXDDz+MlStXYt68edxxPv74Y7z66quYOHEi2rVrh+7du0v7s2nTJhx22GHYvXs3Lr30UvTv3x8bN27E66+/jtraWkQiEcc+paWlmDNnDq699lrst99++Mtf/gIAKC4uTqmfTz31FAYMGIA//vGPCIVCePvtt3HllVfCMAxMmDABAPDII4/gqquuQn5+Pv76178CAEpKStK69itWrMA555yDyy67DJdccgn69euH2tpaHHvssdi4cSMuu+wydO3aFV988QWmTJmCzZs345FHHgEAfPDBBzjnnHNwwgknYNq0aQCAn3/+GZ9//jmuueaatPoTIMBeBTNAgAAtFrNmzTIBmIsXLzZXr15thkIh8+qrr6a/H3vsseaAAQPo5zVr1pgAzFmzZjnaAmDefvvt9PPtt99uAjAvvfRS+l08Hjf3228/U1EU87777qPfl5eXmzk5Oeaf//xn+t2cOXNMVVXNzz77jDvO008/bQIwP//8c+7Yqqqay5YtS9qvcePGmaqqmosXL3ZsaxiG4zsW3bp1M0eNGsV9l0o/a2trHW2OHDnS7NmzJ/fdgAEDzGOPPdaxLbmmIsh9XLNmDddXAObChQu5be+8804zLy/PXLlyJff9TTfdZGqaZpaVlZmmaZrXXHONWVhYaMbjccfxAgT4X0DgQgoQYC9Bz549MXbsWDz77LPYvHlzxtq9+OKL6d+apmHIkCEwTRPjx4+n37dq1Qr9+vXDb7/9Rr977bXXUFpaiv79+2PHjh303/HHHw8A+OSTT7jjHHvssdh///09+2IYBubNm4dTTjkFQ4YMcfwuc88kQyr9zMnJoX9XVFRgx44dOPbYY/Hbb7+hoqIi5WMnQ48ePTBy5EhHf48++mi0bt2a6++IESOg6zr+/e9/A0jck5qaGnzwwQcZ71eAAHsDAhdSgAB7EW655RbMmTMH9913X8a0Dl27duU+FxUVITs7G+3atXN8v3PnTvp51apV+Pnnn1FcXCxtd9u2bdznHj16JO3L9u3bUVlZmdHQ8FT6+fnnn+P222/Hl19+idraWm67iooKFBUVZaxfgPyarFq1Cv/973+T9vfKK6/Eq6++it///vfo3LkzTjzxRIwZMwYnnXRSRvsYIEBLRWDABAiwF6Fnz544//zz8eyzz+Kmm25y/O7GUOi67tqmpmm+vgMSkTIEhmHgwAMPxEMPPSTdtkuXLtxnlt1oTvjt5+rVq3HCCSegf//+eOihh9ClSxdEIhHMnz8fDz/8sENAK0Oq1192TQzDwO9+9ztMnjxZuk/fvn0BAO3bt8cPP/yA9957DwsWLMCCBQswa9YsjBs3Ds8//3zSvgYIsLcjMGACBNjLcMstt+D//u//qHCTRevWrQEkolhYrFu3LuP96NWrF3788UeccMIJabl2ZCguLkZhYSF++umnjLQH+O/n22+/jYaGBrz11lscKyW6wgB3Q4W9/mw4dyrXv1evXqiursaIESOSbhuJRHDKKafglFNOgWEYuPLKK/HMM8/g1ltvRe/evX0fM0CAvRGBBiZAgL0MvXr1wvnnn49nnnkGW7Zs4X4rLCxEu3btqE6C4Mknn8x4P8aMGYONGzdi5syZjt/q6upQU1OTcpuqquK0007D22+/jW+//dbxO8sAZbqfhHVij1FRUYFZs2Y59svLy3MYiUDi3gDgrn9NTU1KjMiYMWPw5Zdf4r333nP8tnv3bsTjcQDg3HlA4toNHDgQABzh4QEC7IsIGJgAAfZC/PWvf8WcOXOwYsUKDBgwgPvt4osvxn333YeLL74YQ4YMwb///W+sXLky430YO3YsXn31VVx++eX45JNPcOSRR0LXdfzyyy949dVXaX6TVHHPPffg/fffx7HHHkvDnjdv3ozXXnsN//nPf1JOVOe3nyeeeCJlNC677DJUV1dj5syZaN++vUM0PXjwYDz11FO466670Lt3b7Rv3x7HH388TjzxRHTt2hXjx4/HDTfcAE3T8Nxzz6G4uBhlZWW++nvDDTfgrbfewsknn4wLLrgAgwcPRk1NDZYuXYrXX38da9euRbt27XDxxRdj165dOP7447Hffvth3bp1ePzxx3HwwQejtLQ0pWsUIMBeiT0bBBUgQAAvsGHUIv785z+bALgwatNMhAKPHz/eLCoqMgsKCswxY8aY27Ztcw2j3r59u6PdvLw8x/HEkG3TNM1oNGpOmzbNHDBggJmVlWW2bt3aHDx4sPm3v/3NrKiooNsBMCdMmCA9R7Ffpmma69atM8eNG2cWFxebWVlZZs+ePc0JEyaYDQ0N0jYIZGHUqfTzrbfeMgcOHGhmZ2eb3bt3N6dNm2Y+99xzjhDoLVu2mKNGjTILCgpMAFxI9ZIlS8yhQ4eakUjE7Nq1q/nQQw+5hlHL+mqapllVVWVOmTLF7N27txmJRMx27dqZRxxxhPnAAw+Y0WjUNE3TfP31180TTzzRbN++PT3WZZddZm7evNnzGgUIsK9AMc00ONkAAQIECBAgQIA9iEADEyBAgAABAgTY6xAYMAECBAgQIECAvQ6BARMgQIAAAQIE2OsQGDABAgQIECBAgL0OgQETIECAAAECBNjrEBgwAQIECBAgQIC9DvtsIjvDMLBp0yYUFBRkLM15gAABAgQIEKBpYZomqqqq0KlTJ6iqO8+yzxowmzZtchSTCxAgQIAAAQLsHVi/fj32228/19/3WQOmoKAAQOICFBYW7uHeBAgQIECAAAH8oLKyEl26dKHzuBv2WQOGuI0KCwsDAyZAgAABAgTYy5BM/hGIeAMECBAgQIAAex0CAyZAgAABAgQIsNchMGACBAgQIECAAHsd9lkNTIAAAQLszdB1HbFYbE93I0CAjEPTNIRCoUanOAkMmAABAgRoYaiursaGDRtgmuae7kqAAE2C3NxcdOzYEZFIJO02AgMmQIAAAVoQdF3Hhg0bkJubi+Li4iARZ4B9CqZpIhqNYvv27VizZg369OnjmazOC4EBEyBAgAAtCLFYDKZpori4GDk5OXu6OwECZBw5OTkIh8NYt24dotEosrOz02onEPEGCBAgQAtEwLwE2JeRLuvCtZGBfgQIECBAgAABAjQrAgMmQIAAAQIECLDXITBgAgQIECDAHsfs2bPRqlWrPd2NpBg+fDgmTZq0p7sBAFi0aBEURcHu3bv3dFf2CAIDJkCAAAECBGjhaEmGU0tBYMC0AMQ2bcLOv/8demXlnu5KgAABAgQIsFcgMGBaAHb+4zlse+BBVLz51p7uSoAAAVoYTNNEbTS+R/6lmkjPMAxMnz4dvXv3RlZWFrp27Yq7775b6ur44YcfoCgK1q5dK21r6tSpOPjgg/Hcc8+ha9euyM/Px5VXXgld1zF9+nR06NAB7du3x913383tt3v3blx88cUoLi5GYWEhjj/+ePz444+OdufMmYPu3bujqKgIZ599NqqqqlI6V4KGhgZcf/316Ny5M/Ly8jB06FAsWrSI/k5cY++99x5KS0uRn5+Pk046CZs3b6bbxONxXH311WjVqhXatm2LG2+8EX/+859x2mmnAQAuuOACfPrpp3j00UehKIrjui1ZsgRDhgxBbm4ujjjiCKxYscJX39O9xoqi4JlnnsHJJ5+M3NxclJaW4ssvv8Svv/6K4cOHIy8vD0cccQRWr16d1jX1iyAPTAuAUZ14cYyamj3ckwABArQ01MV07H/be3vk2MvvGInciP9pYsqUKZg5cyYefvhhHHXUUdi8eTN++eWXtI+/evVqLFiwAAsXLsTq1atxxhln4LfffkPfvn3x6aef4osvvsBFF12EESNGYOjQoQCAM888Ezk5OViwYAGKiorwzDPP4IQTTsDKlSvRpk0b2u68efPwzjvvoLy8HGPGjMF9993nmKj9YOLEiVi+fDlefvlldOrUCW+88QZOOukkLF26FH369AEA1NbW4oEHHsCcOXOgqirOP/98XH/99Zg7dy4AYNq0aZg7dy5mzZqF0tJSPProo5g3bx6OO+44AMCjjz6KlStX4oADDsAdd9wBACguLqZGzF//+lc8+OCDKC4uxuWXX46LLroIn3/+eZNdYwC488478dBDD+Ghhx7CjTfeiHPPPRc9e/bElClT0LVrV1x00UWYOHEiFixYkPI19YvAgGkBMA3T+l/fwz0JECBAgPRQVVWFRx99FDNmzMCf//xnAECvXr1w1FFHcYxEKjAMA8899xwKCgqw//7747jjjsOKFSswf/58qKqKfv36Ydq0afjkk08wdOhQ/Oc//8E333yDbdu2ISsrCwDwwAMPYN68eXj99ddx6aWX0nZnz56NgoICAMDYsWPx0UcfpWzAlJWVYdasWSgrK0OnTp0AANdffz0WLlyIWbNm4Z577gGQSE749NNPo1evXgASRg8xRADg8ccfx5QpUzB69GgAwIwZMzB//nz6e1FRESKRCHJzc9GhQwdHP+6++24ce+yxAICbbroJo0aNQn19va8EcaleY4ILL7wQY8aMAQDceOONGDZsGG699VaMHDkSAHDNNdfgwgsv9H8x00BgwLQE6JbhYgR1TwIECMAjJ6xh+R0j99ix/eLnn39GQ0MDTjjhhIwdv3v37tTIAICSkhJomsYlQSspKcG2bdsAAD/++COqq6vRtm1brp26ujrOnSG227FjR9pGKli6dCl0XUffvn257xsaGrg+5ObmUuNFPF5FRQW2bt2Kww47jP6uaRoGDx4MwzB89WPgwIFc2wCwbds2dO3aNem+qV5j2TFLSkoAAAceeCD3XX19PSorK1FYWOjrPFJFYMC0AJim9ZAGDEyAAAEEKIqSkhtnT8Gr7AGZDFlNjZ9K2+FwmPusKIr0OzLRV1dXo2PHjlLGhw3R9mojFVRXV0PTNCxZsgSaxht7+fn5nsfLZKFOtn2Swdnv+aR6jb2O2Zh+pIOW/1b8L0BP3GBTb7obHSBAgABNiT59+iAnJwcfffQRLr74Yu634uJiAMDmzZvRunVrAAkRb6YxaNAgbNmyBaFQCN27d894+yIOOeQQ6LqObdu24eijj06rjaKiIpSUlGDx4sU45phjACQKen733Xc4+OCD6XaRSAS6HixyWQQGTAsA1b40oaUaIECAAE2J7Oxs3HjjjZg8eTIikQiOPPJIbN++HcuWLcO4cePQpUsXTJ06FXfffTdWrlyJBx98MON9GDFiBIYNG4bTTjsN06dPR9++fbFp0ya8++67GD16NIYMGZLR4/Xt2xfnnXcexo0bhwcffBCHHHIItm/fjo8++ggDBw7EqFGjfLVz1VVX4d5770Xv3r3Rv39/PP744ygvL+fqYXXv3h1ff/011q5di/z8fCpI/l9GEEbdEhCIeAMECLAP4NZbb8Vf/vIX3HbbbSgtLcVZZ52Fbdu2IRwO46WXXsIvv/yCgQMHYtq0abjrrrsyfnxFUTB//nwcc8wxuPDCC9G3b1+cffbZWLduHdVpZBqzZs3CuHHj8Je//AX9+vXDaaedhsWLF/vSnxDceOONOOecczBu3DgMGzYM+fn5GDlyJCfCvf7666FpGvbff38UFxejrKysKU5nr4JiZtIR14JQWVmJoqIiVFRUNJmAKFNYf9nlqP70U7S58EKU3Dh5T3cnQIAAexD19fVYs2YNevTo4SuKJMC+B8MwUFpaijFjxuDOO+/c091pEng9537n78CF1AIQiHgDBAgQ4H8X69atw/vvv49jjz0WDQ0NmDFjBtasWYNzzz13T3etRSNwIbUEEBFvEEYdIECAAHsMZWVlyM/Pd/3XVG4bVVUxe/ZsHHrooTjyyCOxdOlSfPjhhygtLW1UuwMGDHA9F5JEb29GwMC0AFDtS6AwDxAgQIA9hk6dOnlGR5FkdZlGly5dfGfOTQXz5893DVdvKk1QcyIwYFoCiIjXDKKQAgQIECAVGLEYlFCIi9hJF6FQCL17985Ar1oGunXrtqe70KRI2YW0ceNGnH/++Wjbti1ycnJw4IEH4ttvv6W/m6aJ2267DR07dkROTg5GjBiBVatWcW3s2rUL5513HgoLC9GqVSuMHz8e1dXV3Db//e9/cfTRRyM7OxtdunTB9OnT0zzFvQCEeQnywAQIECCAb+g1NWhYsQLxrVv3dFcC7AGkZMCUl5fjyCOPRDgcxoIFC7B8+XI8+OCDNDERAEyfPh2PPfYYnn76aXz99dfIy8vDyJEjUV9fT7c577zzsGzZMnzwwQd455138O9//5vWqAASCuQTTzwR3bp1w5IlS3D//fdj6tSpePbZZzNwyi0PJsn/EjAwAQIECOAbZkMD93+A/y2k5EKaNm0aunTpglmzZtHvevToQf82TROPPPIIbrnlFpx66qkAgBdeeAElJSWYN28ezj77bPz8889YuHAhFi9eTJMKPf744/jDH/6ABx54AJ06dcLcuXMRjUbx3HPPIRKJYMCAAfjhhx/w0EMPcYbO3oi6pUvRsOpXtPrTaPtLI8jEG+B/E9Wffw6zrg4FI0bs6a4E2BthEvd7EADxv4iUGJi33noLQ4YMwZlnnon27dvjkEMOwcyZM+nva9aswZYtWzCCGYyKioowdOhQfPnllwCAL7/8Eq1ateIyIo4YMQKqquLrr7+m2xxzzDGIRCJ0m5EjR2LFihUoLy+X9q2hoQGVlZXcv5aItWeOweabb0aNdT0AhoEJMvEG+B+CaZrYeNXV2HDNJOiCCzlAgJQQGDD/k0jJgPntt9/w1FNPoU+fPnjvvfdwxRVX4Oqrr8bzzz8PANiyZQsAp7q5pKSE/rZlyxa0b9+e+z0UCqFNmzbcNrI22GOIuPfee1FUVET/denSJZVTa3Y0sLogwsAEeWAC/C/BMGDU1gK6DrOubk/3JsDeCGK4BAbM/yRSMmAMw8CgQYNwzz334JBDDsGll16KSy65BE8//XRT9c83pkyZgoqKCvpv/fr1e7pLnjDjtrFih1EHDEyAlostd9yBzbfdnrkGdfYd2Pee/d3//BfWXXgh9BbKBrc0zJ49m6sYnRL2sAEzfPhwTJo0qVmOpSgK5s2b1yzHaulIyYDp2LEj9t9/f+670tJSmtynQ4cOAICtgiJ869at9LcOHTpg27Zt3O/xeBy7du3itpG1wR5DRFZWFgoLC7l/LRmmHrc/6IGIN0DLhlFfj/IXX8LuV1/NmLvHZPMe7YMGTPkrr6D2y69Q++2SPd2VfRf7MAMzdepUrhp1ACdSMmCOPPJIrFixgvtu5cqVNNa8R48e6NChAz766CP6e2VlJb7++msMGzYMADBs2DDs3r0bS5bYL/XHH38MwzAwdOhQus2///1vLgHPBx98gH79+nERT3s1JIN3IOIN0FJhxm2D23RJjJVym+zzvg8aMGbcuk6Ba7jJQM2WfdCACZAcKRkw1157Lb766ivcc889+PXXX/Hiiy/i2WefxYQJEwAkqK1JkybhrrvuwltvvYWlS5di3Lhx6NSpE0477TQACcbmpJNOwiWXXIJvvvkGn3/+OSZOnIizzz6bZjk899xzEYlEMH78eCxbtgyvvPIKHn30UVx33XWZPfs9CN6FFIh4A7RwsAZMNDMGDDux74suJFjveKMXJqYJRGv2zL8UDQPDMDB9+nT07t0bWVlZ6Nq1K+6++24sWrQIiqJg9+7ddNsffvgBiqJg7dq10rYIA/Hcc8+ha9euyM/Px5VXXgld1zF9+nR06NABnUtLMe3ZZ7kopN27d+Piiy9GcXExCgsLcfzxx+PHH390tDtnzhx0794dRUVFOPvss1FVVeXrHGtqajBu3Djk5+ejY8eOePDBBx3bNDQ04Prrr0fnzp2Rl5eHoUOHYtGiRfR34i6bN28e+vTpg+zsbIwcOZJKH2bPno2//e1v+PHHH6EoChRFwezZs+n+O3bswOjRo5Gbm4s+ffrgrbfe8tV3ch/ee+89HHLIIcjJycHxxx+Pbdu2YcGCBSgtLUVhYSHOPfdc1NbW0v2GDx+Oq666CpMmTULr1q1RUlKCmTNnoqamBhdeeCEKCgrQu3dvLFiwwFc/MoWUwqgPPfRQvPHGG5gyZQruuOMO9OjRA4888gjOO+88us3kyZNRU1ODSy+9FLt378ZRRx2FhQsXctUm586di4kTJ+KEE06Aqqo4/fTT8dhjj9Hfi4qK8P7772PChAkYPHgw2rVrh9tuu22vD6HmwK7KLDZmnxzEA+wTYN09mWNg9m0XEtW2NZaBidUC9zRNCvukuHkTEMnzvfmUKVMwc+ZMPPzwwzjqqKOwefNm/PLLL2kffvXq1ViwYAEWLlyI1atX44wzzsBvv/2Gvn374tNPP8VnCxfikkmTcPxRR+OYvn0BAGeeeSZycnKwYMECFBUV4ZlnnsEJJ5yAlStXok2bNrTdefPm4Z133kF5eTnGjBmD++67D3fffXfSPt1www349NNP8eabb6J9+/a4+eab8d1333HunokTJ2L58uV4+eWX0alTJ7zxxhs46aSTsHTpUvTp0wcAUFtbi7vvvhsvvPACIpEIrrzySpx99tn4/PPPcdZZZ+Gnn37CwoUL8eGHHwJIzIsEf/vb3zB9+nTcf//9ePzxx3Heeedh3bp19PySYerUqZgxYwZyc3MxZswYjBkzBllZWXjxxRdRXV2N0aNH4/HHH8eNN95I93n++ecxefJkfPPNN3jllVdwxRVX4I033sDo0aNx88034+GHH8bYsWNRVlaG3NxcX/1oNMx9FBUVFSYAs6KiYk93hcPyfv3N5f36m1sffIh+t+rEE83l/fqbZZdfsQd71ryoWLDQrFmyZE93I4BPRLdspc9u/W+/ZaTN2PbtdpurvduMV1WZO+fONWPbt2fk2M2BX0/6vbm8X39z99vvpLRfXV2duXz5crOuri7xRUO1ad5euGf+NVT77ndlZaWZlZVlzpw50/HbJ598YgIwy8vL6Xfff/+9CcBcs2aNaZqmOWvWLLOoqIj+fvvtt5u5ublmZWWlGa+uNuO7d5sjR440u3fvbuq6bpqmaUa3bDH7du9u3nHddaZpmuZnn31mFhYWmvX19dzxe/XqZT7zzDOOdgluuOEGc+jQoUnPsaqqyoxEIuarr75Kv9u5c6eZk5NjXnPNNaZpmua6detMTdPMjRs3cvuecMIJ5pQpU+i5AjC/+uor+vvPP/9sAjC//vpr2s+DDjrI0QcA5i233EI/V1dXmwDMBQsWJO0/uQ8ffvgh/e7ee+81AZirV6+m31122WXmyJEj6edjjz3WPOqoo+jneDxu5uXlmWPHjqXfbd682QRgfvnll0n7YZqS55yB3/k7qIW0hyAT8f6vhFHXr1yJjZZiv/SXn/dsZwL4A/u8Mu6kxoBzrSQRsFf86w1svecexNZvQMmNkzNy/KYGfZ8bK84P5yaYkD2BsP+V9M8//4yGhgaccMIJGTt89+7dUVBQgLqffgIAtC8uhqZpUFVb/dC+bVts37kTAPDjjz+iuroabdu25dqpq6vD6tWrHe0SdOzY0RFcIsPq1asRjUapXhMA2rRpg379+tHPS5cuha7r6GsxQgQNDQ1cv0KhEA499FD6uX///mjVqhV+/vlnHHbYYZ79GDhwIP07Ly8PhYWFvvov27+kpAS5ubno2bMn990333zjuo+maWjbti0OPPBAbh8AKfWjsQgMmD0FmYDR+N8QokXXrN3TXQiQIprChcQaRWaSSux6RUXi/8qKzBy7OUA1MI1cmChKSm6cPYWcnBzX34jBYTJaFbcqySzC4TC3j2KaCIfD9gamCUVRYFhjaHV1NTp27MjpTQjYEG2uDYBro7Gorq6GpmlYsmQJNE3jfsvPz8/IMRrbf3Z/RVF8tSfbRmwHQMauox+kXMwxQGZgynJgNHag20tgRoO6JXsbmiQKiR3okohFKWO5Fxn59nvdtAO6UV+PhjVroNfUNOlxkqFPnz7IycnholAJiouLAQCbN2+m3/3www/+GmafE7eK09bzM2jQIGzZsoVWlWb/tWvXzt/xPNCrVy+Ew2GaNR5I1AhcuXIl/XzIIYdA13Vs27YN3QoK0TUrC7169ULv3r25NCDxeJwrhLxixQrs3r0bpaWlAIBIJAL9f2ROSBcBA7OnwLmQrJXa/0gemKDw2l4I1uDOkAuJM9iTDdR6hgSxzQk9Qy6kZIeprIRRUwO9ogJa3p5jarKzs3HjjTdi8uTJiEQiOPLII7F9+3YsW7YM48aNQ5cuXTB16lTcfffdWLlypTR6RwqvFb1g+I4YMQLDhg3DaaedhunTp6Nv377YtGkT3n33XYwePZorYZMO8vPzMX78eNxwww1o27Yt2rdvj7/+9a+cS6tv374477zzMG7cONxzzTU4uH9/VKxZg08+/xwDBw7EqFGjACQYjauuugqPPfYYQqEQJk6ciMMPP5y6j7p37441a9bghx9+wH777YeCggJkZWU1qv/7GgIGZg+BC6MmL+FelAfGjMXSTmhmBAbMXoemjkIykzArZqZCkpsR5PyavM8tKJnbrbfeir/85S+47bbbUFpairPOOgvbtm1DOBzGSy+9hF9++QUDBw7EtGnTcNddd/lqk3UhJTtHRVEwf/58HHPMMbjwwgvRt29fnH322Vi3bp2jPE26uP/++3H00UfjlFNOwYgRI3DUUUdh8ODB3DazZs3C2PPPx5QHHsBBp5yCP511FhYvXoyuXbvSbXJzc3HjjTfi3HPPxZFHHon8/Hy88sor9PfTTz8dJ510Eo477jgUFxfjpZdeykj/9yUoptkCnvomQGVlJYqKilBRUdGisvL+3D9BDxad/id0skL2Vg47Anp5OXKHDEG3/5uzJ7vnG+vG/Rn1P/+M3h9/BI0Rw/nBzudmYdv06QACEe/egrqflmHtGWcAALrMfBb5Rx/d6DYbVq3Cb6f8EQDQ/bVXkcMIAkVsuecelL8wB4V/+D06P/RQo4/dHFh5+DDou3ejw+23ofU55/jer76+HmvWrEGPHj249BNuiG3ZiviO7dBatUZkv86N6XKLhFFfj4ZffwUARHr0hJZnC4tjmzYhvmsXACB7wACqw2gJMKJRNFiupaw+faAy7Mns2bMxadIkLi/O/xq8nnO/83fAwOwpMAyMXcxx71ld1q9YAaOqCrFNm5NvLIDVwOyj9vO+B72JNTDJXEiEgdkLNTBN/16bwv/7GDy0UtynljaWsM90S+vbPoLAgGlGsJO1VMS7FxkwVLeTxmTGuZAycM5GfT3KX3sNsa3NF76XDPEdO1D+6qsw9rCwMlPgXUgZCqNmhcHJXEjk+HuTqJGcn4sLqW7ZMlQuXNj446ToQjJiMcR37ZIaVnpV1R4XA4vwFHun4F7yg7KyMuTn57v+I3X//KDR0Wdp4PLLL3ft++WXX97s/WlqBCLe5gT7Iu7lmXipfz8WTX3fKLOPrgNCqGGqqFywEFtuvQ2tzjwTHe+8o1FtZQo7nn0W5S/MAXQ9JfdBS0VTRCG5vg+y41sM0F71jlAGRn5um66/AdE1a5D9wQBEunRptn5FV6+GGY/DbIgi3NGOijF1HdGyMiiKArW0tOW4Y7h77mGkZMCA6dSpk2d0FCl34wseDMwFF1yACy64ILXO+cAdd9yB66+/XvpbS5JSZAqBAdOcYF5EuYh3L1pdNoKBMRtsA8Y0TTR2mDSs3CAkV0hLgFHR8vrUKDRJHpgUaiGR92UvMmDo+bkwMLqlf9B3VwCNMWBSZGCIMapXVyEMxoAxDMA0E+ORabqHLDc3vFiWDDMwJPw6E9gTDEz79u3Rvn37Zj/unkLgQmpGuLmQ9sYwatr/NEJquTDqDLzkZgvMZEz7lOL5mYaBjTdMxo6ZM5uiWw7ULVuGsovGo375cu9+sQZ3GqybtM0UaiFRxq8F3eNkMJOEUdNzijfOIEx32naYJxk0BvTKSjSsXQsj2vhnxW++oJampzMDDUyTIzBgmhPsi8j5/5sn4VVG0RgGhhXxZkKUabbA62d4r77dEF27DpVvv42df/9HE3TKicp356Pmiy9QOX++53Zs6YtM5YFJqZij7q0naWkwTdMW57v0mV7Hxhrx6YZRiwxLBg2Y+M6dMKqrKRPZKLDMdRMzMBnF3sSo76UIDJjmBPsiygbvRtLjus9y8I0FuyJKT8TLrMoysKJukQxMPD3GgK7GM+CmMU0z6TNB7l9SYS77vDaBBiZZrhTKALWge+wJP/oey4DJWGLAxoJliBtpDBCWNSM5n1LI2NySwAnf96J+700IDJhmBMs2UFEiu1JrhAFT8c67WHnoYdj9rzca10k/iDduNc66kDLiJ26BDJaZJgNjr9obf1223n0PVg47AvVMmnMHaLK1JCJazoWUoTBqNpVAEvep7ULaOyYCaZShyzbcdUjrYKb1XwavTSPaMuNxOi5kIus2d88dDAzcf9vTCBiYJkdgwDQn2EGaDFrsS9cIA6b+5+XW/02fGK6xDAw3qGVi0CHXtSWtztNkhUyfBoUf1C9fDsTjiFpJwKTHM8jxkjEwTRGFlIqIN0PuluYCp3Fznptpmrbx2EgNTNrwciE1YixiWRezoaHxhhU7bjoM2JbrQuIN9JbVt30FgQHTnEhSwLFRLhDd2V5TgVuNRxuZByaTIt59goGxBrp4POnAH9+xAzufm4Udz85EdP16Zx/IKtirD8zxvNAkeWBSEfHGW1YYde1336P6s/+4/s5ec+l7HXfWQksbmSol0Eg9iWmauPTSS1G8337IPfBAdDziCFx/773U4O3evTseeeQRx356ZSWMujr3hj3zwLj0v5FQFAXz5s1rXCMu99WIxRAvL/f9LE+dOhUHH3xw4/qSJkzTRHz37hZb/iUIo25GcBOSbEBuBD2eyZV7UhiNcycYdbX2/pmYkKjbpYVoCYC0GRhHfqCQ+yu648knUf5ioj5K3ZIl6PLM09zvZGXvdV0oA5PEjdEULiSkYsC0oER2pmli3bnnAgD6fPZvhKxKyxyMJAxMExiEqU/gPAOTSs0hGRYuXIjZs2fjw9dfR5fCQpx33XWJphoagEgEixcvRp5QbNKoq0PUSg6Xc8AB0nY5xtcRc5U53U6mwUch2X/Gt26Fvns3FFWFVlTE7aMoCt544w2cdtppzdPJJDBqahDbsAFqQQGyunXb091xIGBgmhNcHpi447tGDc7NWK2XG3zT0cDU1dsfMmDApM12NCXS7BO3ck/yPMR3ldt/b9/u3IAYGl590H0af01RSoA7V38upJaQaoA9f92llg0/eUkMGFZH1ljDO92J2yPNSzrGwOrVq9GxY0cMHTgQHdq1Q8hKUElcxsXFxcjNzeX28WRe6EbuhlU6Rlc0A6HdfsC/v4yhRZnRPW+MJ0Uj0mU0BwIDpjkhMWC4QbwxwjmfK+mMoJFJzYx624DJiNvHGuBMQ0fF2+9gw1VXOVL4m9EoNlx7LcpfebXxx/MBv1FIpmli89/+hu1PPJH4gt0+mVuHGYiN2lrn7zHyjHm0Q46XCgOTqcHM8J7kueMnSQrXnDCZa61EIvKN2HdE1mf2Gia7z6aJ2lit6786vT7xL17nuZ1je72e/579zfrO75h0wQUX4KqrrkJZWRmye/RA/5EjaYZt4n4QXUiKouDpf/wDp15+OdoMGYKePXvi9ddfp7+vXbsWiqLg1Tfn4bjzz0frwYNx8DHH4NNPP+WOvWzVKpx6+eUo6tABJSUlGDt2LHbs2EF/Hz58OCZOnIhJkyahXbt2GDlypK9zYrF+/XqMGTMGrVq1Qps2bXDqqadi7dq13PmfdtppeOCBB9CxY0e0bdsWk+68AzEyPpomNm/ejFGjRqFV//4oPekkvPTaa9w16d69OwBg9OjRUBSFfiaYM2cOunfvjqKiIpx99tmo8hl1Onz4cFx11VWYNGkSWrdujZKSEsycORM1NTW48MILUVBQgN69e2PBggV0n0WLFkFRFLz34Yc4/Mwz0WrAABx//PHYtm0bFixYgNLSUhQWFuLcc89FrWTsaS4ELqRmBBeFRB5sSUmBtEAGyWZhYBop4mUf+EysqBm2Y9fzz6P+p59Qe+YS5B9zDN2kfvlyVC1YiPrly9H6rDGNP2YS+GWF9B07sPull4FQCMUTJvB0ebLIIObay1ayUpZP3MZnwr2mKCWQCtvUkhLZsQY4VPkakDNaJH3mWUzvc6qL12Hoi0P9de5Lf5tRfOHy/Q+J/74+92vkhnNdNrLx6KOPolevXnj22Wfx7zlzoKkqxk6ZAsD7eZl633244+qr8cBNN+G1r7/G2WefjaVLl6K0tJRuc9O99+L+G25A/169MOOVV3DKKadgzZo1aNu2LXZXVOAPF1+MP//pT3j4kUcQ1TTceOONGDNmDD7++GPaxvPPP48rrrgCn3/+edJzERGLxTBy5EgMGzYMn332GUKhEO666y6cdNJJ+O9//4uIZcR+8skn6NixIz755BOs/OUXnHPuuRjYvz8usqq4jxs3Djt27MD7L70ELRbDlEcfxbZtdv22xYsXo3379pg1axZOOukkaEyJldWrV2PevHl45513UF5ejjFjxuC+++7D3Xff7escnn/+eUyePBnffPMNXnnlFVxxxRV44403MHr0aNx88814+OGHMXbsWJSVlXEs2R3TpuHhm29GXmEhzr/+eowZMwZZWVl48cUXUV1djdGjR+Pxxx/HjTfemPJ1zQQCBqY5YUomfi5JU/qTecZCMv2AcyekTsdyE0AmRLwMA0PzmgirWvp9GqLjtOBTA0Ofg3g8YbzI3Ixu+7IMjIcB4/lMUOZuD0QhscxQMv1XksKIzQmjlrnWbs8ve70k52Y2MhVBS0NRUREKCgqgaRo6tGuH4jZt7Cgnj3t2+skn48LTT0ef7t1x5513YsiQIXj88ce5ba44/3yc9rvfoX/Pnphx330oKirCP/6RSPT41Asv4KD+/XHHNdegf58+OOSQQ/Dcc88ljAgmfUCfPn0wffp09OvXD/369Uvp3F555RUYhoG///3vOPDAA1FaWopZs2ahrKwMixYtotu1bt0aM2bMQP/+/XHySSfhpKOPxqKvvwYA/LJyJT788EPMnDkThx18MA7Zf3888/DDqGPe22JLS9WqVSt06NCBfgYAwzAwe/ZsHHDAATj66KMxduxYfPTRR77P4aCDDsItt9yCPn36YMqUKcjOzka7du1wySWXoE+fPrjtttuwc+dO/Pe//+X2u+PmmzHskENw8IABGD9+PD799FM89dRTOOSQQ3D00UfjjDPOwCeffJLS9cwkAgamOSEJP+ZErI0ZnJtxhWqmMMk69tV1Pg9MJkS8jHuB5tcRJhZq5DRTyKpfBsYUNFCp6IuSupAoA+P+TFCmINmxmiIPTBKWgt+WaLz2vAFj1tuTjhtzJN5XB1LQwOSEcvD1uV+7/h4tK4NRXQ01OxuRnj092wJAy0ao+fmIdO1Kvzeqqmg0W7hzZ2hFRcgJ5SRtLyk87tnQQYO4z8OGDXMUUxzKROBomoYhQ4bgZytdxNKff8an33yD4sMOc7Bhq1evRt++fQEAgwcPTrv7P/74I3799VcUFBRw39fX12P16tX084ABAyhrYuo6OhQXY9mqVQCAlStXIhQKYdCgQYhZrqdePXqgdevWvvrQvXt37vgdO3bk2JtkGDhwIP1b0zS0bdsWBx54IP2upKQEABxtHrj//kA0CpgmSkpKkJubi57MM1ZSUoJvvvnGdz8yjcCAaUbIXUiZEfHSAbM5GBh2sktxMjNZ9gXIjIiXzQPjFk5OJshMRXwkg1+Xnhhaz67WU3AhIR6HGY3ymgzKRvlgYHy6cBLtNUUeGG8GpiVVo2bZLtfrliQ9ArdfEuNRURRPN46mZsHQ4lDVLGT5cPcoWjYAQNWyue11LQbN+i2sZSPko60kHQeQ5J75uZ8eIt7qmhr8Yfhw3HXttQh16IAQU3G5Y8eO9G8x+ikVVFdXY/DgwZg7d67jN5YlCYfDTJ8NKIoCw+v8UtA8cm0Dydv2sT/7Hak8LrYZDoeBaBSmZJ90+pFpBC6kFFH1ySfY8fQzqPtpWeo7S8KPMyXiRTMO8I1JZCe6OkSBo15RgYo334RezYtwPcHkgXELJ6daj2ai6+1+JBOnCvWx2GckmVEhRFOILIxUZ+Vy/KaKQqpfuRJVjBaBOzZrWPmtRt0YIz8aRcXbbyO21f/KVQbDRxQdn+MmmQspM4uOxgYRNzaMWgSZFL3u7dfffcd9/uqrrzj9CwB8/cP39O94LIYlS5bQbQ4eMAA///orunXqhN49eqB37970X2OMFhaDBg3CqlWr0L59e6793r17o0gIg6YQrl+f3r0Rj8fx/fff099+/W0NysvLue3C4TB0i4mNl5fvefdipnIMNRECAyZFVL79NrY/8gjqhBfPF2QTf4ZEvH5dARlBI6KQDJGBEXQ/u55/HptuvAm7X3vNf6Mmw7q4uRr8aj0yBb9h7YLB4jBoPOAwYETj0FciO3/MXboupDV/PBUbrpyAOsG3DvDMRFKtEHWRpm+g73rxRWy6YTLWNDLHBpfHKF0GpinCqDNZzDGDCyGve/av+fPx/BtvYNXatbjtttvwzTffYOLEidw2z7z4It786COs+O03XP3Xv6K8vBwXXXQRAODy889HeWUl/jx5MhYvWYLVq1fjvffew4UXXgg9Q2HK5513Htq1a4dTTz0Vn332GdasWYNFixbh6quvxoYNG3y10b9vX4wYMQKXXnopFv/4I374+Wdcef1fkJOTYxt6SLiKPvroI6z/8UdsW76c5sjZY2ihhgtBYMCkCDU/4YfUqypT3jeZC6lRDIzR+AHeLxqThMvBEgiDTNxakei7dqXQHyKYNej5i6vaZk30B3vSSoWBMXWdN2iSGTCCIeG4ttSA8ZPILlkm3vTdhgDQsEpSzoDTwPhzITVmYq39ZnHisMKqN1VwblA3BiaZti0FF1JTwZEGJtOVncnEbBquY9utV1+N1xcswGGnn445c+bgpZdewv77789tc+ekSXjwH//A0DPOwBeLF+Ott95Cu3btAACd2rfHRy+8AN0w8IczzsCBBx6ISZMmoVWrVlBdIsRSRW5uLv7973+ja9eu+NOf/oTS0lKMHz8e9fX1KGRcVhwkVbNfeOEFlJSUYMQ55+DsSZNw0XnnoaCgANnZ2XSzBx98EB988AF6DR2KYWPGSLVtewQt1JAJNDApQitMGDBGVXXqO5v86pqdcAE0joGhFHvTD4ZmIxiYpBqYeBqGBluWwU24SraJxWCaJrfqaRL41cAIeV9SCqN2uJAYbQYb0eQrkV0KWp00dERKSHN8xxlFya5TCtW9d8ycifjmzSi59VbuPoc7lPjrbBLIopC2PfgQoChof921iX7Gvc8toy6kFBgY3pBwfwfSWUxNmjQJ10yciPpffgGQCCsmgmEYBpc3JW4lAOzQth3efvZZAED2/vtDkRgd/Xr2xL9ffBEAoBUUICJkhO3drRtefuQRhDt0QMgybFiwkUJ+IZ5/hw4d8Pzzz7tuP3v2bMf+9wuhxR07dsT8+fPR8OuvMOrrsaUhim3btqF37950m1NOOQWnnHIK6pYvp+/v1KlTMXXqVK6tSZMmYdKkSb7ORXb+7L1g+0wwfPhwmKaJ2PbtiFvM7gUXXIALLriA20fWt+ZEYMCkCLUgYXGnw8CIk7UZj/PfNWJ16XfFnxE0xoVUK4T7itdET90QIyJejoFxaGAEV51Hiv5MIH0GJr0waoBnYPy6KKhB0ARRSNwkILveXL2gzCWy2/HEkzDr69H2kksQZoScoZIO9qGrqqAJUSV+wUUhGUaiJtXMmQCAtpdeCi0/j7+PTR1GbQr/e27LbCTaLxlgYLh7rijWQUyYhgGFyWsSs1wvqbrPHIYV87lFlRKQ9PPjjz9GdXU1+ubnY/OmTbjlscfQvXt3HMPkqyJQFKXRmqaMgD5bLaI3DgQupBRBGZjK5FkQjWiUZyuEgcyMxoSib0aiFH06qa79ijEzgMaUEjDqvUW8doXeFFal7Lm7VS1m3XfNohNyiYYSwbmMdKeh5QFiSKiWkJDVZnBunhQZGGlOmTREvOx2iuY0YDg2xWcpAT9GPnl/xPusZNkRWrFNm5K24wYuCike58sJkAitZPeR+72xz2MKFozXRJRJF5KiQFEUm1Hxszjzc0yxlECq+wOYO3cu8vPzpf8GDBjgqw37kKbc+Jb0JRaL4eabb8agUaNw9jXXoF3btli0aJEjsgeAU5/kgrKyMtdzyc/PR1mjNTQt03AhCBiYFGFrYLwNGKO+HqtPHIlIjx7o9vzsxJeCYNWMRXl62TCw5swxiG/ejN6fLoKaleW7X3SCaQ4GphFRSKY4OYrXhGpVUhjUGVeJzcDIRbxA8xgwfkWnpjiRcYaWtwFjWNdea1UEo6KCy3DMMzAeUUgGf73LX34ZW+68C12efAL5xx5rb5gOA8O4C5WwjIFh+uWzlEDS62mavEuRO569b2zjRmSnmNCMQIxC0isq7I/RKDShn7I+85mNm5GB4eAl4k1z4hInblVNvHuSa1C7dKlnU927d4deX48GK5eKtP00jK4//vGPGDpUntlYakx4ILZxI4zKSmT16QPFa1/TxMiRIzFy5EjUr1wJMxqF1ro1Ip07u+zgz4Dp1KmTI2+O+Huj0MKjkAIDJkXYGhhvAya2eTPi27ZBr7RdTQ63RizGD26miQYrQVPDzz8jJ5US6n61DBlAY5KacYM/ZK4ekj02BRcSM2HZCc/kYdRA6n1OC36rJ4uaF8Pfytw0DMqyaEWtEEMZzwxwDIxHH2j0WmKbuv8uBXQddcuWcQZMOqwbF3EmWVF6sZOObd2YNRFiXh2X48U2NoaB4aOQ2MUMyfTMa2BkBoz/cPlkMNNlYDzsl7SzgpNGyP22GBhfwQWySVLcz5NB8tE/AAUFBY6kdOnCqK2FaRgwGqLQWAMmAwyWH4RCIU5Dk3G0TLuFInAhpQhbA5PEhUQiQNiJRBykYzFXatVXlVYGdubXZoiykeSz8b1rnaCqdxHxppSQj7AuhmG7oDwYmOaI+jDZPnltJxgGnKHl0U/2N424kGoawcCIBoIuTv5puJDYjMtSNwqr/8pMGLWnC85gDZiNnu14HkNkYJiq4LS0BsfAyM6d1cA00qBOyX5hrRS3htDoCVixrKOUXEgSOO53BhiYpoFHv8TPfliNDMYY6DU1Tu2hb7RsBiYwYFKErYHxFvHSQV7X7ZfQ4UKKuU4uKYfP7SkGJsXBN1kUkpsI17NNxnhzEwGnUjgwI0iDgYGuc8+IlwuJ1UlpViinqM2wj5GcgRENBIcLr5EuJJnRaHqwJQ741cCwhpuoOdMzY8CImXj1cjvknzIwnCHl7UJq/KIjXQ1MExgDlIGxPjfSgHGMD5792gOTLDVGXL73s68EmYqSNHUd0bVrEV23Ns0GEn1smeZLYMCkDLXA1sB4vUzSKAPxZYzFXH3NqVrMpt8JMxNoDAPDrMoBCVNCmYBUNDDWS+aTgWkWDUxaDIxQC8nLhcRcd00i4mV/9zSExCgkVwYmHRcSw8DI+uBTxGsahj2QpsLAiIYbq4FpjIiXFaIbBuJMziJ24cJu4+gnZxBmRgPjy+ZoLhEvYWA0uQtJkUSlScdTLyZD+LxHopBMxx+ST3BhYDzazZQBY707pq437voEDMy+ARp6qetUNBnfsQMbJl2Lmi/tWvbcxE4LNwoPeSzmujpOnYEhE3czMDCN0JOYDUKElUOrkkYUElvPh7xoe1oD41ezwTEwcScj4wLKwIRCUK2U6dwzwzERHn0gxp+DgRGuH8O0+Xch2QyMzOjhjEwvzUUKbAVvAIrsXoZcSLUCA8O6kEgEVDJ2Sffn4vPZI+F/v7uZiG3ditjWrc7dM83AiAaq3wla1NT4NcBSgKnriK5fz4mxU9hbfmyvaKkk3wLImAHTaKO0hRouBIGIN0UoOTmJnBbxOPTqaqh5eaj+9FNULVwIMx5D3rBhAPhVFR28ZS4kNw1MigYMK2RtajQmK6sYIu4UWqYj4jUdfXEYQEISwaZGWgyMLlajTm7AKJEI1LxE0T3TzYXkGUYtGL5uTF4aLiSWgZEyatwk7sHApONqSmwsHM/+rO/eDVPXudwkfsGJk3WdyxpNn+8khijP0DZWA5MCBcMyFoYBfft2AECoTRuwE2rj2YwkIl4/bAvbmqryCxTZPmn2Ob5jB/SKCugVFchxq23kBrdjNloD0wQGTFq7BxqYfQqKolAWhuhgaGFGZnLmKHxZ5WnyvZsBU51ipl+aNr459B0sm5FiIirBheSeiTeFdmUThAuzA6RmHKWNdKKQ4roQRh2D4ZITiDxTSjgMNScn0ZSriDdJNBNgs4QuTF462Zd5BkZyjzgRrz8DJpmWwkvE63g30nxXRA1MnClNQMeCuLfRxV2PDFaQT2p4uEz4rJsOQFqaleHDh+Pa669PfLDm38aKeGfPnYuORxxhMzlNwcCkk3cr2bFTzoosgDFgMub6yZQx04IQGDBpgNXBAMzA6CJupTVpJC4kN4Mj1Uy/9oq/eRmYlF1IsSQMjM/igtw+MveDI0Gev+ieTCEdBibhQrI/Vy5YgBWDh6Di7Xec+1EGJgwlN8HAuIdRp8HAOAxAnnXzM5ixTIX0mvst5piKC8nLcBANmnQjY+p4DQzHwNAopCQaGF3C0KaLVCYWtwnNEOoVZZiBcYZDJ+mb+J3iYsBkUnjclPum2k+WgclUfbt90IUUGDBpgDAwNMcLieRwSQ8urTxNvncT8frI9MtBYkQ1GRqRyE4U8Tom13SYJFmUhxiFxAmPWxADI0RHsaxE3ZLvgFgMdd9/79iNGDBqOAI1xzJg2ER2MX8aC1Hz4lYM0/Fc+Zh0zSQuJO4YHnlgHGyQ14Cuuxs7DmM5zXfFEYXEuZAIk5UkjDqT1ahZJJlw3IwU0zCREQ0MgaCBcd6z1CZ+RVWsjx7aknS73IhztT0s/hkY08c2XBTSnhTfZvKZaAIEBkwaUIWCjqYhrGIBXo8RIwyMzIXkwsBUp2bA+M2TkQk0JpGdXxFvSjoVqUjSnYFp6oKXfNRMMhcSr4FhdRuEwTCiDY7dOBeSjIFhdRWeiezs622aps3IeLjg2ON7wUgm4mWP4SHidRgaug6jpgaV8+dDr65x7acjOZ5HXphUwDJLRmWV4C62nm/OkErmQmoaBkavqnIuGDj7RXQZNV4DE4/Hce3dd6Nk8GC0a9cOU6dNA8mOXF5ejnHjxqF169ZoM2gQTr38cpQpiq1DMk3Mnj0bXbt2RW5uLkaPHo1dxDhUVazbuBF5Bx6Ib7/9ljv3GXPmoN+JJ0JP8l4vWrQIiqLgvffewyGHHIKcnBwcf/zx2Lp9O9777DMc8sc/orCwEOeeey5qmcXAwoULcdRRR6FVq1Zo27YtTj75ZKxevZp0ANFYDFffcAM6duyI7OxsdOvWDdMee4xex7uefBK9Bg1CVlYWOnXqhL/cfTftuxtM08Tm7dsx+sorkVtQgB49euDFF19E9+7d8cgjj3DbGnV10Gtq3Bri2kwdLc9oYREYMGlAEws6koEyKQMjcyG5aGDSZmCagV1oREiyU8QrXBMahZRGJl7uO3H13YwamCQ5QFhw919gYIirwmH0AbyIN9fSwNQyg5jvRHa8DsXVhSdcMz8GjJksjJpjn3yyKkgMxDtnz8bG6/6C8jkv8L955L9JZpT5BVuyIW6JYOlvNArJW9/Du5CSuMVME0Ztres/vb4eBvlXUwOjthbx8nLUr1iRqHzMbl9Xa29bV8fsV534nXyurUtkmU1x0nvhxRcRCoXw2euv49FHH8UjTz2FWf/8J0xDxwUXXIBvv/0Wb731FhbNnQsTwMmnnoqYtcD7+ptvMH78eEycOBE//PADjjvuONzz0EOJhlUV3Tp3xvGHH47nnnuOO+acefNw/qmnQpVUspZh6tSpmDFjBr744gusX78e502ciCf+7/8wa9o0vPvuu3j//ffx+OOP0+1rampw3XXX4dtvv8VHH30EVVUxevRoGNZC5cm5c/HOggV49dVXsWLFCsydOxfd9tsPADDvgw8wY84cPDF9OlatWoV58+ZhQN++5MZ69vOSm2/G5u3b8fH77+Of//wnnn32WWzbts2xXXTdOkTXrpU+z2ZjGZQWkyhQjiAKKQ2oBfkAGCNDwsDweTisvyVRSG4rz6SZfgX41VxkAukIOun2DhGvXFiZ0uQiO2fHqr35NDB8HZwUGJi4LmUFHMn/IBowVhRSrVsUkg8Ghuzjl4Hx40JiGRjZ6jiJTsTt2NB1NPyyAgAQLVvv+M3ez4OFE7b1CzMe5575+I4d/O8Sd7H0nUyhGrVZV4cVgwan3NdMoN93S6jGyg+6dO6M6ZMnQ8vOwcCRI/Hjt99ixpw5GH700Xjrrbfw+eef44gjjkDdsuWYdd996HviiXjr44/wpxEj8NgTT+Ckk07C5MmTAQB9+/bFfz75BO9/9BEVA1/wpz/h6nvuwcMPP4ysrCx8v2wZflq1Cq8+9pjv+k133XUXjjzySADA+PHjMWXKFCybPx89unRBzgEH4IwzzsAnn3yCG2+8EQBw+umnc/s/99xzKC4uxrJly9BbUbB+82b07tkTRx11FBRFQbdu3XBYjx7Qy8uxfvNmlLRrhxOOPga5Xbuga9euOJBcT4/urvj1V3z81Vf47OWXMXTIEKg5Ofj73/+OPn36OLY1Gbe7M6ougy6kFoiUGJipU6cmKowy//r3709/r6+vx4QJE9C2bVvk5+fj9NNPx1aSY8BCWVkZRo0ahdzcXLRv3x433HAD4sILvGjRIgyyKLfevXtj9uzZ6Z9hE0BkYEyZBobVWdA8MIIBE/XIxJsk068IOkE0Z4QNUjdgRHeIW72atIo5cu3q4hf2n02tgUmbgYlLJzv2mhkNDdh0402oeOttAEIUUiM0MAASbiQXLVVaLiRWAyNzIXGCW48+iuyPbiBqVdll9Sdim8kZmNSNfUMwJh0GjIyBkYZRs4ZWM7yzzYShhx6a0G9YEo5hQ4fi17Iy/LxqFUKhEFNE0UTbVq3Qr29frLDcMb/88oujyOLhgy3DzTJgTjnhBGiahjfeeAMA8H9vvoljDzsM3Tp3BmDCiEYRXb/eMw3FwIED6d8lJSXIzclBjy5duO9YpmPVqlU455xz0LNnTxQWFqJ79+4AQCs9n3/qqfjxp5/Qr18/XH311Xj//fcpW/GnkSNRV1+PfocPxSWXXIJ//etfzHznbh2sXL0aoVAIh5SWUhasd+/eaN26NbddUuF1oxmUfYyBGTBgAD788EO7ASaj4rXXXot3330Xr732GoqKijBx4kT86U9/wueffw4A0HUdo0aNQocOHfDFF19g8+bNGDduHMLhMO655x4AwJo1azBq1ChcfvnlmDt3Lj766CNcfPHF6NixI0aOHNnY880IqAaGMDBkcnSJLLAz8TpdSK7+61TDqPXmZGAEt4dh2OGSyfaNChOfWybeVKKQfGhg+BpDTZvILm0GRtflegnGEKj5z39Q8eab9DPLwKRXSkA8vouWKi0XUpIwao6B8RgcHQxMHNH1CeaFDWFOtOPBfIh9SEMDI1ZT13fv5n+nBgybSDCJyDyJQa3k5KDfd0tcf69bvpz+nd23L5RQCHplJaIbNkBRVWQzi0zyPQAomkYN01BxMcz6esr8kv0UyzhOHSSO2hLfeo1LfnKeWONLJBzG2PPPx6xZszB69Gi8On8+7reYEpgmjMrKREI6RUHEhTliK04rioKwkBVYUZSEe8jCKaecgm7dumHmzJno1KkTDMPAAQccgKjFJh+y//5Y9d13+ODrr/Hhhx9izJgxOP6IIzB3+nR06dQJP779Nj79aRk++W4JJkyYgG4lJXh/1ixkZWUlP2/AOwoplbD5NNASQ6dZpKyBCYVC6NChA/3Xrl07AEBFRQX+8Y9/4KGHHsLxxx+PwYMHY9asWfjiiy/w1VdfAQDef/99LF++HP/3f/+Hgw8+GL///e9x55134oknnkDUevGffvpp9OjRAw8++CBKS0sxceJEnHHGGXj44YczeNqNA2VgqvkwajdxK/07lVpIVVWpGSPNmInXoUlIRa9ivfSK9fK6uSoa60JyGA7NWcxRYGBMw3A9H96w0qUGD+t2i65dx/2mhO0warOhwb5+PksJiNWw7YSIvIarKUS8fos5iseOb99OdSgOBsYjZ4xXdepkME0TZizmKLIqukTNWCxxbZJpYHxqlIDEhKrm5kr/KTk5ULOz6T8lJyfxPfmclcVvz26blWXvm5XFfSb7pVqT5xsisLV2+/rbb9G7a1eU9uyJeDyOr7/+2jppEzt378aKlSvRv1cvAED/fv3s3y18vWQJvQak0fEXXogPP/wQTz75JOK6jlNHjKBtZjrx2s6dO7FixQrccsstOOGEE1BaWopy0WgGUFhQgLPOOgszZ87EK6+8gjcWLMAuy5DKyc7GySf+Do899hg++fhjfP3jj/hp1SrPLvbt0QPxeBw//PwzPZdff/1VemyKJjZmWiIDk7IBs2rVKnTq1Ak9e/bEeeedR2m0JUuWIBaLYQR5mAD0798fXbt2xZdWiv0vv/wSBx54IEpKSug2I0eORGVlJZYtW0a3Ydsg23zJpOmXoaGhAZWVldy/pgIt6FghhFFzegJJHhjZJOBGYxtGStl4mzcTr9MV5ntfEv6bnZ34QmSlaHXkFNr0oYHxW+U5E+AjYXSsGzcOq3//B3lSOq4eUFz6PLAuJOI6IWAZGMBmYbjnz8s4EFxIYi2pXc8/jxVDDkXDihX8fj7ccEnDqH1m2BWP1bBmjd2sw4XkYRg0IpHdhiuuxK8njoQuTCCiKL128bdYcehh2MkITeVh1E0sKqcFZE33VbQYhSS4G9JZfZdt2IAbp0/HyjVr8NJLL2HGU0/hyvPOQ++uXXHqqafikksuwWeffYb/rliBi266CZ07d8Yp1ng/8YorsXDhQjzwwANYtWoVZsyYgfc/+STRsKJQpqa0f38cfvjhuOmmm3Dm73+PHGssMU3TPocMTbatW7dG27Zt8eyzz+LXX3/Fxx9/jOuuu47b5rHnn8fL//wnfvnlF6xcuRKvvfYaOhQXo1VBAebMm4fZ//oXfvr5F/z222/4v7lzkZOdja6dOsHLhdSvZy8cf/jhmPi3v+GbxYvx/fff49JLL0VOTk5qIdYZLCXQ8syXFA2YoUOHYvbs2Vi4cCGeeuoprFmzBkcffTSqqqqwZcsWRCIRtGrVitunpKQEW7ZsAQBs2bKFM17I7+Q3r20qKytRV+de4PDee+9FUVER/deF8WlmGkq2pTmwVl+ySVeeiVfmQnIfuFPRwdDBWkxI1RRw5LPxn8mSMjBk0hUHdzKwp1QLScbACN+JYtmmhMDA1H27BLGyMtT/+KNjU5GBkT0PrCEQW+80YJRIhNnWYj1SLCWQOL6twSEujpqvv3EKr5EGAyMzePxqhQTjJ7pmrX2M2lo+VNijzcYwMLXffov45s1o+PVXvg3BgKlZvBhmfT3imze79sNx7MYYMG75R9wmLr+ZeGVt+8DYs89GXUMDjho9GhMmTMDVEydi/JlnwjQMPPfccxg8eDBOOeUUHHf++TABvPvWW9Slc/hhh2LmzJl49NFHcdBBB+H999/HlGuuSTRsaS5Jv8aPH49oNIpxo0fz/c2wy0RVVbz88stYsmQJDjjgAFx77bW4//777eMByM/LwwOPP44hQ4bg0EMPxdq1a/HmrFlQVRVFhUWY9c9/Yvjo0zBw4EB89OGHeP3xx9G2VaskfTUx85570L5tWxz3hz9g9OjRuOSSS1BQUIBssvhzdt77u7QkMPuQBub3v/89/XvgwIEYOnQounXrhldffRU5aftKM4MpU6ZwlnFlZWWTGTGK9cI5DBOX3A508Ja6kNwHbr2qGmHXX8WNdf5vSbXXTMGZ5Mz/AGwIDIy7iDcVDYwsRNeLgWlGDQwbsSKjfzkNTFz6PHAupHWCARMOJwT1kQjMaNTWYKQh4mU1MGTSNVzyS/gxWrkw6iTlHqTZlF32ja5dy33Wd+2C2rFjYlv22XTUQkqfgSEsiS6kN3CwajLDTupCcjK0acGPAWMYyVPx64Zzgktxwlq0aBH0igpE16/HjPvuQ1aPHjB1HfU//wwAaN2qFV544QWYhoF6S7eT3bcvGn77jbZx0UUX4aKLLqKfo5s24aozzwRgC4Nhmti4cSMOPPBADDngAL6/HgzM8OHDHQbKBRdcgLMOPcx+VkwTU6dOxdSpU+k2I0aMwHJGZ5TYzIQZj6P+l19w0Rln4LIJExAqLqa/N6xdC6O6Gn888Xc45dhjoLVujUjnztz18Ly+pomOxcWY99RTCHfqhFCbNtiwYQO2bduG3r178+cs+5vpJ/PJ/Xge/WjJaFQemFatWqFv37749ddf0aFDB0SjUewWRG1bt25Fhw4dAAAdOnRwRCWRz8m2KSws9DSSsrKyUFhYyP1rKijhhHFAB6FkYdRuUUgeiewAwEihnIBjImoETJLUzPVYqesh6LYk/DfHWkW4ZuJNJQpJ8uJ6TFbNmQeGNT7YqsX0dzFaRXLviAvJiEYRY1f2AGVfyP/UgEkjjBoSBsbVjZmJMGq/mXjjIgOzhvscZzPhehSIdC1b4QOkD+I7KWOnHPsmcXE2hW6NGw98rKIT73TjGRjHuOHD3aF4/U5LCSRcSNW1tfjpp58wY8YMTLzyStf+psRCs4ZuCvuxx3DsRTIIi1W0fbZvAlj09dd455NPsGbNGnzxxRc4++yz0b17dxxzzDEu/fHf37TQAo2ZRhkw1dXVWL16NTp27IjBgwcjHA7jo48+or+vWLECZWVlGGZVaB42bBiWLl3Khah98MEHKCwsxP7770+3Ydsg25A2WgIIA2MXwPMOo7YNHeEBMHTPQVRc7XkihXoxXjCiUaz+wyiUMasg57EaYcBYA75queGcCedcEql5QXa+YrvNWI2amzyYFbpevsu5seDakjERhMmIbdjoWM0rkbD1f8KAMSQGTEoMDNkvKQOTYhi1xIXEPft+jSzIGJhy+bYO92R64nPTNOm+4vXwVQhQxj5lyqD2y8C4bc9uI6bpb0xEo5f4lz0OI8712jaxmYLr7r4bhx55JIYPH46LLryQ2/Sq26eida9eKD7sMLQdMAD5+fn03+WXX+7SfOONNul+rOElwedLlqDdoEFcH9l/ME3E4nFMfewxHHT00Rg9ejSKi4uxaNEiLooqKcOyDxotLFLyM1x//fU0pGzTpk24/fbboWkazjnnHBQVFWH8+PG47rrr0KZNGxQWFuKqq67CsGHDcPjhhwMATjzxROy///4YO3Yspk+fji1btuCWW27BhAkTaEjZ5ZdfjhkzZmDy5Mm46KKL8PHHH+PVV1/Fu+++m/mzTxOK5Z6hRgoZKJNl4hVdSLrh6fv3y8Bw4jU0bkVX/9MyxMrKECsrcw2PTpeBMU2TMWASDEx0zVpsvP4GtL30EmT37ZteJl7ZpO9VzLGp88C49D2ehIExXUS85JpFy9Y5flPCIgNjGdWsi8d3IjudYWAS34sTNnVVpRpGLesDe+wUSgkQIa2SmwuztpYzDL2KOTp1UT4naKafYsp2PwaMbOXLuTGbwqD2o4FhNzcMpxnR2MytgC8GhnUNubZnMTDP3n03Zr/4IrS8PJixGNin8NarJuK6q6+CXlEBNScHEUZC4MrIO4pMpsLceOhLyGehCCV5FgYNGICv//lPZEkS0wEAdB2/O/JI/O7IIxEqLkZY0IXK+5BMA5PO/XRpq4UgJQNmw4YNOOecc7Bz504UFxfjqKOOwldffYViy/f38MMPQ1VVnH766WhoaMDIkSPx5JNP0v01TcM777yDK664AsOGDUNeXh7+/Oc/44477qDb9OjRA++++y6uvfZaPProo9hvv/3w97//vcXkgAGcGhiSDt81Qy2tRi3xyXsM3LIJT4pG+PZFqNl2bgKjthZafr7keMLE4HcAZq6JYqW/3/3KKwCAqo8+Qv/vv2ueYo4ZnjCiGzYgtmEj8g4fah1Lfk/1nTtR9fHHyDnoIITatk18yUUhuYRRR6MwDQMxIQIJcDIwMheSawi3o7hhjNHAWAaM4EJScnJ8GzCsuFZaC8mniNfNnRgqbofYujLOheRZgyjN94S7lqJLzc+gLjtOpqKQ3Fb+LNvLuZNc2tENmOJipREGjDT8WsYO+WRgiIjXZL4Te1fcpg06FBVBLy+HmpuLrJ49k3dXfAdM06s38r5Je2N9VuWt5WRno2fXbshh9SwM6tmov8YYDo00YMwWGXtkIyUD5uWXX/b8PTs7G0888QSeeOIJ1226deuG+fPne7YzfPhwfC+pwNtS4BDxSoSn0ogkR8iw4SnijW3a5Ks/jvDsxvjUGfGvUV0tNWDSyQkC8IJH4kKibZDw33RqOqVYzDHTmU83XjMJ9cuWodf77yHStavrxFg5fz4q589H9oEHosdrr1p9EaKjXJ4HMxp1CHgBVgMTptsBcLgUzXgc0DR+YpFM6CwDY5qmg4FRs7NhVFT4KyXAZq2VXXP2+B6GvNv1DBe3R2xdGedCEkPYuf6kGYXEnqtRI9cEKVlZrnoYeSK75BoYP5oFty1YRsuXkNPQnZNto1bcibYUEv5sJqZC6XSeAgPDfefl/vHb98YwMNx+4mc/GhhvES+F30R20uvnvqsvNGEUUiaiZYNijumAuJAos2INQLEYvSm8iFdwNRHouqeI168B44y4aYQBww7WbvWY0jRgWLpdyXZmoeSqIacUhSR5wb3SyGeYgSEF/cj/ybQD9UuX2h9Ew8plIjcbGhw5YADbmKYMTMwZhWTU10t1TU4GRucYGLO+3qm5se6bH9cJz8DIopDYc/fvQiIItW+f6KqLCykZA+P7GWPfCRdRs+oW2io5LiCwOsLzqFn1bKJ+9DV+NDA+XUgODUxjXEgyS0XSt2SJ8kyJARNdtw4xSVFDLgrJL9IoJ8Edz/4g/03xmGI9o5DYzXyek3S7DLqQMgxS8ZvV9KSKoJhjGnAyMELWTU0TwqhdopBMQzrZKeFwwr+7caOv/khdU2mCHUz1Knk5AwcD4zORHc0BEw5D0SSPniDqNE3TXyZQaZiqaCw2nQaGGrJkwk43BDyuu07kRn0D1cBo7dpBt2rwqJbhoobdXUhxK6ovVlaG+M6djPtKfG7iHAMjm6y1/ALEABi17jmZ6LnVe2fi5ZgwL6PP1YWUcF1zrlZ2W1FzlqYGhmdg5KJmJS8XqKiQNyBlCJl+CtcmFAohNzcX27dvRzgc9qyybESjiDLtGw0N0FQV0WiMpsM36uuhWYuuWDQK3eW8lViMu0ZGXT00nyVC6KlEo4gbBtS4TutGNZhmIj9VfT1Uw4ARi1l9VqDU1yNqGDAMI9F3odZUVNdhGAb0WOJ8yDk1bNmCSHY2d+4AoFrnrcbj0iKoIvS6WsRYQ7q+HqrPid5oaKDHj0dj0JnjNVh6MtVI9F+NxRJVvoX7hbo66RjXwAR4qNGoowaXrA9GNOq4fuz9ll3fZGD7YdbXQ00xM7MMpmmitrYW27ZtQ6tWrajBng4CAyYNUAOGTFwsXasnKoLyUUjyWkhwEfGGu3VF9NfVjWBg0l9VsBO/vmsnqj7+BLmHHQYtP8/eSGQ3/EZzMGUEFE0iDhYn/ngc8GGdSyl6j1ICmdbA0BBbktgwyfVXWbeczj87bsaPUVOD2MbE85C9fylq/v0ZAAkDQw0YuVFZv3w58o8+WtpP7viGLp2sNauYnFGdPEKOTzDnXUrAMxOvyzWhDAwbRs2FJydhYHxGupl+GJgc94rN0ueTy1djcpWEFUVBx44dsWbNGqxb5xRui30jzB8AaKYJNRJBfOdO+r5p8Tgt+KlXVLgaYSI0XfdmliQwqquhV1ZCqapGyAqjj23bBpgmQooCJRSCqeu0z+FwCPEdO2BGo1w/CdjfjJoajvkLKQp37gCgVFbCbGiAEgoh5MNANerruecnBCbKNAnMWIweX62thVZjL/hiW7cCug61pgZGbS2UykqEolHH/QqHQtJIpdjWrbYbqqoKIRfDg+2D7PrpVVWUSZf9ngyxLVuoAU6erUyhVatWNH1KuggMmDTgycDE40Ak4q8WkiEX8Ua6JAwYo7ISelUVtIICz/44c56kP0GzE9/OWbNRt2QJQsXF6PnO29CKiqzjCefhMxMv0cAokYicWnVUHdb9DSZ+ijkyxmNTGTBmg3Udklz/iFXNNtEvQcTr4kKKrl0DxONQsrOR1aOHbcD4yQPDoH6ZbcA4DVGdq+slZWAsAyZZiL+p65xoW8p6ccUc03AhFSfqsLHp/XlWJ4nLyGcxR/b4TeFCIn1TmJVoJBJBnz59krqRous3YP1dd9PPHafdh9x+/bBp5t9RZ+kIi6+7DoW/S6Tr3/7kU6h8+23PNtWCAhhVVehw+23IKy313FZE+T//hV1//zvyjzsOJZNvAACsuWkKjMpK7PfM04h07Yroli1Yf9XVULKy0GPeG9j4zLOo//FHtL9xMgqGD+fa2/j4DNT//DM63HoLdr/1NpfNuvOTT2DDXXdDyc6mbEv2QQeh/scfEe7SBV2ffSZpf6s++QTbpt9PP3d66EFk9+3r61zrV67ERuvaF55yCoqvvIL+tnbqVOjbtqPw5FGofOdd5Bw6BJ3uuAPRtWu5+9XtX/+UGhW/XfcXek45Q4ag0513OLYBgPpVq2gfZNdv1//NRfncuYnfJ9+AguOO83VuBGtu/isMK7dbpwfuR06/fint74ZwONwo5oUgMGDSAJ1UScI3yeqe93HLXUjQ5SJetSAfWqtW0HfvRmzTJmjJHpoMMjCsEUEGwPj27dg0+UZ0eeZpq/3UKxMD9gSvZGUBPhgY3yn/k4gkAQjhwhnOxEtchFFSWiLJ9eeEtCIDI9+3YeUqAECkSxeoBXZIqGjAUKG0yz2pt2qO0eMxYKOQTDcGxioVoicJ8Rfpe2km3rg/A8bNIFSt0FiuwCJ3PTOlgbGvpTsD476ylWoYxHOKxQBhdauqqnvaeAuKAqhMcsMsw0B2djbUbVvp9+GaGtpOqKKC216GkGkivmULwvUNSY8vIlJXC3XzZoRra+m+2s6dwI4diJiJQA9VVaFu3gw1NxfZ2dkIVeyGunkzIrGY43jqtm2J31QV8S+/hMq46ULl5VA3b4ZWVJSoQA1Aa98+8V0k4qvvdRWV3PWI6LrvczYNg+4bqqrk9tM2b4G5bRsisTjUzZsR2rkr8bui8PcrFIImOZ66YQMdV7UtW1z7ZJombS8SjTq2C1VX2c9BQ+r3U9u0ibpGU7k2zYVAxJsGFDZNv1AOQFoN2CUKCYZcxKtoIYQ7d04070MH4zSMGsPAyHUJNYsXM+0Lx/PrQrImeDUSgSJhYBzCUJ/nITUYxMlKLFpoofyll7Dt4Ud8Hcf1+MSFRCbtJBMjly1WLCXgwgo0rEoYMOFuXaEy7jxXF5KLzqeeTYku0U6xiQTlLqRWiV0rq7B9xhPY9cIc6XEMsUqzrJgje+5pMDBaXuI6uOabSZYHJp0oJBcDRvGi5pMZb0jBmBLbkbkBAU6XZjLFQP1E4NEyHynUOHP0h1mg0FxSupAigbjMVGsl7lG1WwmFYQgao9gWK2N7OExLJZB30O/1FO9nSvmnPNIA0H6T95I8645Fg/x4nBbJI9uzI4pRhNBH0zSx7YEHUP7aa65turXvlS17TyEwYNIA69ZIlANwTo7cg0n+driQTM61QdsPhRDu1AkAqO7BEyId3YgMmm6ThVlbywwOcgbGqK1F9eefux7fZF1IEvpQF8pQ+B7U/RRzdHnRt06bjp3PPONfbyQeR9epr5owTEkZMK58APvs6K6DRMPKlQCASNduXGi704VksUEuA2Ns40Zak0nKeFEGRl4NPWS5kOqWLsWOGTOw9Z575InaRJ+9tJijIH53gdu5EC2Rm9bGYQymyVRKjSLBtclWBHfs7zExu332DYfWyxJcMtckWUZkESRHUypV5sX+UKMEAEKJv9mCswDs+kyWsSOtA2axX0oohKLTTuN+i2/dYh1LpYtKo15Ix5Csu2JiwhQE/p4h+9ZvSpbFqpFs7clyEwFcNCYgeZdc9pcuEuL877H167Hz7//A9gcedG+T3d8rs3ULQGDApAGWgWEr+JLPgJyBkU6qsocipDWKgWmMxsPLvULFbg4NTGKfteeeh/XjL0bVwoXS/Y0kIl5dKHbodzBJlYFh7xEZHNwirpIem3UVkpWu5J6G2rdH28svc/zOMzDuYfWEgYl07cqJgN3ywHg9A8Qd5RWFBEs0KYK4kLikepJBmJs04eJCkkwApiGppu7mQrKug1lfb6cv8Aij9qpQ7gXZcyhqXjzFkdJzz4wB42ByxIg48W8fxyGC5FRKhND2ZQwMiTgUUiQQZsZmYCTXyeqDEgmjw223outz/0DeMQkNF2VgNM3WJZLnzuf1dDAwqZwze1/FhR/tt8DAJNNlie0CXFV3EabbYoj8LuSDIufrKELqBi4hZiOkCU2EwIBJB6wBE4sJVjARQUoEjJIBVfYAKxrLwPgIpXaIEzOjgXH8tMtl5R6LwaitRcMvvwAAqj5ZJN2f08BIXEgiA+PbFZamBobVTviNzHAch823QqOQnPdUKypC/pFHWsd3mWRdqlGziHTrCjWPMWBSjEICAINES8g0ISwDI0naRgwYbj9ZiLQw6EonToGeNg0Da886G+vOO58vlOfCCqp5tiuNnrcPBoZeK78aK8m1FPMY0eKkMpim0yhrREV3Di4MjMG6jdiimr4MGIuBScOAkTEwRJzsYGAIC6u6MzCEMVJCIai5ucg74giaVj+2ZbN1LJaBSdGFJDIwKejjOOmAi2FCo3ZotnZx8ZckQzXAVXV3gCteKnvHWC2mTo1Z35Gj7NjaAhmYQMSbBhRFoblaRAaGDkRsGLVLFFKCgZG7kLQ2bRKbVCavh+R0BWRIA2NBLSqCUVFhJwxzGDBxVH/2H/rZrb6H7UIKS0W8abuQfKxiZIns2NVXugYMO7nZLiRJf8IhOmCbbgwMm0jOBaEOHbjrRGohqYIB4zUh0kFMZO7YVVk8DqPWeU1USU0ZaZI6cfKTGTlC3h+jspIm+TPr6qBYbhm354AzYOrrgawsh1HEHY8YMOFw4lz9MjCS46vZOWC/9QqjTvTFADQN0XXrsOOZZymj5nUMf31z0cA02PfSYP72Z8BYGhi/q3RZfzSJCynuwsCQsUBW0yxuGzC0ueJE+HycYWCIS8+R0TtZf0V2I5Wx06NshaiBYdMTuLZBv3MuEN3gqGYv/i64kKi71Uq66pVny+HKChiYfQhsKLVY0Rf8Q2dn7JWUEpCJeEOa7RLwUzRPeHBjGzagNs1SDLLJiNQUIS4kx8QXi6Hq/feZNuR9tkW8WbyP3EJcdCGlUi1Y/M7hLmBW9DFiwDAMjIs4M+mxWYqVDA6y5IRayA6TdaF9TY8waoJQmzZJNDDeIl6A0Yw4qGpm1W4YcheSrCie5H77MqrZwdE0ebFsshwyqpo4ZyreJCtLD589Y8A4tpXAqKtD9WefSZ8NVWBgkubXsI69+5//QsW//uUwDtJOruhDA8O7kJKPJ0pGGBhWxEuee5IPS2RgBIaGAX0mWAOmvZXAcItTA+PHgOfaF657aiJeOQPDTvxKxMpcTRNEyg1Oz+88jDFTYFgcv8d5I4s1bMl9qP3ue7kGMM20A82JgIFJE0o4DBOJl1xWKFCaKlyWCVQm2tRCjgnJE0K7m26YDCgKen/8EcIdOybfn4E4wCm5uQh37Ii677+3M56S8yE1TmJRVP/733YbLgMfZWCysqRFzvTy3fwXFrslq4jN7yh5scSBSHKPMsHAyDQwUrdgKCQfqLk8MHHXMGoAQCgEtbAQKtNv6kIimXhpKQGPVRthikSDmnnWTF2XupBUH7WxADgjgJIN1LouNwYhH5gVq66Tkp0Ns7aWrqS5Ad1FA+PQJbhg1/MvYPsjj1DNBXf8LEEDk+ttwJAigXqlS7beNCMH3RkYuQvJj4g3MxqY5CJeBwMj03AQLQkjmiYZmEnoNKuBsfvhk4ERxdQpnLPpxsAwbSZjYKTuV0mOIFdwi+ckLiRd5yPS4nE0/Loa6849FwBQ+svPie+tMddZYy9gYPYZUIs/xk86chGvNTGQ1TVZAbqGUTOiNB8GjHQlaZo0hXwqEF+eUOvWtjtLYGCUbJtqZusmufWZingjES5pF4HoQlo/cSJ++8MozzBCwB8DY8ruUR1jwGSAgaHCVcmLrmgaM1DLaVkzLq9GTaC1bgVFUQQjwsrWKeSB8VpJ2kyRMECxUSe6Sxi1JKmifBAWB79kDIzBGzBcaLRkX+v9ULMSK1wawu6HgYnwkSFuiFlRLrLVqSji9QyjZo7tVgwyk1FIpmFw4w/nQko2sSsKZZfScSHRaywR8VLjSjRyLD2ctBI7ccVIDBjavqrwqS3g4zyF9unnVJgwSfoM8W/bWPYfheTH+Ke/xV2MKPo7v0DiFimxOOp/+onbPr5jB1Ydcyy23HmX5yKwpSAwYNIEl41XyKYKCA8WdSFZEz952VwS2SnhkFPT4AWXB0uMBPEFsbBcmzbQ2iRCZ+NUA5PYhgzi4qDsysBQEa88E69owMTWlSG6di1i69d799mHBoaPGMikBkbmQnLTwFgDuYswztTjnrkWQq0ThiQbsmsyRiEAX1FINlPkroFxq4VExJQcZMci50XYM5lYkbsOJmdAsZOu7P6Sd4ga0RIBtcOIJe8feXeTsB40elBS90lxRCF5a2DIsd2eM9+C4iT7mXHd8f4lq0nFIRRyZhqXoGH1amy65RZEN2zgj0VDpJ0iXpGFoPoLy9iJrl2Ljdddh/WXXY7K997n+strYHgDBqrmMGD8u5CEa5WSC4mP8JG1QaQA1CjxxcCkIPBOwsDwngDd4ZpVsmxXqGkYqJw/H/qOHSifO9dzEdhSELiQ0gR9YeIxaZp63rXAJ7JTQqHEutnQ5RFDKbqQ3Cx0h0DNB8SXR2vTGiHKwJAoJGsiyMkGyuEQeyZ1IUUivsKoCdiJVK+qQv3SpcgdOtQeGH1EIcnCqDMSheTXhaSF7HN2C01MIuIlTBjLXoW7dE1858gD4xGF5MrA8EaD2zVRCwu5e+I1CCtZWTDr6uTPqBDiyUXuRZO7kACbgTFlOYpcVrt+GRhyPbhMvxZUIepI1MQ4kNSASTM7tKTmlykmEYx6a2DUvDzaLyXEjD0eBkz5iy+h4vV/IlRcjPbXXGP/IGFgqHidinh5BoZoZHa//k/6TETLylBw4u/scGTWgCHFSGn7qjMowDR9uZ/p9SDu8FTuAzumuFS7p88nSRPgSxvm34XEMywyNy0fpWQKgm6apwaJcVZrY19bvUIIIAkYmH0H3CpFYn3LRbzWy03cT7qLiFfTfA0iFC5h0+kwME4XUhto1sqfGhgkRDA7QZs7k0ElF/FCIuL1Y8Bsu/8BlF00HtWLFiXadAsZ9wyjtgyYmgy7kDzCqDkNjCsDo7ufD4CQxYQBQK/330P3119HuCQRkSHmgfHSOpCwTAcDw058pgm9Rp4bRyvgdTByDYz1jNCQZWFQtiYY9jNn2CVxIYkMDH3W2agL0UATGZgkAzJN0CgxYEQNjBIOexYeJdfI1VDOYBSSaMBwbJbkuSA1zgD/7uv4rp0APCIHpQwM0QIKRo7qNOyN+npeS8JcWzERpqI6NTBie64gYdppCJfd0iGYsn6T370SbJJcRpK0GNJyFICg7ZMtEvg+ijmB2Cgko7KSM8yja9ZwTbVEBiYwYNIEW5FaDAcFIBSyE0oJhBjmQOZCCmmpMTBu2XPTYmD4F1hr04ZOnFQDQw2YxMOui4OyyyDAJrKTinjFPDBkP8a4iG/bljjE5i3Wj/KXys19AGSYgWHD5WkxR0mfQhoUct9dGJiEC8l9kCCGJJBIaJdzwAD6OR0XkoOBEVLHGy4FG9laTIn9ZLksLGOBUNRMf3b/6w2sHHo4P2kLIl5u0pU935YBQ1e4DZL8H6I7TtRTJDEaKJslyYQqMjAyISkHwsCIhjJZzGRQA8NdOyCpC0ltxRgwPl1IJK2/4xkRjROAPvfkmaDPvGXkSCvTx2O8ISC4iFTG9QFNhRJyXns/OhhyDKppSuU+eCWkBBL3Vkid4Fbvre7HH7Hy8GGJFP9+XOLC/om2k7iQBBEv4rwmRq+q4t7l6Jrf+MYCBmbfgS3iFcKo43pidSlhYKj6PkRWgAZkuQ9YP7Thi4Fx08CkbsCIL3CojS3ipSnoySBlrVqM6jRcSDIGxs2AqXG6K+hE7WbAeCT3o4nsajPBwLB5YEh+FRkDE5YzMJw2x5uB0RgGRoSomfKaEN2YIlEsrVfJDRiHkFc2cFrfEQOGPdbmm2+GIeY3MnnhKZd8zYcGxhZQM31xY2DItfLpQpLBwcCEwlDTYGCoAZauBkbGwES9XEjeDAx8upD03QkDRq/mnxHbPcQYHFTEyzMw1O0jGQsQi/N9Fa4tq0FSZBoY+DRgrHO0k/eloIFxY2CY5Ht2HSg5A0OuSe23S2BUVKDm8y94AyjZuRj8+OHoI+dSjfOpEuJxLiOvUVnJbd/wG2/ApJurqCkRGDBpgl2l8GHUMYe1LCays0W8ulzEm7IGxmUST8uFJGhgWrehBoxRWZk4lzjPwPh2IbEiXsmqyw2c3oIUhKMsgj8XEmcYkDwwdZkV8dLsp6lEIYk5hDwGCaJFksGZByZ5GLVjMBVq3ziMDAtiMju5H583Fkh0jGufdENgs7wLEBK3BMmIazMw7PVMooHx6UKSQdS8sKypvLEEGyQ+Z1SEnCkNjOAmAHhXsuxaakWt7P6oqi8Xku7GwMiikFT+uaeGpCcDE/dkYLhMyJoqNWD8sCmUgSH1n9JlYDg20TJgNM12j9EoJLlAlwrGo1E6Bqvs8+TSL46Bkb1f7O9x3aGB4RmYau440d94F1KjMrw3EQIDJl2E5WHU0CVRAEIiO9sHb0gfCm4wFF1UMrhEU3jV0HCDQwNT3C6xQrNexHh5Oe0PeenFQdmtzgZ5WdSsrOS5Xdj2WHYkxjMwfl1IUp1SpvPA0Ey8LpoNMaW62C/d+16zLiRH+z4YGLqNCwPjSK5GGDMh4sahgfFY+bEiwWTRFKm4kJQwcSERBkYi4k3GwCRhPTwZmGwhbDqZC0lPMLMi02cX+8sQAyMT8bKfk2hgzGjUlwuJGDB6FW/kyqKQbDcZiUIiLI01Bsgq08fjtkGtaY7xQs0SGBjJtfdT1JZGOWU3VgPjHF+kujeXEGnWgKFuOMaAcQ3UEPNIOfooiHijggHDZmyuquS2d2pgAgZmn4E7A6M7Jg9bAyNhYKTFHEP8w5vkpcosA5M4VlafPmh11lnIPfxwKKpKa+Do5eX2KstFxOumgSGsSSKDqoQ2dgEb5URf+CQuJK9SApTOz3QmXuKyc9PAMFFTVLDHuZPkBi2BlwvJpv3dDRiSet9wYa/EiY8eV3AZOTQwMvaAGLkRJkzTS5djGoI7ztuFBMsNSxkYqYjXhYEhk10yBsbDgBE1MIrwzjraMoxEmnuhT2QiTjsTrzhp6bq9gLAEmqLbQARbksGor09qwJjxOIzqhMDbFwNDn3teB0LdyC4MDJhK1CI4o1pTqUHraCMJyDOnUiYsXQ0MLyMAkBjHBdbVLQqJjmcMA+PHgBEZFhGOZJGCO5FjYCp5DUx8+3a+sUDEu++AFfFyaer1uNOAifMuJJqZ0nQR8WqCAZPMjeQyEKcj4iWr5ILfjUDHv02lNCaZxIzqaoeI1+FCisoHPjuRnbwatRtkIbtGEgbGodyXRAlkJBMvW8wxmkwDY59z7eLF2HLHnZybJiHiFfZloi38uJDodZFMPrR6s6sLSf6csRMcAGiFogbGfeDk8kx4reB0Q55TB3IDyQ6jtp5BmYiXS/Vu/23ngUmigfFYODg0MFoSF5JLaQbqQspYJl47XbxqvbPJqlGz76JZX59UA8Nqo/RqPlJNmgdGqIVE74tYjZoF40KSGTCsiFdRNU4vYnfOvwaGFONMqZgjazDE49h6//2ofP992oaUgXFxa3IMDGEvWVbJBwMjfYaEgAFO5xaPc8J9varS8zlMFrW3JxDkgUkTVIgbizqSpDkmcBLNQPPAMKF1EhGvEuJFackMGDcqPL0waqeADBBcFGRyIi+9SFm7MjB2iXm31b4Mcg2MR+FEAl236Wv25ZOEx6bvQnIWc3TVwDDXdMdTT6H2y6/4jeI6TAdVnkXPX/MyYEgpAZoHRrLSpgZM8kR23H5C4rpw5/34/aQaGGLARLy3IxCzx7LPrsyFJCayo6HhzIDtkpuDJhdLlsjOi4ER874wwntpWy55dVRJlFZKkOWBsQxprbAwoVtraKCF+6T3QMiKnUwDw4rtzdpamLGYI7KLW6DQEhpCGDV51l0WM+QZ8MXApBmFRFxqNBFhKonsmGtfv3w56pcvR7hbV3S+//5EHyW6N0dov0wDQ65hKJQYv+Jx93MRggAcfeRyLfHV7kUGxqiqhiYsVvhjBQzMPgPehSTQh4IVTx8i9sEEEoON7KEgPl+/5QQyyMDYqx5B9U9Stjc0MAyMPH26u4iXhFGnJuJltSrkJaXGglt+BEjcM+R7Gkbd+CgkGWsgZWDCIc6PL0spb+q6q48cEKJFxPYZA9PUdfu6MIM/GZyoNkropxHzx8AUjDgBXZ59BuFuiSR60kR29FkPU1eGZ4VsQQPDi3hlLiSLgRFEvGLeC7Z9At8MTAoamGQuJBiGM90AWBGvMLF5PNfcdh55YFTClDFRkVIGRnUxYNzSIVTw9ZwIC8Pl9vHIxOtMZCcfC8x6a4ERcRonIgOTbh4YKuIlUUgu7LFjP6FSM4FRW2tf43CIskz0fjqqVgsu8ZhtwEBj3M5uIl6XZ9z+XRTx8gkieRFvpeciQyxY6fcZbUoEBkyasDPxxp1CTFHESwYPIQrJdNE8EONB9WnAuA3E6TEwcr8zDYdtsBkYRy4M0kYSA6YxIl7RZ+xJE7MvoywPDNtuQ0NauTjESddtYIMW4sMiJQyUVMTLTryS+lH0NyaRHXv92UgG0YXkTGQnec5UlTJt9FihEPKPOQYhkrXTI2+Fotn0frKidFwUEuurl4qiLQ0MFfFKhMksu8l8T9iqjEYhsS4k2WTq4kKyw6gZ8eSGjVh1zDHY8fQznv1LtOuMQiICaI3RKtHnTXZOIcGASeZCEgwYo6oKFW++iVVHHIm6775LtMEuUIQ8MA4GxkUPZ9QljFIZu8IxMKo8CimVPDC2Cyn5GFC7ZAlWHXEkKt58y9le1M5fo2ghSQSWeL94BsZgGW7GgHFnYOLyvwmEPDCGkJWZFcsbggbGeSwrkso0sW7sWJRddNEeN2ICAyZNcAyMKdByDg0MoU7tUgIALBGv3IUEJB9IaPsuVLgsAVdSUAZGHNSYCZIWc3RGYpBtpP2J2XlgUhLx1ni4kDxqB3HMmMSAEWvcpMPCiC+8GYu55i1hjTapC01SSqDw5JOhFbdD0WmnefaDzQPDhZ8yK1WHJkKksyV9UsJhlNx0E9SCArS7aiL/G00RL2Ng7FU2NdjpylQeMcK645K6kDSBgaHFHHmfP9s+3Zc8y42JQhI0MNA05B0+FGp+PnKHDHa25aaBoXly7H7XL/0v9O07aLZpzz56RCGp+fmU/TLr6xPsjGQscWVg3FxIIgNTWYXqz/4DvbzczqbNMTBkvOOjMSkD4+ZCshhSqQaGMSAVlzBqP7l1aB4YEoXkx4BZvBh6ebkjSgewrhmr3dG8NTCUgaEupBjvxhfKMDiOJxSDdfwuupC46D4xjNqfBsaorETdt0tQ++VX6c0xGURgwKQJTsQr1LNxDNSGwbsHqIjXbbUuGDDJXEhuDExjaiGJmS8jpEJtA33IHfVgLK2EK/VM8sA0QsTrDKNOooFx+VsW0pqODsZhrDY0uGZXZrUGRlTGwDgN2lDbNuizaBE63XevZz84FxJz/dmVqpqfZ/cRkslP8pwp4TCyevZE36++RPGECfyPJJWAbHA1nKtIMrCrMleLISayk7iQ2PTxRANDRbwSBkZSZBVgrlWGo5DaXXEF+n79FbL7lzp30HWp25BjcslxWUFnMkiikGjJjqwsxvUb5Z5vzi2oqZz7S+ZCMmMx1Hz9DYyGBprEjsCoqnT0la+FZLlRaBi1PwaGTI5SDQxrQKqaNAopmcYp0SfBheTH7eRVpoPRsCCkORgYx6JBYGC4MGpVdURwOY7H1TryjkIyxVICuu7QwHieP2FgZEla9xACAyZNkBfGjAph1Mwqh7wUgMXMEBcSobB13WZvuMHZosf9upDcHu5G1EJyuJBIlAszQTsq8hIXhR8NjCT3gxt4ES9ZsSSJQoLw8orbxeOOGjfpGTDOyr+uofGqaq+IZb72eNxxPonCl8nZKjoBmSYMK0pECYdtwSoYDYyL8edmwABy9xVZWcsiN+hkxayO7ZwbEtejrvNJAVnjWywBAFDjSREYGHHApn9LNDDSEgXsOXhGIYmJ7Kz+uEQjmbqcgYEYocMcVyztIO2jLAqJ5O9hDBizoZ6GPiuRCJ/JVgtxY5WM+d32wAMo+/OfseW225wMTFWV89mRMDB0shYNUklZEYBxIUkYO0VkYGSsXrJSEUz9LZrIztc195rkbQZMCYUdDIzD3S8Lo2YMoKTuV27xLGNCPfLAxJwMjLdOzRp7WWM7MGD2TvDFHFlfe5xa6JwBE4s5XEgmUwuJNRhEF5JbYjj7mJlkYIgGRi7iZV8wUcSr5nkzMDSRXUQi4vWI4JAZMITN8UxW5cbAIPHi0XZJvox0hLyOdPxR19B4APaAJtXAOPMCeSZHY7djJk0ywSi5uZx7IJ0oJC9hKusKdYCuIp2DsHSCN01pUkC3/cj1pKH8DU4XEmcMkj4qij2hejAwYjkQFko47DTo2AWI7J6ZLi4kEs3ITjQkU7QfBsahqdCZdAURqrEx6uup2FbNz+eMBkVTaVkQtv/s87Dr+RcAABVvviXVwIjlC6R5YCgLQYS+iT5Iw6gBGJaIVx5GzTMwsjDqpJMr62olY5mfCTnJNmRhpGiavVCjiezEcUhwIcUEDY2HmxYQnhvZWMiyRXExD0yM++xbA8O+pz5Fz02FwIBJF+yqUtBXyBiYLbfdhujq1QBEDYwQmQT7hbfdAulqYBIPZ8Wbb/oTBALuGpgsksXVXcSr5louiqQMTJZjAhBDdVnwLiSBXvdiYFw0MGR/smqnpRLSYWBEDUy0wSUPjLVCJ1EJLgaMaPykZcBYFL+ak8PdRzWPN2CcUUgSfYTX8Ql7ICvmGLdXkY5BWGrweJUSkBgw1IXEJ7LjWTeeGQVgRXYI9Wlk8GJfwmFn6DH7/koZGHkYtSzKhNVDJINTA2PngVGyIlyqA1KzTM3P540GLWQXMwSSRiHJNDAOY4vLxCsWc2SMW8A1ItEkDKnEPeRgYCRC36TFOlmxO7lOPhIKJtuGJMhUpIns/GTitRa1rAuJOZfK+fOxfcYTlgSBXzwT1H7/PbbcfQ90Ls+Uzme4ZpMewmLSPFMd8H0F4Ii4bW4EBkya8AqjpixGVhYNo6ucvwB1P/6Y+D7E0IqisBegxc/E7KqucM3Em5igN914E7Y/8gjqli5Nel40C6RbHhgmjFoU8SZjYMgEqWRlUdaD7uvTgHFk4vWahDgBGz+Y6VV2Aq5Qu3bO4xgGar/7Dnq1t1Ej1cBI85ZYAxExfGWraxcXkh8omq2xIROMmpPDTSSUgYlGEwyDIwpJLuJ1PaaEPaBtMQyMqPOQPR+mmAeGzcRL3iemLwoNoxYT2bH33MnAKKrKFBd0n+AMD+NBCYcdUXRKMgbGTcQr05uIkXZekDEw1sSvZufYmX7r62HUEAYmjzMaFE1F0Z/+BADIKi2VGzDM+6pX7E58RYq5VlU6IthYw1kU8dL7onkksoN3FJKaLWhg0hDxsu9uShqYZAyMNY4o4RBn6CbGe5coJGZBRt9DkgcG/Llsvfc+7JgxA7F16xxh0gQ7n34G5XPm8ONJPM4vDAQXEpgMyzKYMg1MCqUXmgKBAZMmbBEvX7yRDaNWwmF5kTGaB8aw92UH57BgwCRjYNyqUQsTUrSszLMdgHk53US8MQ8GJs9mYMTwOlPX6apWpuvwMmBIBAXbPzIJe4l4OcNS6I9Raa0iFYWm6GcnmN3//CfWnXseysZf5Np+oj+CBqahQU7lCgyMtC2JiNcvAwPYzwuZYNScHO46ExEv6aeDvZJFT3m5kLxyVFDXqMaswJ0+dApHHhhmYKWRIszzJoh45aUEJBool6KaIrwWDUokkoSBYe4ZUz6CGsjstkx+JfvY/kW8sigkfdeuxKFbt2aqddsaGC0vHwqrQVM1tL3oQuz35JPoNus5TgNjSvIJEQM5sl/nxOeqak8NjCjiZY3bxLbeeWCkGhjWheSqgfE2NEyJC8nPhJysXZpfSuMjD2XFe0UXUmJ/2wVF92eeZfIcGXV1wtxj/63XOA0R0xBEvJKkq/HyXR4nZrUfaGD2ftiZeHkGBnEdbBid9OWjmXh1RtjLGDDEheQ3kZ1bmmlm4gec1K90Hz+J7GgYtTwKCYw4jrbLnIMaEUS8qspPThKQl5pOgg0NKLvgQpSNv9h9Jw8NjG7VcFFzcqBZzARrwFT86w0AQP2P//Xsl/gCG4yLjYWogZHCMBzXLT0DhmhgcrjjkfMEiKGVPMzUm4Fxj0Kig7yqMe+KOwMDXeeMQTY8k9DcbD4aWwMjiHjZd5ENsWfz0ojp3SXwWjTIGBi4uJCoMcCIeAnjB8BZywm28ZQeA2NAtyahUJvWdo0fUQPDBQ0kGIyC44+D1qqVfc+Z95g10AzLRRnukkhkSLL9suA1MLyIl94XwsC4hlG7RyFxYdSuUUjJXEhWf5hCnJlgYEjiTTaMGiAMjGjAON8Jct5gjX+pyFtI2eC2ACDf6XHOZSSKegFA35UIg1ckC0pTpoEJGJi9E3Ykg0QDw7z00syXSUS8tgupkYnsolFeZc6kAHdti4p4XZJbMXkOWI0PwIdmOpL5Mf1IMDC8yE8amcKAhqBax45t2oTar79GfOtW93Px0MCQKrpKXi41vFgXkl/XjdNQc9HAEFYtSUSReN1SM2AS2xrUhZTLTbQJl1Lis+ES7u3stw8NjBcDo7F+/Ljr9qZg9HIJtyxjgqtALJQSoAyGi9uQY2BCfH9k8GRgwmFnqQ0XFxKbdZsYMG3Gng+tdWsU/vEURy0nQMIyesCRwVfXEbcmIa1NG2ogGfWiBsaZ6l/Wf8omM+dHDKFwx46Jz8mikOj1FhPZaY5tWVAmIlkYtaa6iHj9aWASC033iDoHfGtgNCisq9wwkiayA5j8N6rmNP7APB/xOGfAcuOdS54p7nvBpQSA1mYTC7gmfgyikPYZUCNE1MCwLqRIWK4rSCbidSSyS7OUQH19ygYM3DQwRMRbZw+0ImuieRgwdIJRrcGGHbTCYahZ3gaDUVvDp8j3AdNlMgNAq+iqObm2L59JbOfXgBEFfUZ9vdwwIBNAkvw3DgPGryEFQA0TBiYxCKk5OfzAHg7z0WTk2fNiWTyjkDw0MFQ0G2IyT+sOQ4VCSLLGMxLW+8Suuq0Jh2aylYVRS6KQFFW107vH4qj97rvEPRP775XELhJxMjCsq06WU4VhYMKdOqHPvz9Fp2nTpAwMFRC7XSsWEg2M7UJqYxtI9XXUhaTm53FuG7fFCiA3YIhhEepQkvhc5RTx8nlgBBeiqIFxE/FSF1ISEa+LBiZZpmUw2ir6DvgR8SZhdjhXIcvA6IZjbBBLCQCg4mWFrWBPr51OF8xc0jsIRo4sSCDawBv1ogYG9r11FGyFfd9YdjJgYPZSUHYkxmtgENftSU32UsF+Id1EvORv1a8Gxm2lYRhcrhO9fLdnO4m2XDQwxIVUJ0zyzApDycmhn90YGCUrK7Eq4cI4NSgRoTieeCq1tb5Sg/M72amvReqWGHNqbi6NnkqHgXGKeKPSftLcPilkIAYa50JSc3K4iVYJh+1nis3n42WkeBk3nhoY4rKxV8dmLO4e3WOa7lFIJPyeFY1rcgaGT2QnYeA0e1VbvWgR1p17HnbMmOHsTipRSBq/0pa5kNgwajU3NzFpKootQq633yu+pIJP9pXJNxK3suGG2rS2o5DqG2wNTH6+UGxRYozRfEXW8dkyGNZ7Ei5JGDBJGRhVYLxEBkbICUWeOa88MKpYzDHsfIb9iniVUIhbkCZDUhEv1bAIGhjDmSZBjEJK7G8Z1Ez5EZlWJpGag597aBuS58YQMo+LiezYvqtMGQq2/4m+OEP+9xQCAyZNKMygLKapt0W8LhODRMTLvaRkcA43joEBwIXRxbdv924H7EstaGBITho2+ZsWcgzWbiGY1ICxtucod01zJAZz9Ku21jO0VbqPmHcCgNY2Ub+n4ddfAVg6AcLA1LEGjD/DQSbilWpgCKvmIykdYD8PjdbAhHjXhp3YrMGeSDyuvacB45GJlzcYyArcWSeM24fNCsquSMmzw666hTBqENctO7hKykckopD4YS+6caNnX0SIGhjH6l+yGGHDqFlXq0OEDGEy81nIldwnvbKCvidaG5uBMRvqqbBTzcuHtNgi+awojvdYxnCQd8moq/XMxKsIOg5qdLlUo1ZEo07qQkrOwPgW8YZZQ8GPBsZ7HDLcNDCSNAneLiTVIeLl3TciA8P8LWEVxcSdZjxmF3C1+mkzME4DhibjiwcMzF4P7gUXXUguBRHpvoR6Nwx7kA2zgx5xITVOAwOAZmUF/BowbhoYwsAwk7yQglz1MmBIfRayPbsyCYeoi8r1PNJhYMj2zH5k1Vi/bBkAIFRcbJdAYNklVgfgVfFaqoGRlRLwIeJltyeGXgouJCcDwyeyU8IRoaq4DwbG6/iax6CvE4OBD6P2miA43QszANO8SpwGhg+jBhI6D+4ZkbExbGkD0r6E4UxmwEDzMABkehjDgF7rNGActZwgrLKjMehVVdh63zTULf3J2U9yD4kBs31H4nNuLtTsbNsYqKvnNDDc+yfLsixk43UY3ooCrahVYpu6eqfLgmOohMSBBsPOwclKUrca1ZIkC6NW0xTx2kk76ZgsPJ91P/yArdOm87mokjA7dIwMafx1lmhgTLE0CphxSCLiFRkYrr24twvJkaiTiUIiKRaovlHiQqLGl2BE7UkEBkya4GshCTQeQ02qTOQH3ZfNYEoiepiXlK4uw34z8bpPCjprwGzb5t0O6T/bR9InooFhdSKMeh9AQmORjIGxJlBuBauFqIvKDVyZep+g9CxjgIQ6dAAANFhJBRMGDNHAyF1IpleGXlED48LA0PpWPqtwh4qLE/8zESvJIHMhORkYJiEhZWDSdCHR51imgWF0Dswg7MnAsNl3rcreiVWr1U82bF9kYJBgGfxoYJwGjCRiw8uFJGpgxIUK+2zTuksGFaLLGBhDCG+1+xHFjqeexq7Zs7H2zDOdnREYGLJICbVOpAagBhJTSkDNzxPeP4kBI0ZAiuNBTo4tfq+uhqhNU2QaGwcDI9eFEVeh4bMWUrrFHInxwGpgxDFm+1NPYdesWaj6+BOmXZ95YEKhhGuRuBeZoA0xOzXHwNQyLiixDANrbMfjQtoA+3mXzRkiK2Myol5Wvwjwlczt9l3cWHsQgQGTLsgDKFi6bC0kJRxGj3nzUDR6NLcNXS2QARrCSyomsvPLwAjJ4QCegTGqqqSCRa4tFw2M3IWkuTMwom+VSW+e2FhwITEaGHbSJIN9OgYMXXWzDIwlPCTfhdq3Z6KQWOOMyXvhkaFXqoGRMjDWObmwciI6PfAAujz7DLL69PG1PSAxYHJzeAYmErbz+TTU0+dGLAnBtelpwHhk4iUMjBbixL5e91B8ZsTClBwDQ94R1WYBzfp611IC9J6ENIhRL1IDplEMTIjfFkisdmudBkxyBiaK2Hr3/E008aR1DeI7EgwMyS5tu2NsDYyal+fZf7bfbgyMmpND80BJS3Cw2xPRtO7GwIgGDImccs8Dw4ZRJ4o5ppMHRhKFJC68LKNT37mD2S9ZGLVtgADg9ElUOE/GQT3uKFtBx2hNkok3LjIwPPtP++czHJzqywQDxouB4c4/iELaO0GFZkINEC6MOhxCZL/OKBhxAr8z6xeVuJucUUhJrFzxpWDAMjBAcjeSmwaGinjZwUrlE0gpXgxMA8/AcCLeUIjXNzCrai7Nf4ouJDtxlv2Sh0o6cNuEiouZKCQmEy87oKRkwCTRwPhkYCLduiL/mGN8bUuPQXQ7ZNIRSgkooRCfOM16brxy8HiHUXtktGUYGFbs683ANDg+c+H3Eg1M4nubxUhWjVpRNceKXxqx4cnACLWQRHer5tTH6EyGU46BEcPAITAw0Si0Vq1c++KYEC0mhCRnZPPAkEy8Wn4+H94rEZY7XEjCOaq5ud6pDwSGFWAmWENgYBwuJCupnEceGL4YpTyMOul4IRPxiu+z9TnORnCmwMAAzDvPaGComJ4w9gyDRTUwWsjbhSQaKpKIJi+wySxFT4E3AxPkgdnrQVeVYsIg3fYrUiGmyGawk0Is7tjGWQvJHwMjM2BIuDCBfwPGRQNDVweJyAvfIt4YU8gRwoouxLuQWAMmVNI+0e9du9JgYCQaGMLAkPaLi+0oJIZd4g0YdxcS6RNligQ3BgG9vz4ZGL+GDgtyHvRzTi7PdIXDtr6AYYqUHA8GxjMTr0fuDLrKZnNs6DxbEwqh9bnn0o8OBkYwYLhnhNE8aEVFAJAIH3arRs0ZVPw9SJ2B4TPxOjQaEg0MfQ8FwbqSlZyB0Vq1du+XoIEhCLW2GBgaRl1Py2I4EtlJwpgdTKoqYWC8DF8hUR7bVzZHkOz4KpM9ONEXSSI71nVomlKdTEp5YMh7KWQRJ++3wSQB9RuFRA1bDwaGZexp+5TBsSPmouvLsPW+aYiuX8/1n2dgEm2LGdhd+8ks2NQCwYDxZGBYFihgYPZK0BdcXDXGdacbRjRgmJeNPrzsS0o1MGQQSRJGTeh6yWqZJGwjSKqDkWTeBJgXjqwuBCOL/O3GGpkOF5KQyI51ITGajKwePQEAsY2b0tDAWC9cEgZGpoHhImK86oPEeRGcWc8wMBIho2/DJA0DJtSmNfc5UUpADKMmeWDsMOp0GRhbnCuJQoozbgJG7EueC61tW/T7bglKbp5C9xH99kZDA+eOBWt4MNc23KkTACBatp7bXyzxAcBKDiYwMJIov5SikHyIePVqK+9QXh7HfqgyBobpjxmNcoxNfOdOvjMuuXwIc0mLFDKlBNQ8IZGdJmE4hIWI+O6pubne0WsyES9lYKz74srAWH2mxRwl2czZZzYedxHxSlybsRjqfvxRYMrD/PWTJGpjc2j518CQ1AlOBoaOk/GYM2cWMWZDNltY/uJL2DV7Nsrnvmj3IxrjzzGVGloQDBjRhfS/oIG57777oCgKJk2aRL+rr6/HhAkT0LZtW+Tn5+P000/HViFballZGUaNGoXc3Fy0b98eN9xwA+LCQ7Fo0SIMGjQIWVlZ6N27N2bPnt2YrmYcNOtpgyiM4mshAc4VGmscsC8RAC6nhF8Gxiufh1HFT77x7Tsc24j9B+A0urIEw0Qod0D+dmNgqAZGJuJlXBsA6CQLAJFelgGzaVPq/lZaPM6eyELt23ObhIqLpWHUvKjO3YVEJm9iwBgN9TazIalv5RqFJOqXfEYrcbtYq24CNTfHnpws8SpfEkK3t3OBLw2MLLMuM0mxmXhZl6kaiXCGmpcLSQmHBdeM3a9w584AEqtUbn9WWMpEIYkTplTwKBuYycIi4q2B4eh4Ep5aaRswLBSm2CKF4EJitRwigypGIdGuWsYsy8C4JrLzYmCoAcNfj4S+SnU3YmQMDzF0qYhX4f8nbRMDxiOEmxNvR2NyDYzEsN5yzz1Ye9bZ2PbgQzZ7EA4B7KJSEmXDGTDJXFNs2QrA1gAxxRxp/2NOtyrNI8Nk4iUMkGhI8SyjZWCkysCoqkMHpwmMTOLgsiikvZSBWbx4MZ555hkMHDiQ+/7aa6/F22+/jddeew2ffvopNm3ahD9ZlU4BQNd1jBo1CtFoFF988QWef/55zJ49G7fddhvdZs2aNRg1ahSOO+44/PDDD5g0aRIuvvhivPfee+l2N+OgPlOZC0nQkYirA/azY1v2xfcbRi3TwBDfu8DAsAmznO3YtTrEAUGMEiIGCJsvJZU8MNwkEhLCqBn3VVZPwsBsTDmMmjIwTLIv1oBR8/KsRHZWGHWNCwPjQwNDCiWyDAzHThGDz8UwEY3PdFxImoyBIfeJGNNZtguJGr5eIl6vMGovDQyNZtN4fYFo3HsYMEZ9PZPVOgJpenrYDExsnSB2lRS6U1TV4R6VMZwyo4ZMrI5aSMIEm9WrF9pceCHa33A93Y68h6Riu92mnZeHGFxsf4xolJskHC5gNwbGMmZJ+/quXaD6mPx8XgfkI4zakSHaemfc2Due4REy8QqJ7BwMljDWyCIUWRbLjMVc8sA4n8vdL70MANg1axY39srGZADUxa/vZurI+QwdJgsDO5eLQccikmdFr3EWwrRrKTlD/tmxKFELyZn3KFUDhmXOCaQGoTSR3Z5lYPw55AVUV1fjvPPOw8yZM3HXXXfR7ysqKvCPf/wDL774Io4//ngAwKxZs1BaWoqvvvoKhx9+ON5//30sX74cH374IUpKSnDwwQfjzjvvxI033oipU6ciEong6aefRo8ePfDggw8CAEpLS/Gf//wHDz/8MEaOHCntU0NDAxqYG1dZWSndLlPwdiHxKwfHy8WKeMVVhqQoXNKHhEYi2A+dVlgIfdcuhwbGyxjiqrOKg4o4kQnZgsk2blFItoiXaGB4BsYtjDpiGTDxbdsciZhcoaoJQ4ywAKRgpqpCy8+DkpsLs7aWGjNUxFtXl/CnK0rKIl4tz3IhuTAw9L66pE1XIhH+WUrLhcQzMEq2HUZtGzB2Jl6zkSJemQam5ssvUbt4sX39VD6XhSlzUVr3S/bMmISNDIehCMJvApuB4V1I5D7s/tcbqCKLHwkD41cDo+bkwKiuthNUahqg61KjtOTGyQCA2m+XALCZUAcDw1x7s6EBSna2Q8TLJnD0y8AQY5YYp9T1pKoJcbdHIju2PXodBK2DmpMwYJScHEBWJJbTwPAuJFbgTfpEEQ5L3NdJkly6GDA0SZxpYuczzyKrX1/HfqR/Mlac/ZtjPnzqPmhBRNaAs945GpxQUeHuQmJEvPQ31oCJx/jEeESvIynkKAMVC2dluY7vHMiCMOZkqPYU0mJgJkyYgFGjRmHEiBHc90uWLEEsFuO+79+/P7p27Yovv/wSAPDll1/iwAMPREmJLaYcOXIkKisrscxKLvbll1862h45ciRtQ4Z7770XRUVF9F+XLl3SOTXfsBkY7zBqdlt7XyddKTN2VJ8uJLumjf0QkmJcxPdOt/XS07AGjMOFJGdgILqQIm4MDElkR6KQ3DUwYJj/cMeOiWMbBmIbN7n3ne0bUwEYgEOTEipuZ/2fyLVCxa+mSe9nuhoYo77B1hFJivq5lRLICAMjcSHRVa7VF5kGhsuvIvbLRyZeVgNTduFF2PHkU6hetCixTYipRq073auJTlkFJh1h1A08cyewdgSUgSlzMjBGNIrNt92G6k8/TbSjSTQwPqOQiKFLnnHKqnkJs61jkXQGYr4NToxK6jkJiezYCUPUsFFtj/D8hKwsuRwDg8Rzmijl4V7MEZC4kITrQdyubgsPqUaIatJ4F4u4rYOxzk5uwHgVc6z5z+fY/sgj2HDFlcLv9rOYqFJuuXrYWj8yA8YnE0zvteZkYIiLT9/tNGAoCy4RnIuRkqaEZTQFWYMbCOOsRMKO99yrttRerYF5+eWX8d133+Hee+91/LZlyxZEIhG0EsL+SkpKsGXLFroNa7yQ38lvXttUVlaizmUVPmXKFFRUVNB/64XVWKbhNrCb8ZgdWRR2sioAT387jB2JANC/BobJn2JRlA4GxiuM1cuAcVjoiX6KDAxon71dSDwFr7kmU1M0jRFprnPtO7cPuTeOsM3EMWmSOGLAMBM4GSDY6+SVB4bca1vE66KBoQaqDwMmDf0LIHchUQZGSPxm1DcwE0nI9Xn2zsTrroGxO8HQ4GwmXjbzNJk4krmQuArmTgZGF5gA0zQSxifbP011XN9UGBiAua+kHQ8DhhiQJJ0BXZWT35mcMrSekxCFZHowMG76N1IpmqvaDNvVKU00x/ZLdCFJRLwA3CPYpCJekgfGWqFIRLxKKOSsw5akUr0Zi8lrIVnvf2zjBvmO4uJRUjyXRiHV2uUS/Oo+yL0mzwDHwFiLDb2iwn18ZyunWxBdSFyouFUsNVUXkhqOOEqnyF1ye3kemPXr1+Oaa67B3LlzkZ3koWpuZGVlobCwkPvXlHBdmcZlDIywrcIMonHR2GE1MH7DqC1XgC8Gxp8LyTGIOBgCsrJnDJhwhG63+a9/Rdkll9LJXBTx8tVww/wgJWT1dNU4uMCNgVFcDBhF0+x8HFYIY7oaGDYTL2fAaM7Bmu8zs20a7AsgcSHlOBkYhU2cxoYWuxgq3iJem1kB5NdJ0VRuNe/FwIhZX82GKGVlHJE/jAEULmkvd7kxFaDpfqqslEDUUS5CxlRSA0Ywwj3rWwkaGJGBAeCsqC2KeFkNzLbtqPtpGVYedTR+GXgQqj9JZIjlnrWsLGhWBmdVYNeIq1OWaI6FnefKmrRFBsbSd7gaFzKRMDkPttAn+zuIO0eYTJO5kKJRlygkg/4u3U9YaHJ1wsg2zLUnBrJftwm911QDY9oaGGuxYUaj0IVFJoGihZzuTvY+xONONkjXUw6jlmpgPPLq7LW1kJYsWYJt27Zh0KBBCIVCCIVC+PTTT/HYY48hFAqhpKQE0WgUu9mkPwC2bt2KDlYK9w4dOjiiksjnZNsUFhYixyNnRbNCkncAsFxIQiSPgxLVVOckRVfovCgWgF1wyw0S0ahaZDEwu4VVqRcDQ6hq1dk/R7QBGXzYgVOgIms++4xS3jQ3DmFaPDLxOgwYonEQXQQuoNeBUJ5sBAqAvMOHAZqG3MMOpfvQSCQr4ihlDYyMgeFE1WTVLn/lOAMxTQNGTHim5uY67lPI2ia+fTsnpkzPgLHuofXcSHMMMdmaE2HRzkSJrMgRsI1vtkigIkQsiblWQkJ+HwCJwVx0/0kYmMQ5iHmLnO9J7pDBQDiM7AEHcH3wMmDIublpYABw2XLFY8sYmKr334e+Ywef5I+5T+GOHe1IRsHAIOOCmEjS0SfSXjIGxk3EK1TrBhgXh1ciO0GPkjhGehoYWZp+cT9yTMBeRHAGD8vEknktSX4ZAnKvuYKMVp+0ggLKVpPsyQ5ozrIXjv4LBoxpGM7AEgFi4k5Wu0ghu57kvu2t1ahPOOEELF26FD/88AP9N2TIEJx33nn073A4jI8++ojus2LFCpSVlWHYsGEAgGHDhmHp0qXYxvhyP/jgAxQWFmL//fen27BtkG1IGy0BrtWKuSgkFxGvqjomKXkUkjWpWC+RUVeHmi+/ROUHH3D70geLUeaT5F5u0UBufZf2l3wnya7JRdqEnS9CzKr0K+aB4XQIHi4kgM3z4deAsQYiGrbJMzCtzxqDfku+RYElNAfgKOjIa2B8MDBMIjspA0OrUbu4G1iDOE0XksztZ9+nRPuRXr0BWLWgWAbGTcvglchOiEKSGTAKY8Cwk7GMgSEgz65RW8u5kPjkaPxzRp4RFqZp+mJgAMBwcXmyaD12LPp9uxj5Rx9ltWX121MDY7mHquRh1ADDijVIGJiYMwqJ1PHi2mANGMvgB5walVDbdlbfmWspY2AYF5JpGI6JkkyCvhgYtvYb8z8RZYvibPE59uVC8hLxuhkwQgQoYbC5wopSBsbfpK06RLwGZ7yRSKT4DonhD3CZeKX9j0kYmHic6g3dQPRRZKGoZGU5GXbZwkViEO5pBialKKSCggIccMAB3Hd5eXlo27Yt/X78+PG47rrr0KZNGxQWFuKqq67CsGHDcPjhhwMATjzxROy///4YO3Yspk+fji1btuCWW27BhAkTkGW9bJdffjlmzJiByZMn46KLLsLHH3+MV199Fe+++24mzjkjcBPumTFWqGhN1uLDoDhXgbIwW7pytV6o+M6dKLvwIihZWSj44Xs7lFDyQpFKsY7++XAhuVbRzsqiE7wYnpvob9iRdCq2aRMweLAt4nVzIYnlA9asoZ/DnROTky4m8eI6p9gvJHFZuDAwgHNQFJPZ+WdgLBFvnh1GbZIIDZkGxi0KSfOeUHzDiowBkMiUTI5n9SWrdy8ACWMw58AD6fHSYWBEDUwyBsaMxuSV2oV3gRowNTUwC4vsfriEUQNApHNn1FkRPxS67rx3mnPxkOhbAwDbuJCKeMVoOR8iXkedH6kLic8868nA7NyJhp9/dh6HNWAYY07UqNDJK1kYNeNCkk3YRPjuJgDnnudkDIwQseRgrJO4kELt2nnmgXF1IcV5Y5ors0G3YQwYi4HxbcB4MDCKpkIrKoK+c6drdvREGLX7syVlYHy4kLS2bRDbYOuCWO0i/U7yTNAwbS4KaS9iYPzg4Ycfxsknn4zTTz8dxxxzDDp06IB//etf9HdN0/DOO+9A0zQMGzYM559/PsaNG4c77riDbtOjRw+8++67+OCDD3DQQQfhwQcfxN///nfXEOo9AVcRr548jFpRFXcXDRtGHbYHfsDWbJgNDTCYMHE6IDCuF03QALnlZ+H6TgWW8nNjrXTirvDNwFAtg1PEyyZYA4DWZ5+FwlGj0Gn6NOm5yMCVYqCF0qzrQlw6HoYBEdyRUG2/BgwV8ebZLiTIMiPThHIuGphs58SYDhyrVcLAEBdSSUliYI3H0bB2De2T6iaiTkEDky4DowhJ/NRWLgyMh9sj0r2749iJCtASBkZGj0sKScrOhW/LvwaGfsyVMTBW4jaJiDdhQDDvrGEkFgUACn73O7sN5j30YmC0dm2tvvsMo47FHO41gI1CcmNgNMffpsDAUPemGLHkYGDkBkyXmTNRcOKJaD/5BhcXkl8GRhDxWuNtQnRrhynbLqQMMTCkBIarC8kp4uX6L0QhkXNK5kIiLBxBosirUwPT7cW5yB9xAkpuuzXxJdXA7OV5YFgsssIlCbKzs/HEE0/giSeecN2nW7dumD9/vme7w4cPx/fff9/Y7jUZ3A0YSaioqJdRJQwMyY/CTcS8T1bNyoJaWAijshLx7dvpCyArWuZImJWfD7283JuBIfoEH8nWQu2LHd+pknA8EvpsiMUchVopXCbe3Fx0fvAB+3ePlOV0m3CYXndCBZfP/T+EO3eyw4s9JhqS14LUPWqMiFeWm4MKBV36QI4POCf0VKDk5ABMf6lQkrgoFQWR3r1Q/+N/0bByFd1GFsUhnoPjN0EDE5OVqVBV/jmWsXwiA1PIMDAuYdQOA6ZXL+exdZ0roggg4a6UMjByA4Z9rhzvsZ/6VmKdHw8RL83/4cHA0H0KC5E77HBUWe5k1qVNGEvSf5aVo5OXi56I28/qi/T4eSQKyY2BkUQ5kVT3dEHhZGAQloh4XVxI+UcfRd15oggbgD3huqWOEHJwURGvxRaL7ELKLiTKwFjvs4SBAdyzoyuSnEUszHjcznhNO6nLo5BIbiwwLBw5jkTEi1AIuYMGIXfQIFR/9p/E8QgDI8lUvKeQcQbmfwVs3gAOsbgjjNqhkFecIlkyiPFh1E6fLGFh2NWuXevHfolVgTqmLo40NTAAb0jQCB52ghNrikCigSErfYXPZKp4iFj9GDBiPhoAaFj1K9Zfcik1QLwMA7GcALcK9swDIxHxSnJz0PvqasAw9yujDAwfhQQAWZYOhtaaUbUm1MCEfGhg+PvCuZBcSgmI9Xuyevd2HDuhganlvktUo5bQ46IBQ4xhtnK06NrwwcCIeX+8RLymVMRrp2XIOegg+n1Wr17cObtpYACehQlRBkaSp4XtE+O+lrqQqAbGTxi1xUAYPCNKjTuFNXZST2QHWO+2UJ/NruDsMwpJWDCKAlV99+7Esy4zlsT+sMJY1T5/GQPjWmBXk+u17P7HHIJiUzekGhi2Ha2tkC9KIuLlIyit+7O3RyEF4CEb3H0lslMV5yQt5phg2mcfEpkBQ1c2zIslpoenBowPF1JKBgwR5YbDjurUACjdTVkkiYhX0UJCGDV/XLdkWVzfJNeNgCRV82RgGBGvaZppMDB27RAyEfEuJGfSLu74jAHTGA2MGDarSA2YXsI26WpgSCZeLxeSyiVkFCcNAFAU/nzlIt4wr5sSjImILHGliwZG6t93YWA4A0bcj2pgvFxIgnvMK4y6oT7x7Ilh1NY1yD3CDmLI6s0bMCzLIAqaWR2MrYFxGhjcPpLQd1mbbhFCvOCaJDwkDIxYSkBwJ/t0Ibn1mTIpJLy/Xq4JEV3mdpJH61kQ2AV9d4XvJHYqm++HSWTHMTCWq9QtCimpiDfOV6NOdDIuP1/mmjpdSM5MvNyzrvIGqBjKvSfRaBfS/zKUcJgvwgZwYdS2cFMDKzKVhSnnDTsCBSNHovD3J9ntS8L6PBkYZuIXC/TRRGt+8sDIcipAcCGJBgxjyLCIrl2L1aNORtSKnJDngeEZAFOoIutGIXPbeBgwlQsWJL73MAw4Ea9IHdfWynZJ9FViwFDGh7oQQzb745bIjr1fjTBgHHWNZAZMb8Hdkm4YtfWcxMrKsPr3f0CUEV7bx5czMJAYd/SjCwMjZm9O2k8XDYwvBkZiwDjcvj6ikFJhYAxSR4tZiLB5YLJLSxPCz4oKRHr14vL+1P/3v/Rv8m7SY2ZlgUy7GjFgWD2RRx4YMxZzEfGSWkguDAx7r0ieH6qBEUsJCMaO8I74ef/JviYso6qqirIThsv7S5gKUQNDEwqK48Du3VI9kAyc4ctogFgGRiUamPJy+flIMvFy/Y/FHGOV6eJCUhSFTg+EhaO/JckDIzIwbFkJz8zuzYCAgWkEpIM+m22UfQjE2i+OQbsQ+z36CApPsg0YKqwyDNom0Z7EtzGrXevBKvzD7wEAuYcf7oyysXzWfvLAuL00qsyAIase4X8WUSbsk9DBYjE87loKL6UvCtnDgIlbGZ79MDBGbZ3TyIvFpIOgaZp0QFOzs+mgTfMrSBg4t1ICrAbGLVeMH5RMmQIAaHvZZdzxOBeDwFYomsqHsTOuNk8XEnM9pcYLaZvJZyRj+UTXnsaKeBkNDGe0SIwGTfDtA85ippDlYIKzfozDhWQxjHxbSULjmW0IpAwME0YtTpqc2y0SQdFpp0GJRJB/9NEAgILfnwQlOxslt94CtagIOYMHOxP1sdXY2zpFvKI7DmBYjPoGuQaGGDBuGhj2WolFP8VSAuzzHpaEUXtlg2aPSeuzEQaGGDByBpXoo6g+TEgcKjNgpPoXybPoi4EhGka3drSQN7sXizsYGJMJo84dMgQA0PaKy7nIJK2NxIDxygMjuABltaL2FAIGphGQh+651HsJh23RmCxRnCz3CvPiGvUN0PJDDANjCybJixpq3x79vv8OSlYW6pfzoZa2CymaSGIWj9N04xTpaGAi/MvvyDrsdk5cmGWIry4r+HXdImS4drnoLXkf3EKYAXDJnbgB2xJAxneVI5Kbi+iGDVBzcxOrX3bwCIUShfhqax0VvfmJN7kGxs3I8YPcQYeg33dL6ACqtU5k/GTLDJDv7INrfEmIcJhnPtzgJV5l2paGUbOiYVcGxr4XqpDITvaMRrp3R50Qai+W0lBUZ5RLom/eDIxUJ0I0MB6TjJ8waoUJo5blbWLzlbS/cXKiyrV1Dp0feghmXR3U3Fz0WfSJVMvEslB2ZIwkUy7bTyYqT5asjCayc4tCYs+P1kKyNBSEgSGuQyG/FDeGqKprVKQDRMtCNEXEheTCwJDkgg4Rb4OLAVMhdyEp4bAz0R/LwCg2A8VrYFo59jGYchhKSM4WEsgYGDYTb94xx6DLs89Azc3Fzqeeto+Tzz+DSpbAwIT48Zg+w/tiFNL/MjiRZiSSGGw4FxKfB4QSwyIDwwjQuPZzcugEatTUQMvPsw2YbawLyV7RUHFdjsjAkCiZKFYdfQwAoO+330JjHuZkGhh20KOVnAUXklnP1KoKhRwvGDVG2BdEmADEwcCXC0kWRi3CwzAg4a1GXZ1dVFBRECouRnzLFujlu6Dn5+G3k09BuEMH9Fq4gK8dFU7ksmHdTbZR54OBYV1IjWBgEm3Zq7/CUX+AEtKQd+SRdvOFheDy5mgqx3KRZznxt1cUUvLhQwlpnBjdUX0d4HUiigKVZOIVRbxJDJicgw9C3RI+F4whlNJwY2BEoSfJfk0NGNm50grjKYRRC9GBAJjyDk62QxQ+K0ISTEVRaAoAUbhPz0VW4oEVzkr6b7tUa+QMjMs4I4WQB8ZRSkC4r5w+Kjvbd1SeWHE9mQuJiPPpfg4Rr6iB2S3PPCvpn9T1aJieDIwmGDAJqUGSMGqRgdHtTLxqVoRngkh3hUWmVlDIl4Rx0XrJNDB7moEJXEiNgNRtwTIwEd6AsT+oEFN5y15SRVHsKsfWQCwV8ZKwXTZRmzCYkbocJCMoAER/XcVtk0wDQ1YsAGg5eNF1pDOlC7o8MQP5I07gz4lEW7EVccXJQdTANFLEa3faQwPDptdmKHvCXOi7dqFh9WqY9fWIrl2bWI0xg5liMTDSPnF0rEsiO5aBUTL3WqpZWSj64x+50ElF0/jcOoIGRszt4wYpKyHeK5XPAyOt1C1oIKixLeSB8QqjBoDiCRNQ8LsR6DB1Kv1OrDOjaCFfGhgILiQpQ0qjkDw0ML7CqC0GpqHeMUEmMvESAybN9aYsaiaJiJeK2mvrHGJWJRKxWQs/iwuGgTFNM3kiO+Za+3UfJfa1xLhZhIGxGIMauQFD6sSR60rF1FTEK9HA+AwbZg0HNpEdDXtWNeoqpfsIz4ZMD8TClNZCijMRny4Ca6FNrajQfa4C7HG6BTIwgQHTCHADPfMi02y1LhqYRCI7NveB+yqXhOcSw0Mq4iUTPjvAO8KoE+3ojAET37WL2yaZBkZnkufRwVtgYNiy8/nHHosuM2ZwYZ2yqsvkeDmDByf2Y1L8A9Zkl2QV5uZCYusDeRkGNmVeyxUQDFk5ZOK7ymlIOABEy9Zzg5kjSytso4gXxLnoizgNTPouJL/g6iapCjfYyXIRySAOdB3vvgttx18kbOOSyE7UhBGEw/a9qKmhzEhCA8PrpkSoubnY7/HHUXTaqfQ79pkF4DsKyRBFvDIGxkcmXgjvuWxC9mJgDLfQ80aCY6EkjJTq5lIFvzhKluYfEAxdJjmcjIGBUI3ar4AXsO8DfZaTuZCIcUtr1lljWGUlts94AnU/LQMALgWFLikrIhuZZAyMqRvMYtPJwDgMGM1/Jl4qutZ1GEScLNEOssYnPW6hwMCIUbMODUzLYWACF1IjwA4oanY2VfqLIk5AMmALFVjdQOh03WI/QsXt6TGMmhqYhoH45oRIlaWn3fLAsKuK2ObN/MGSaGA4etMCWdkTpiJn0CBUvPkmNwmHO3emkz/nqrCU8WRF0G3OCzDr6x20p6IkJlgS8aUVt4MuJH+ycy7wE1Ske3fU/fBD4oOXiJcYipVV3KqfME36rl2cmyFatg7hjh3sBjTNMdjSrKec3qdpw6j9QmvdGli3zuqT5mqopKKBUfPynRO9qkKJWBoAtzBqwYVAJ4y6OhoS6ohC8pm+3xAMGLcoJDH9OomuoFoPDwbGa5XMMq3iiptuQjPx1jtW+GweGD8uO98gfdc0KfvLaWAIa2a5FkkgAeDTwGD6LepAuL5AwsD4yQHF7AuAupBMvy4kQcRb9f77iG/bBq04EW6sFhUmDNpYDPpOScizzABMxsBomkOLJhowam5u0ky81BiMRGjEmEmThjqNZTU/3/EcaYVF/PsvvvMCA8NFISUrNNzECAyYRoAzYFhfMNEWsA8KS/8qvG/Ta5LQBBeSlp8HNTcXRm0t4tu3o3LBAhg1NYj07oXsAQPsNrOywOocZNQ1yZJLu51EA6NLDJicQw5Bp/vvR87ARF2dVqf/CWpONnIGDbZPna3NImNgyMCjqtSfL4I1YAqOPwG5gw5BdONG7Hjscft8rbbYqAPWgPEyDMJWNePY5s125exwGCHiQirfBb3CngxjZWUwLcaIRKiwg60SDtOqyty996OBaQ4DhmNghDwwrD7JMxOvYMDk5zsTYjHJuPwUc1TCYe5Z1St2W98LIl4vlor5zZGJ100D4yLi1QoS75/0nfARhcS+5/lHHCnfJssOo06mgWkM2GzFUvaD7RPJTM0wMFm9e6Pt5Zch0q073c5Nd8O1JTIwggZGdA1y2sFUDJiw4EIyEi4rVwNGjBa0jkXYbX1XudWncCJ8fccOec4WqQbGyahyDIyqQisogNauHS0lwKZiCHfripxDEmOcG4wGO4WHkpWVyMDNhFHLjD+1wLnI0Iq8NTAOBoZ9RvematQBeHBWqxZyvmycC0nIbChL9CSBzcDYrh/iRoquX4+ds58HALS74gp+JasonBuJfTkISJI5Aup/91pRClAUBUWnnIxIt270XIr++EdE9rPdRqwBw0YU0ZWfVxgq3Y8pNZCdhaJTT0WkS1f6XahjB7QaMwbtrrgc8Z22a0xjcmV4MTDEzRXfto0aQEokQssQOFxI68qc+X6Y1ajWqhWdcNkJzm1FxWfibSYGxoKiaa4rXU8DRoweys9zpoEXayFJUgw4VuCRCL1XRFPlrEbt5bZhrp8oCHfNAyMYDpaxTN6bdKOQ2L4UjDxRvgl1ISWLQkpvvdntxbnIO/po7DfjceagVp9d2qQiXoaBQTiEwhNPRHa/vnQ7X/o05trJGBix7IAo4vULhwsprifuY5LMuWIeGLo9MbRCISbpnKSgrEy/yGrHaCkBg2NgAD6pJGu4t7v0ssS74BWFxCSsY7MPe2lgtDwnA6MWFAQamP9F8EJE1fHAeLmQuDA1LwOGMjA2q0DyXdT98COMigqoRUVc/hi6L/Pyy6IfYoJ1L4ueYtHxnnsAAB3+9jfX/soQKimhf3PXiK5gkxtM3H7UZ81H93S8429od8UVXNVq9ry9GBitbdvEMQwDsfUbrPbDnIiXNfiiZWUOPQeblVRr3drOcxFKzsCwCegaE0btFw4Gxq0WkhcbJDwnMgaGq0Ydi0nDsx1RKIpCB3OiqRJdSJ7J4xRFOqkk+qNKXSZuGpjs0lIoOTkcu8meW7K+1P/0E/2bjQTj+ktFvA3eeWDSZGByBw1C15nPIqtHD/tLa1J1zQzNZqb2CKn3w8CwBqMZj9uuCDKxC/l90nUhZQ8YAITDyO7fP3EsXXdlX1jYIl6XdyAUou9LXOZCkhkwrEFAM9nqdhI/67qzBkyky34IlZQgq39/FP3xlMS+ngYMy8CQnGF2GLVMAyN1IRUVpaiBCfLA7BMQ6/eIPkdXA0YIm/YyYAiFzYaDkjj+2NaE9iXUqpU8FDInh+pypC4kkYFJooFp9afRKPjdCNs14hMhy5cM8NeMrmB9RFew11YRKiwD4LQGcSazpcYyT141axQF4Y4dEV27FtG1a2n7JNtpXGLAiIUJ2cq8LAPDMlquGpgMhlH7ASdu1txrIXlBZB5kgyPLwAB2tW9Hrg/apnUtc3NhVFbaBkwkYk+2kjxKDmiaNM25m3HIGjCmrtMopHDXrujz2WeOzNbk3BL/uz+/OQcfjOpFixDu3Nmd5fLJwDiKSTYC0kKKDFjDhAihZQsbPyJezvDUdS7tAwBhMcfXQkrluSy59RYUX3ct6r7/AUBiPPNlwIgMjOR3krNFVjlaZirzxUoJg2E4zj3Sm2Vg8tH7ww9gmqY9tiUT8ZJ9ySKBcyHJNTBim1phIT9/iOMxeVZkDExgwOy94GvdqFCzbCGv+DsfhcQPwF6RHmo+L+IF7Ek5vmWrtY3TPQSAqxQrM2D0nTth1NXRwYqutDwNqtSMFwBcwjxp0UYfDAxrHJCJ0y0UV2vdCrGyssR+XEpv70kv3Lkzb8AwIt6GVasS18fSFek7dlCDhvrQWQamVSvbJ88lbXOLQmqaMGo3aK1bMQdX+WfQb94NqQZGOD/RgJEJ3CXvAg2lJpNnOGy7HPzkn1FVsaRWAi7uHrYAHmvMqJGI9N0BQCcmLxdSm3FjobVtgwIhso6FSksJMGHU1nNmNDTYrgyPcSJlkL67vHtKdrbdB/YeyLYjfzP5g7htFIXmhGJ1ILL3X9E0zlBzq7Uk7bOiQMvPt+9H3C8DQ0S8LscKJ3EhebQJJGNgetvbWRlx2bfP0z3J9dGKQop7h1FHuuznLEoqpn/QxEUIk0kYQh6YwIW094LLXiqp6Osq4hUT2XmsrFTCwDAaGBISHbcYGDcDhg3NlSU0AvhIpNiGhEspxEbXZABZ/fuj1dlnoe1ll/FGBHWxJB+Y5S4k+Sq+0733Iu+oo9Dtxbn85JPMgLG0OiwDQ7QiJDQ+1KED/W7r9PsB2Cm7OQamdWvkHnoo8o87Dq3HjrXPw0ceGNM0pNtkEg4GxkXE692IwMDk5jpFvIJA2K4T5RJGHeINGNoOG0btKwOwy3X2w8AwEUleDEAyFgNIXJPWZ57J5eERQRYFRnW1nXk41xbR0uNlMApJSbJ4UFSVPpMkl47s+CwDI6Zu4NqjuWDiTBi1xvcFieeCfTZUH5l+nZ0iolndUY1ciqQMTJhxIfkzYCAsbgEkjBedZ2DYumRiDbjEvv4MGLpI0nU7DQRz7To9+ADyjz0W7SZOFOYlqwivorgWHybvEtUutaBEdgED0xg4GBhmsFMUQXTIrnCdiezcQAY3nXMhJQyW2OYkBgyrgcnK4soZEMQ2bkRWz54AgIbVvwLgVwWZgKIo6MgkF6Pf+xFBWmAr0lIXEpdfxR4Es3r2RNe/zwQAVH/2md1IEtcMEfJGLfZGiUS4gnlAwsgJtW2LqvffpzWe2l5u1R0SRLxafj66PPWkcCJuUUi2gdkcBdJCbAin6i7i9YKoJVFU1fksh0KJ+2ytwGUMjCylgCOUnhH2psrAqHl5djZaF+PMYAwYWhcp5KzLw8FPLSQfoEX9Kio4A8aoqeHe10zmgbEFtN7Gl15bC72ywvX4SjhM762akyNNtQCAy8Zri3glRpRwzRvl2oz7dSHxYdTO320XkiwKyVERGsLYRBhV03CcOxtkQBaQXDt+ni1VpQtkVsTLupCKRo1C0ahRiW0YUTMX7m2FYjvcwIGId98Ex8AovIjXsRL1SGTnLeK1VmeMC4loYEgeAy1fTnGzFY6VSASqrNDi+vX2378mJuSsXj1d+5NRpOBC4vLHyBgYF7eLrCqsG8KdEwwMpWDDYaiFhdyKP9KlCzre8TdklZYCAApOPBHZfRNRGargQpKeh9uKl3mWZNVkMw2egRHDqBvRsISBAezzowyMbIBnvncwMOEwzR7sdm05MNc51M7WYLlVY+cYGMudlCwLLHEr+OqPZzuJ/Y2qqkQuGMhdvhllYIjR6Cc7NdXAyI8fatsWUBSHsc8fzzJgGBEvfRcctZAYBiYFF5LjWLruWsiR257UUPIU8VpGpiyMWmLAECEx2z6XeE6i/8liorvsc0k+RbMJ70w/mXiZY4oGDACnBoYVYTOFhQEk3IJJoryaEgED0wjwq0gNXmGevKhL41edXnlgqIjXqYEhIC4lEawLSQmHEw+osCKJrv4NQGL1R/IfsPkimhI2A5OaC4musFxW8Sz4jJj+GBh6nEgk8bIzL2yrM06H1qoVus2ehYp330Xh73/P9JF1IbWSH8TNhcQWs2xmAwbw8P/7hRv9bA2sajgMHXINjJgHBpAxMGGEO3ZE58cfQ7iDUIRUAtYtobVtS5P2uV1blvVKNgEQFF99NXIHDULBib9L2h8vsLoykgLAYcC41EtLGwrJA+PBwBAXUoW7BgYA9nvsUcR37MDuf/4LWL5cfjhaD8hwhlF7JLLzUyzSATqZp6aBcTNY2SgkGVgGpse//olo2XrkDBxIv1MLLeOnssqZxA9Ar/ffQ+23S1B08smu5+IJZu4xamvtPGQ+2CvOgKHFZ10YGFgGqGiwxWJACiUfMonAgGkExIgaTrglrkS5RHapMDBWCQCJC8ntM/1eENhx/cvKgtnQgAbLDdJgGTKhDh0cBlKTgboEUnMhUZ81K/ZzCwdNhYFh8tUA8gGb6F20oiK0Ofdc1z6mysCwMKLNa8Do1dXQCuVZYv2CPGtiODZNmEaiJCwtEVzcfzYDI3EhASj8nU9jgXke2Oq7bplDTc6F5M+ACZeUoNXpp/vrjweUUAhqQQGMqioapusw4ELyemlpI4mIl+0DLcfgEi2Yc9BBAICKeW+6Hy9kuzgciezYhV84xIt4fVSiF5G6C0nIHyMiHHJUjubA1CPK3n9/ZO+/P/ezRl2Eu53nDiDStSsiXbtCBj9jY0L4nNiuYWWivp1aVOQ6L7DgxkdJ8dnECTAMjGQBYMbj7vXnmhiBC6kREFeR3AvgMGCEyZZdiXuEEUtdSHk+DRjWhUQYGAskrwXRvdj6l+ZhXxIdlOSBcAHnQpKGUbtoS9iVbBKqM1RczN03EvXR+txzoGRloduLc737yKwWQ24rNh/nyiaoaiqw186orOL85W3OOw9AopaV7/ay7UzIHIiRKgxwbu4/kqRR5kJKCWxhU6YtsWQAATsw2wxM8w3KdJLbwRgwPjMipwN/AmQi4nXXwHDwSlNAdRRxhw6Ey9ujiSLeNJhBVm/jw4Ahonw/Il4CMn5GevRI6kLRWI2ThIHxgp8FDxgXUv1//5vo3/6lvgxeLvrRxYDhGBiZAbMHdTCBAdMI8GnxvTUwYuZR3u/vw4VU5cXAuGhgSHI0S1wpM2D07Tug795t6196N58Bo9CwWB8upGxJGDUbVqrKX1aNnbyYxE/SY2gawh3sCCxyD0tuvRV9Pv8PcgcNStJHPpGddBsfA1dzuJBYRLp15Z6NrL790Pebr7GfKED2gGo9a2Kor+JmwLjkgSHVy0UGIpWqxAA/6LIGjJtAWq+sRHRDIoEhFUE21q2WAsgkF7dqfCmRCH8NMmzA2FmiPYwOEglFXEhJ3lPPyTZkGxWUhZAUlHRkn01DIE0mYFPXnaUkBER69KARYp4iXsGA0dq2Qd9vv0XPt96UamC4bS39jFFRIWVgvHf2IVhnJAl1S5cCAHJkiRclkLmQvDQwhmRxtScjkQIDphEQY/25SBmHFcu8lCkksiOlBMxYjK4eRdGum8uHVkMmljXT31Dbtgh1SmgJGn77jbqSmkv/AjCGiA9xIpeUSSLidTMM+CRqyVdjssrZJL9EMnC6CzcXkg9K2E1ommn0mPcGOt1/P3KHDOHdoZqaSG6VQk0m1Y2BEUS89BjMvatndBP5Rx+d2E0SRp0SmPdLYxhLt2tb9913WP27E9GwerVvF1ImQQ0YK0xXCYd4ej/TDIzEfSOCaOj0JCJeglA791BxqqvQdZuxYMdA1oDh3Iup637oPrEYdKasiAy5hx5q7+dlwBTw77+ihRKlM8Lh5AYMube7ypkvfTIwfvLAaJptXFp9Ed1YbpC6kLw0MMS9TXL7IGBg9lpw/n5NlUbKsL/T31SV9/t7DE5qXh6lVwkL41sDk0N0Cc4wQSU7i4ZLN/z6K0Lt2iHUsSOyemc2hNoLrceORf7w4cg5+KCk20pdSGJ24yQw67wZGEAoPJnipGEw7atuCf+aoUyAX2T374+iUxLCQW6yTqOPhO1zCNut++I0YOx7x5V+sJg2Etpvb5/aveAiLTgGxsM4NE3UL1vGVPNtRgOGJkqzGJhwmF8dZ7ISNSAV0Do2IccneVuS3IN2EyYg7+ij0en++x2/sZFBUgaGlmXQeDduCnXZaL+taDWjtpbmuXJjRFkDxlXE+//t3Xl8VOW9+PHPmTN7kpns+0JYZN9RiLtCBavWtXW7lrpeFW2tS63eVlt7W7x6W/VnXdreW21769rWuqIiCBZFQATZJLIHCElIQjLZZn9+fxxmmMlGEkLC4Pf9euWlzHnmzHOeOct3ntViNua46epHZw+bkCLTM9DDH0RGpnrWB8YZWVj2oB4HMJ114u1BHxjNbI6mlxqYBBW33oVmimtC6GxCryiTifYrsHb5GSbToVlJD1aHdghguhiFpHVTA2OyO6L9XfzbtpH/8HxGfLj4sM0k/SntO9+h6NlnejQdeVwTkqVjDczhfgXB4ZuQ4NBQ6g777wHlbTv03q4mUhuAZQL6on0NTG9FO/G2m3G6s/1DfNlm/Lsxj07h009FX3O0Ow+PpAYmLoBp3zzX7nsKVFYeGkY9gH1gTO36wNBuVe7+roGJNrl2V/vbbmK6wwVRustF8R9+Hw2K4zdGhlHHzAMTWwvRRQ1MX5qQYmfB9pZvBozBCZ1xnhRTA9NVwBpZnyvmvtuT5U+i+Tn43Ub64+jp6T3+PntWA2Mi9bL4zuSWLjoFt9fZMOpOa1EPfj/RTtGWQ0s+DMS8VV05Nu+mCaL9r02TrZsaGFN8dWl8DUz3F8OhFam7CGC66ANzqF+CNe6/YNTORPq7+A72fzmWxT1MIv0qYso/usprN6IjYLphye/YhNRTthEjDp8o5oYcuXnoMfOUDJYjHUWg2eNr+4D4X6zt+8bEpMu64weM+HhZ3HT7enJyXHNmb/PXvg9M5PNiH1hAh+A5sHdvTCfePgzh7aPoQy5mgdC4AKafa2C0HtXAtAtgjmApg7iZeDupgYmdUiF+WHUfagM1LdoZPHSwT5GliwDGErvQbJc1MMZxx6+r1vPvIxKcRkTy1hNdNqHFNbOZMTkc0R8CzmnTetz865h66IdC9Pttv9SAph0aUh/TnHioBmbwAhgZRn0EOgyjtnZTA6O3q4GJnXjtcL9skpMIcmhBx/YdHLvsA+OMr9aPy6/Njn3sWNKvvRbHxAmdvv9YosWthdRJDUyoBzUwPQlgjqAGJun008l7eD72g5PcdSb2PMi660403UzyGaf36nOOhtjqc9WDsuzw/kggEDsENi6AiX846DE3dU3TOp1q3zFxYnS24yMahZSczNAFC2j55GPcF10Ul0xzOuPmRgrsrcR2cBKyge0DkxqfL4u18w6W/faBkWUZDj+MOpqHIwmiYjrxdloD09WUCn2c+8aclRW3+KolZnkUx9SppF56Kfax8c0sXU78FlneIqZZuDdlEZmAMTZvPdbF50QWO4VDwV/W92/HWlKC88Rph91t6euv4920iZRZs6KvRbpEdHZsmtMBLS3RbgyaxXKoWXAQ+8BIAHMEOrT3x85V0tWKnmAEMD3sAwPELOh48OQ52KwUmdW0y8UcI7+KD0bWcU1IDju24cPJufdH3X72sULrrHYrtm02dPgamB4FMDE1ML0e+aJppLZ7QHZgim/aOGz6ARI3E3Bna7Ic7v2HqYGJK0td77qPUAzHpIk0/uMfxn57+/A0xfaBcWItLMD6ne90TOZ0xi3AatTAGH1gBrIJSW/3K/3o18AcfiK79msbHUkQpcVMLhedN0XrrAamm8EPvWDOjg8SzDkxowutFlIvubhjHrs4vkieYn8o9ub70A6e75GHf3/UwJgcjmgAEx3UoOudHldn7CNPwN5u5t/oc6KT2iWTw7hOYtfFipaB9IFJTPE1MFq7JqSua2C0DhPZHSaAiQ6ljl1OILnT/49lGzECzGbsJ4zsmF+7o9P3HKtiHyadTcNNDwIY1ZM+MLk5nTZR9ZfYX5gdbhRH4fN6LPaG3IOyjEg5OLFc+ty5QHxzaFwNTEyHd93t7lEVt2v2bDSbDdvIkT3OT/Tz2gWKXWkfpAT27SN8sC/TEc9O3AuRTrwRHTrx9vO5YR02DEymbps9Tc525XYEQVT0XIiZybVDrXQnn9GXJiSIDxI0pxPdfagWpKv7rWYydXoNRidXjK2B6UUfGIgPUNsHV93qan6r2PlbejFasNuP6qoPTMznhZtimpCOgVFIUgNzBNpPpNZdE1K3NTCHuTHk3Hcf6u6740bImJKTobra6EzVRU2BtbCQEf/6KFqFGduGHRmhlCjilnzvpLw6W1CtT59jNmPOySZYue/ozC4ZG7i2uwm6zp2D5403e9aXpp/FLWXQi19UBU88TqixMbo4ZIclMyL7jynLnq4dpLvdjPh4WZ+G0nbVibe95DPPxLdl68GEJpTfH216GIxh1BHta2C6m+yyLxxjxzLi42XdfhcdOvEeSRAVuxZSu9eg6xoYa7vRaD1lzs4+9P8ZGd3Okh7LZLUSbvdAjlynpi76wCSddhot//oXjnYjgWLpbjeBg/MM9aoGposALnaduyMJLONEuhp0cq6ZOlmZPPI8GcxRSBLAHIEOw6i7mwem3a+Nni4lAGArLe3wWqTjrp6U1O2Mi7GrDscvJZBgAUx3Q9Sh+1qDg6twd/cgi2XNLzhqAUzcedDuwZz7wIM4Jk2Ka5ceDL15UGkmU9fnWBejkLoa0tqZvi5rETcnTyf7GPrOO7SuWkXqpZdgHzsWc1YWe+++h+C+ffi37zD2MZhNSFYLJi22Can/a+fMh/keOizncAR5iPaXiBnG3tkw6si1PeTll/Dv2YNj/Pg+fV5skGBOT48fHdfdqE+rFSIrl0d3cLAJKaXzJqSCRx+h8Z134tZFay+uBqaPTUiaxXJotXL70aiBOXiP7eT6bz8rMzFLPkgNTIKKG0ZtajcKqbsaGE2LG77Zl979kcm5erLexaHPiR+FlEi6myQQuu8DM+SFF6h55BGy77m7R5+V9m//BrpO0imn9D6jh6N33YSkJyd1WF9pIGXd8QO8GzeRdPLJfd5H3HdjPrIamCPSxUy8EbahpdiGGj8MXHPmAEYHbiOAMdYF69M09n3UIYCxWOJ+IB2N5szD6c8amOi6SjEzindXA+OYODG6xlJfxAYJemZmj2tgOqt1i3biTe68E6+emnrY6za2ibCvnXhNSUmEGho61Lpb8g+/uGlPuM4/H9+WLbjOOafDtkiXg3CkBsZyaG09FZAamIQUVwNj0jodKRO7PbpN0zpdwK43IoFLrwKY2Iu4B3OvHEvibiydNSl0M4zaMX4cJX/5c48/yzVnNq45s3uTvR6L/0V1bF1+mTfffOQ7iZsHpqsA5sgWjuyJrpYS6I4lP582VhsPCQa2D0z7obbWoUMJVtdE/93vE9n1QMdOvH3PQ3QqiMbGQ/vrZCmBvsz70pm4GpiMjHaT4x2mBqb9a9E+MDH32l72zTHF1cBkd5Oy3We3awoNNTR0mCvH3sNlAw7HOWVyl/fJaBNSU0wT0jHQB0Y68R6B9jUwsVXOHSeya3fCx/77iAKYnt2cIX4kSE8mjzuWxDchdfwF1Zehv4Mituatj0NEj2Waph1qS+9iHpjDNV30i8hnm0w9DtY7rEY+gDUwJqsVPT0dgLSrriL5zDPjmnAGowam49DuvudBjwQwB4ND48WY5R4O9tPrr+A2rg9MZkZ8E1I3Nd6dbYsEbnofh1FD3zvxtg9gjPxY4r6L/gpguhNpQgrHBjAyD0xii+8DE9+E1HFBrPhYMb4Gpvc3hkN9YPrYhJRgAUx8E1InD/4+DP0dDEc6y2giiLbVH2En3iPKw8FA0XSYPmKxzAcDiIjYc24gFD7xOIHqGlznfdOYPOwoDqPuCUtBPo4pU2j7/PMjzoPJ1TGAif1ecn/xEL7N5dhOOKH9W/tET0szfhgGg+gZGfH36u5mH+6k1i1aAxPXhNS7e3YkGNTd7t5Nz9BZAGM2x/Ul6umyAUdC62QiO9d538QxaVJ0RvfBcHzeQQdIfA2M1m7F5PadeLuugenLLxv9SJqQdH1wh+z2Qdw8MJ3UXCRkDcwx1oTUXzSzGUV8kG7qYyfePosEML24PtoHVgPZhATx6/JA/DDmwaiB0TSNzFtvZfcNNwAcWoSxD/QUo4alqxoYx9ixPV5BuSc0kwlzRgbB6mrMGb3oA9NZcBENYGIDyt7VnkZqYHo1hBo67culWSz4tm49lL1OJoHsb5GFPaOT51nMpHUyr9JAkyakIxDfB0aPn2fF0u5C6NCEFNMnpg+/bCKzhdpG9XyOjEj+TDZbj3+VHiviFxvs5LTtwVICx4K4ZpXjsAkJYgPl2Gr7Ae7Eq0dqYJyHSRjzlnaB1UA2IXUmLu+DFOwmnXKysS6VxYL94D2nLyL9R2L7wHR6Hfcjx8SJoOvYR4+KD2C6qT3prhPvkTQh2UePAk3DPqF3s55rMas+xwYwwerqXu3nSHVYSuAYGcV6fP4EHCBx7aWaFtcs0+0watp1cOzDzcl1zjk4PlrauyF5kamiHYk1iR3EjwjpbMRRotTAxAUtg9AsMBCiSz10NYx6QJqQjHLuaQde6KQGZgCHUXfmqC7m2EOaplHy/HOEvd4OU+L3RuS94YaDAYzJdNR/RBX8+r8JeTyYMzKiD17oWQ2MZrVGm2k6a0Lq7bVrHz3amJOrD7WPmq6jgsFovx7d5cIyYwatn35K8qyZvd5fX0TXxTpYCzcgP0J64Pi8gw6QuFqWUCi+maO7YdTQq4nsumLJ7nlvdjgUcCVa/xdo14TUyY2vN52ZB1VsDczxGsBEzv3YjpOWAW5COnh96UcQwAzkMOrOxM3EexTmgekpzWpFP8I5kSKjkIKRJqQBqH3ULJZo84rWw1FIkX5PelpatJbjUCfemHlg+tB/zdzHRVs1XUcBjgnjsf3iIeyjx2DOysKz4B1SL7usT/vsdR7a/ehtP+x/sByfd9ABElsDo0Khbidb664GZqD6oxyqgUnAAEbXSZ/7XYIHDmApKYm+nv/oozS8/DLZP/zhIOau574WTUid1MDEBuwDUgOjRZqQetEHpn0T0gD3gWkvrvboCPqfHAuiNTAHm5COpDanL3raB8Z98cUE6w9gHzuGA3/+i5G+k6UEUANY4xtd2sRK2gUXRF/O+N73BiwLkT4w0SwNwFQIPSEBzBGIvRBUKBg/UqZ9s5DWrr23H2pgeitaA3OMtF/2Vs5993V4zX3B+bgvOH8QctNHX6camNjFNmPWoRqQh5fe+yYkU1JSdOQKHANNSDE1MLGjThJR+87UvZrMrR/EDaPupsk+5eyzSTn7bA689NKhF9v1QQEIe339n8kuRNd+68OEp/3F5Dw2a2CkE+8RiF9MMGxcJF0tBNihBubIhlH3ReSX74BU4YtOxdVKHKcBTKTDaWwNUzhmevaBCNw0/dAw6h6/R9PQ01Kj/x7sJqTY8kv0AKZ90DrgAUwPa2CiaTqZdyr22g23tfZj7g4jUqM5iCNH28/KfKwEMMfpHXTgqVDkV5sN1dracVXVbiayG6jhtEkzZpDzk5+QNGP6gHye6ETsyJzjtQkpWgMz8LWMUX3oxAtgTk0ltL8WGPxRSLESPYCJa35hcAOYnvxwiJ+UtJOlS9oOv7J9f9G6+lE8gNoHMO1njh4svaqBeeaZZ5gwYQIulwuXy0VZWRkLFiyIbvd6vcybN4+MjAySk5O59NJLqW433KuiooLzzjsPp9NJdnY299xzD8F2q1kuWbKEKVOmYLPZGD58OM8//3zfj3CgBI2RMZFfbR1m4m03b8CRLiXQF5rFQvq/XY1t+PAB+TzR0WB87wMt+os1JlhLvewynNOnk3P//QOTiYPTFPRmHhiIn332WBkqCqACCR7AWK1x82QNag1MD667uHXtOkkf9n69AhitfR+YdrM0D5ZeBTCFhYU8/PDDrF69ms8++4yzzz6bCy+8kI0bNwLwwx/+kDfffJNXX32VpUuXUllZySWXXBJ9fygU4rzzzsPv9/PJJ5/wpz/9ieeff54HHnggmmbHjh2cd955nHXWWaxdu5Y77riDG264gffee6+fDvnoiAztjfxqa98slHTqqQCYc3ONF45wIjuRoL5Gw6hja2BMSUmU/Ol50r97zYDkwVY61PjvCSN69b74JqTB7QMTK5zgNTAQv5ZQryd0O1Lm2Cakw3+vWhcBjGPaVADcF13Yj5nrnnXoULBYsBQWDdhnttehD0widuK9IKYHNMAvf/lLnnnmGT799FMKCwv53//9X1544QXOPvtsAJ577jlGjx7Np59+yowZM3j//ffZtGkTH3zwATk5OUyaNIlf/OIX3HvvvfzsZz/DarXy7LPPUlpayq9//WsARo8ezbJly3jssceYPfvoLLDXL8Ld18BYcnMZ8fGy6C/CuFFJx+mDTHT0tRiFFFkLqX2z6QDKvP02Ur99GZa83q3UGzdd/LHUhORL/ABGT3FFm+cGvAbG2rsamLgRaDHpS557jmD9ASw5vZvC4kgUPv0UYY+nz8Ow+8Ox2gemz514Q6EQL730Ei0tLZSVlbF69WoCgQCzZs2Kphk1ahTFxcUsX74cgOXLlzN+/HhycnKiaWbPno3H44nW4ixfvjxuH5E0kX10xefz4fF44v4Gkgq2q4HppN3UnJFxqGpSG/hOvGLwaV+HUUiRToe9nG69X/Ogab0OXiD+Rn0sBTAJM89RN2Jnsh3cUUiHv9/G1r5p5vgOwAMZvIDR/DaYwQu0C2B0vddNs0dLrwOY9evXk5ycjM1m4+abb+a1115jzJgxVFVVYbVaSW03x0NOTg5VVVUAVFVVxQUvke2Rbd2l8Xg8tLW1dZmv+fPn43a7o39FRQNb3daxCekwD6fYvhDH6Zo4oiNTUhLuSy7BfeklccNkjyfRB8Qg1sD0VWxVeafr4gywgsd+g2PiRHI7mUIg0ZhiRiKZswY2CNBMppgRoj2pgem+E+/XTexEdrrLdcwsRdPrb2bkyJGsXbuWxsZG/va3vzF37lyWLl16NPLWK/fddx933nln9N8ej2dgg5iDHZFtw4fjXb8e65Ah3SaP+yUufWC+VvJ/9cvBzsJRpXUyjDpRxN6oj4WbtOvcc3Gde+5gZ6Nf6IPZBwbjPqtCoZ4Noz5MJ96vG81kQrPbUV7vMdN8BH0IYKxWK8MPjmKZOnUqq1at4oknnuDyyy/H7/fT0NAQVwtTXV1N7sGOq7m5uaxcuTJuf5FRSrFp2o9cqq6uxuVy4ehmDR+bzYZtEKt8IzUweb94iKwffB9LpLNuV0zH/2gU8fXU2UR2iaL9jKOi/5gOrkitu91xq5MPFM1iQXm9PesDIwFMByaHg9AxFsAc8UR24XAYn8/H1KlTsVgsLFq0KLqtvLyciooKysrKACgrK2P9+vXU1NRE0yxcuBCXy8WYMWOiaWL3EUkT2cexKjoPjNl8+OCF9hPZyQUijiOdLSWQIPR0meTxaNFdRh+Ywah9gZjO5T2ayC4mwJL7M3CoH4zpGBmBBL2sgbnvvvs499xzKS4upqmpiRdeeIElS5bw3nvv4Xa7uf7667nzzjtJT0/H5XJx++23U1ZWxowZMwA455xzGDNmDNdccw2PPPIIVVVV/OQnP2HevHnR2pObb76Z3/72t/zoRz/iuuuuY/Hixbzyyiu8/fbb/X/0/elIVkOWC0QcRw4t5ph4NTCub34Tzxtv4Jg8ZbCzctyJ1MAMdAfeiOgPxd7OAyNN/ABoB/uHHUs1ML16ctbU1PDd736Xffv24Xa7mTBhAu+99x7f+MY3AHjssccwmUxceuml+Hw+Zs+ezdNPPx19v67rvPXWW9xyyy2UlZWRlJTE3Llzeeihh6JpSktLefvtt/nhD3/IE088QWFhIf/zP/9zzA6hTj77bJoXLyb9e3N79T4VE/D0ZF4CIRLFoanXEy+AMVmtFP/xj4OdjeNSZE4e+9ixg/L51qFDCR44gLWw8LBpTUlJmLOzQdM6DCH+uoo0rx4rk9hBLwOY//3f/+12u91u56mnnuKpp57qMk1JSQnvvPNOt/s588wzWbNmTW+yNmgKn/x/BKuqsBQU9O6NKjaAkRoYcfxI5BoYcfSknHkmwz5Y2Kfh7f2h6NlnCHk8PaoB0sxmhr75hvH/CdiX62iIBHIJWwMjOtJ0vffBC4c6/YL0gRHHl2hfA13OaxGvJ7UfR4vJbsdk7/nyEMfSg/pYEA1gBmI1+R6SO8xgCavo/0qEL44nKbNm0rJsGSkHm5aFEInPfdGFBGtrST7zjMHOSpQEMIMlHDp8GiESkGPCBEr/8ffBzoYQoh8di3MSJd44x+OEiqmBEUIIIUTvSAAzWMJHMOxaCCGE+JqTAGaQKGlCEkIIIfpMApjBciQT3wkhhBBfcxLADBYlAYwQQgjRVxLADBLNOngLTwohhBCJToZRD5LUyy+n6f33SZ45c7CzIoQQQiQcCWAGiZ6cxJCXXxrsbAghhBAJSZqQhBBCCJFwJIARQgghRMKRAEYIIYQQCUcCGCGEEEIkHAlghBBCCJFwJIARQgghRMKRAEYIIYQQCUcCGCGEEEIkHAlghBBCCJFwJIARQgghRMKRAEYIIYQQCUcCGCGEEEIkHAlghBBCCJFwJIARQgghRMKRAEYIIYQQCUcCGCGEEEIkHAlghBBCCJFwJIARQgghRMKRAEYIIYQQCUcCGCGEEEIkHAlghBBCCJFwJIARQgghRMKRAEYIIYQQCUcCGCGEEEIkHAlghBBCCJFwJIARQgghRMKRAEYIIYQQCUcCGCGEEEIkHAlghBBCCJFwJIARQgghRMKRAEYIIYQQCadXAcz8+fM58cQTSUlJITs7m4suuojy8vK4NF6vl3nz5pGRkUFycjKXXnop1dXVcWkqKio477zzcDqdZGdnc8899xAMBuPSLFmyhClTpmCz2Rg+fDjPP/98345QCCGEEMedXgUwS5cuZd68eXz66acsXLiQQCDAOeecQ0tLSzTND3/4Q958801effVVli5dSmVlJZdcckl0eygU4rzzzsPv9/PJJ5/wpz/9ieeff54HHnggmmbHjh2cd955nHXWWaxdu5Y77riDG264gffee68fDlkIIYQQiU5TSqm+vnn//v1kZ2ezdOlSTj/9dBobG8nKyuKFF17gsssuA2Dz5s2MHj2a5cuXM2PGDBYsWMD5559PZWUlOTk5ADz77LPce++97N+/H6vVyr333svbb7/Nhg0bop91xRVX0NDQwLvvvtujvHk8HtxuN42Njbhcrr4eohBCCCEGUE+f30fUB6axsRGA9PR0AFavXk0gEGDWrFnRNKNGjaK4uJjly5cDsHz5csaPHx8NXgBmz56Nx+Nh48aN0TSx+4ikieyjMz6fD4/HE/cnhBBCiONTnwOYcDjMHXfcwSmnnMK4ceMAqKqqwmq1kpqaGpc2JyeHqqqqaJrY4CWyPbKtuzQej4e2trZO8zN//nzcbnf0r6ioqK+HJoQQQohjXJ8DmHnz5rFhwwZeeuml/sxPn9133300NjZG/3bv3j3YWRJCCCHEUWLuy5tuu+023nrrLT766CMKCwujr+fm5uL3+2loaIirhamuriY3NzeaZuXKlXH7i4xSik3TfuRSdXU1LpcLh8PRaZ5sNhs2m60vhyOEEEKIBNOrGhilFLfddhuvvfYaixcvprS0NG771KlTsVgsLFq0KPpaeXk5FRUVlJWVAVBWVsb69eupqamJplm4cCEul4sxY8ZE08TuI5Imsg8hhBBCfL31ahTSrbfeygsvvMDrr7/OyJEjo6+73e5ozcgtt9zCO++8w/PPP4/L5eL2228H4JNPPgGMYdSTJk0iPz+fRx55hKqqKq655hpuuOEGfvWrXwHGMOpx48Yxb948rrvuOhYvXsz3v/993n77bWbPnt2jvMooJCGEECLx9Pj5rXoB6PTvueeei6Zpa2tTt956q0pLS1NOp1NdfPHFat++fXH72blzpzr33HOVw+FQmZmZ6q677lKBQCAuzYcffqgmTZqkrFarGjp0aNxn9ERjY6MCVGNjY6/eJ4QQQojB09Pn9xHNA3MskxoYIYQQIvEMyDwwQgghhBCDQQIYIYQQQiQcCWCEEEIIkXAkgBFCCCFEwpEARgghhBAJRwIYIYQQQiQcCWCEEEIIkXAkgBFCCCFEwpEARgghhBAJRwIYIYQQQiQcCWCEEEIIkXAkgBFCCCFEwpEARgghhBAJRwIYIYQQQiQcCWCEEEIIkXAkgBFCCCFEwpEARgghhBAJRwIYIYQQQiQcCWCEEEIIkXAkgBFCCCFEwpEARgghhBAJRwIYIYQQQiQcCWCEEEIIkXAkgBFCCCFEwpEARgghhBAJRwIYIYQQQiQcCWCEEEIIkXAkgBFCCCFEwpEARgghhBAJRwIYIYQQQiQcCWCEEEIIkXAkgBFCCCFEwpEARgghhBAJRwIYIYQQQiQcCWCEEEIIkXAkgBFCCCFEwpEARgghhBAJRwIYIYQQQiQcCWCEEEIIkXAkgBFCCCFEwpEARgghhBAJRwIYIYQQQiQcCWCEEEIIkXB6HcB89NFHXHDBBeTn56NpGv/85z/jtiuleOCBB8jLy8PhcDBr1iy2bNkSl6a+vp6rr74al8tFamoq119/Pc3NzXFp1q1bx2mnnYbdbqeoqIhHHnmk90cnhBBCiONSrwOYlpYWJk6cyFNPPdXp9kceeYT/9//+H88++ywrVqwgKSmJ2bNn4/V6o2muvvpqNm7cyMKFC3nrrbf46KOPuOmmm6LbPR4P55xzDiUlJaxevZpHH32Un/3sZ/z+97/vwyEKIYQQ4rijjgCgXnvttei/w+Gwys3NVY8++mj0tYaGBmWz2dSLL76olFJq06ZNClCrVq2KplmwYIHSNE3t3btXKaXU008/rdLS0pTP54umuffee9XIkSN7nLfGxkYFqMbGxr4enhBCCCEGWE+f3/3aB2bHjh1UVVUxa9as6Gtut5vp06ezfPlyAJYvX05qairTpk2Lppk1axYmk4kVK1ZE05x++ulYrdZomtmzZ1NeXs6BAwc6/Wyfz4fH44n7E0IIIcTxqV8DmKqqKgBycnLiXs/JyYluq6qqIjs7O2672WwmPT09Lk1n+4j9jPbmz5+P2+2O/hUVFR35AQkhhBDimHTcjEK67777aGxsjP7t3r17sLMkhBBCiKOkXwOY3NxcAKqrq+Ner66ujm7Lzc2lpqYmbnswGKS+vj4uTWf7iP2M9mw2Gy6XK+5PCCGEEMenfg1gSktLyc3NZdGiRdHXPB4PK1asoKysDICysjIaGhpYvXp1NM3ixYsJh8NMnz49muajjz4iEAhE0yxcuJCRI0eSlpbWn1kWQgghRALqdQDT3NzM2rVrWbt2LWB03F27di0VFRVomsYdd9zBf/7nf/LGG2+wfv16vvvd75Kfn89FF10EwOjRo5kzZw433ngjK1eu5OOPP+a2227jiiuuID8/H4CrrroKq9XK9ddfz8aNG3n55Zd54oknuPPOO/vtwIUQQgiRwHo7vOnDDz9UQIe/uXPnKqWModQ//elPVU5OjrLZbGrmzJmqvLw8bh91dXXqyiuvVMnJycrlcqlrr71WNTU1xaX54osv1KmnnqpsNpsqKChQDz/8cK/yKcOohRBCiMTT0+e3ppRSgxg/HTUejwe3201jY6P0hxFCCCESRE+f38fNKCQhhBBCfH1IACOEEEKIhCMBjBBCCCESjgQwQgghhEg4EsAIIYQQIuFIACOEEEKIhCMBjBBCCCESjgQwQgghhEg4EsAIIYQQIuFIACOEEEKIhCMBjBBCCCESjgQwQgghhEg4EsAIIYQQIuFIACOEEEKIhCMBjBBCCCESjgQwQgghhEg4EsAIIYQQIuFIACOEEEKIhCMBjBBCCCESjgQwQgghhEg4EsAIIYQQIuFIACOEEEKIhCMBjBBCCCESjgQwQgghhEg4EsAIIYQQIuFIACOEEEKIhCMBjBBCCCESjgQwQgghhEg4EsAIIYQQIuFIACOEEEKIhCMBjBBCCCESjgQwQgghhEg4EsD0UluwjUAoMNjZEMc4pRT13voepW0LtuEL+Y5aPg63fXfT7sOmO14M5HEqpY7a99qeN+jtl/20BloJhPvv/hZW4cOmaQm04A/5u03TGmjtsiw9fs8xe/62BdtoDbQOdjaOW+bBzkCi+euXf+Uvm/7CJSMu4YqRV5CTlEMgFOCDig+YmjOVbGc2ABWeCt7c/iaFyYV8a9i3qGqpIjcplw93f8iamjVMz5vOyfknY9JMlNeX89rW17hy1JXsbtrNuv3rcNvcnJx/MqXu0h7l641tb/DgJw9y30n3cVbRWexr2cfYjLHoJr3Xx7jLswu7bicnKQdfyIdNt3VI8+LmF9lQu4EzCs9gZvFMWoItbGvYRqYjk6KUoi73/cneT/jv1f/N8NThXDXqKoanDmfhroWclHcSBckF+EI+1tSsYXL2ZMIqjC/oI9We2m1+y+vL+dWKX3HR8Is4teBUdnl2MTVnKpqmxaVTSsW91uRvYlPdJpItyYzNHNu7Qorx5rY32VS3idsn347T4gTgv1b9F3/98q/88tRfMiJ1BDs9O3Hb3Oz27ObUwlMpSC4AoNHXyMWvX4zL6uLVC17FolvYVLcJl9VFpiOTz6s/Z3LOZBxmB2EVZmXVSj7a8xGhcIg0exqBcIDPqj6j2FXMxcMvZkrOFACW7l7KM188Q0VTBU/PfJptDdtwWpzMGTInrgyeXPMkf1j/B/59wr9z2+TbouU/JXsKwXCQt7a/xaa6TYxOH8262nVYTBa+N/Z7DHEPweP3YNbM0WOOFQwHeX7j8yilOLPoTEakjYjbvtuzm1XVq1hdvZpsZza3T74dk2YiFA6hUJhN8bcmj99DTUsNpe5SdjftZsHOBext2suM/BlMzZ5Kmj0Nu9lOWIV54vMnqG2r5aczfordbI/uY3X1ar6/+PtMzZnK/dPvJzcpt8ff8ZLdS9jbvJfLTriMV8pfYWXVSjLsGfz4pB/z0Z6P+GjPR2Q6Mjm98HR+/dmv+UbJN1hRtYLPqj7jz+f+mdEZo1FKEVRBLCYLAKuqVvHVga84vfD0DtdM+3O1O69vfZ2ffvxTvj/l+9ww/obo61UtVQTDQQqSC9A0jWZ/M1sbtrK9cTtN/iYuGn4R9y+7n/2t+7l4xMVMyZ7CTQtvwqyZeeLsJxiXOa7H5RPr3Z3v8v7O9ymvL2dP8x6mZE/hrml3ddjfxrqN/Hnjn3l/5/uMyRzDX879Cxpa3HHXttXyqxW/YsnuJeiazlWjjXtGiauEUemj+GDXB9y/7H5GpY/ioVMe4oS0EzrNUyAcwKyZO5RpZXMlr5S/gj/sZ1bxrOj1cziBUACLbmHhroVsqN3Av0/497jroDXQyvyV83l3x7s4zA5eueCV6Pn26b5PeWvbW9ww/gaGuId0uv/qlmqe2/gcabY0zhlyTrfPgV2eXbQGWhmdMbrDtrAK88+t/yTZksw5Q85BKcWn+z7FZXMxNsO455XXl5PpyCTDkRF9XzAcRClFIBzg/778P2bkzWBC1oQelc1A0tSxGroeIY/Hg9vtprGxEZfL1W/7veada1i7fy0Adt3ONWOuYU/THhbsXEC2I5vn5jzHF/u/4Ccf/yT666PUXcqOxh1MzZnK2pq1hFQIgDMKz+D2ybdz08KbqPfW4zQ7aQ3GR+uTsibxnZHf4bSC03Db3FS3VpNmT8Om2wirMOX15Xj8Hn7w4Q9oCbRgMVmwm+00+ZvIdGTy/cnfZ3P9ZsoPlDM8dTj/NvrfqPfWE1ZhpuVOo7atlkAoQF5yHgDvbH+H+5fdj67pTM2ZyvJ9yzk5/2TK8srQTTqTsyfTGmjl+vevj+ZxRt4MNtZtpMnfBMBVo67iRyf+iK8OfMXnNZ8zZ8gcMhwZfFjxIXctvSv6C89sMjPENYStDVsxa2YuGXEJWxq2sKZmDaPSR1HdUo035OXxMx/n5IKTUUrx9BdP88bWN/jRST/i7KKzCYQDfOfN77CtcRtAtAy/fcK3mT1kNmEVJj85H2/Qy62LbiUvKY8fTPkBe5v38stPf4k35EVD4xen/IKzi88m2ZKMpmk0+hpZVbWKElcJzYFm9jTtYU7pnOjDJ2LJ7iXcvvh2AM4uOpuxmWOpbavlxc0vApBmSzN+YYYP/cIsSC7g4dMeprK5kt1Nu/nt2t8C8NDJDwHwwCcPYDVZyU/OZ6dnJ8NTh3PduOt4pfyV6LnXlak5U7nshMu4/1/3o1DR89Qb8kY/OxAOcOWoKynLK+Oqd64irMKYNBPPzHyG3637HZ/XfM7w1OHUtdVxwHegw2eYNTPXj7+eF758ATS476T7mFM6hy0HtvCHdX9gb/NeJmdP5oXNL0TfM6t4FnefeDd5SXn8asWveLn85bh9PnTyQ2Q4Mvj5Jz/Holt46OSH8Pg9DHUP5ffrf8/b298GYHT6aHZ6dtIWbIt7v8Ps4FvDvoWGxkvlLwFwyYhL+Nawb7GqahVptjReKn+JrQ1bAUi3p3PduOt4bsNzjEofxemFpzMqfRQTsiZwwHuAFGtKNPj5vPpzrn3vWuNcSsqnsqUy+rkZ9gzqvHXRf2to0XKPOKXgFJ4860luX3w7n9d8zvXjrsdutvOb1b8hrMJoaNx70r1cPfpqlFL8fcvf+c3q3zAlewo/mPIDQirE9obtlLhLKHWVopt0dE3nr1/+lbAK8/t1v6c50Iyu6Tx6xqOk2lJZsnsJf970ZwByk3KZkTeDt7e/HVe7km5Pj6sljM272WRmWs40Ti04lbEZYzGbzNR76xmRNoIsRxbBcBBfyEejv5FcZy4hFWJT3SbW167nic+f6HDOWEwW/jj7j0zKnkQgFOCBTx7gre1vxaU5d8i5LKtcxmUjLuPWSbfyxf4vePCTB9nbvLfD/iL59wa90Xumw+zghvE38Nb2t5hZPJNbJt6CVbeyoXYD8xbNozClkGtGX8PiisWU5ZcxOXsyN39wc3T/Js3EPdPu4d/G/Fv0M5RSePwe6r315CfnY9Nt/Gnjn3h89eOMzhjN+tr1AIzNGEu9t568pDyuGn0Vb257k6V7lkb3c/7Q85l/2ny2NWzjyrevpC3Yhtvm5jsnfIeQClHhqaDOW8c5Jedw2QmXce2717KhbgNg3NOeOPsJdE1nXOY4HGYHoXCI6tZqlu5ZyiOrHiEYDnLLxFu4YtQVJFuSeXjlw3yw6wMynZlsObAFgLlj5lLTVsOCHQsA4/kDsHTPUtw2N3dPu5vatlrW7V/HqqpVmE1mhqUOY3X1apIsSbx8/suUuEpQSrG1YSttwTZK3aWkWFM6/X6ORE+f3xLA9FIgHGDp7qX8edOfWVOzpsN2l9WFN+jFH/YzOn00X9Z/2SHNuIxxbGnYElclGnvzmDNkTvQBGlRBwLi4bpl4C0+tfQowLlarbqXR1xjdh0kzRYMmXdOjgVJXhriGUNFUwcXDL+bOaXfyuy9+x/99+X+HrfaN5HVi1kQ21W2K3hRjb4hptjQafA0oFHbdzom5J/Jx5ceEVZizis4iGA7yr73/AoybW3fV1maTmVFpo3BanKysWhk9PqfZSVuwjaAKHvZ4OwsOI/mMfUi7rC7S7ensad5DMByMSzs+czzTcqaxrHIZe5v2UuouZWvD1i6rts0mc3QfeUl5WHUrTf6mHjctdXUcc0rnkG5P54D3AL6Qj8nZk9lQu4G3tr8VV46zimfxZf2X0Ru0TbfF5TVyvnRVNgDFKcWcVngam+s3M9Q9lMqWSj7e+3GHdF19hxMyJ7ChbgNhFSbJksSI1BGs3b8WDY3J2ZNx29x8uPtDzJo5eq53JTbNpKxJTM6ezMJdC6lure5xs0eqLZVMR2Y0kGkvUkYuq4tZJbNoC7SxqnoVtW21h/JhMvPdMd/lL5v+QiAcwKbbOH/o+by+7XWC4SBFKUXsbtqNTbcRDAcJqRDTcqbxWfVnHT5viGsIOz070dC4ccKNfLH/C1bsW9F9OZjMlKSURIN26Pp6jz0HAbKd2QxzD2NNzZpoUHv5yMtZVLGI2rZaCpILGJY6jI/2fNR9QcawmCyYNFPcufWdE77DrJJZZDoy+fVnv+bjyo9Js6Xx7ZHfZlXVKtbUrEHXdOaUzkHXdN7Y9kaX+y9KKeK/z/hv9jbvZcGOBXh8Hr468FX0up2cPRld0zuUb44zh6k5U1m2dxkev6fL/RckFzAqfRSLKhYBcM2Ya9jl2UWFp4Lq1uposBz7oyJWV2Vv0238cOoP+a+V/4VC4bK6aA40E1ZhrCZr3I+aWA6zg7ZgGy6ri6KUIjbWbYzLa4Yjgy/rvuzynG9/LbU/B0yaCaVUh0D7cLIcWdEa0H0t+6KvP1D2AN8+4du92tfhSABzlAKYCKUUH+7+kMdWP0ZFUwU/mPIDFuxYwOb6zQCcWXQmT5z1BO/ueJfPaz5nas5UHl31KMNTh/PkzCcpry/n/mX3s8uzi0xHJk/PfJqFuxYyKXsSpxeeDhjVpy+Xv8yiikVsObCFh05+iIeWPxR3cjrNTkyaCZNm4vGzHud3X/yOYlcxd069kz9u+CN/WP8H8pLyuHHCjSyqWMTHez/GrtsJqmD0pJ6RN4MKT0X0l+W3T/g24zLHsb52PeeUnMOHuz/E4/fQ4m9hVfUqWgItZDuz+eeF/2RT3SbuX3Y/03Km8fOTf85Hez7iwU8epDnQDBgPwIqmimh+LxlxCT+Z8ROUUty19C7W7V/H42c9TjAc5OGVD1PbVst/TP8P3tnxDiPSRrCtYRsLdy2MK/sJmRNYV7su7rVHz3iU6pZq7LqdVHsqz37xbLRmYXvjdsIqzDD3MMZmjmXpnqV4g16+N/Z73DLxFh797FFe3Pxih8CtxFXCvuZ9mE1mTJopekztTc+bznml5/HbNb9lXOY4kq3JZDgyGJMxhnuW3sMQ1xBeOO8FUqwpfFn3JdcsuAZfyBe90WTYMwiEA9Gb7LdP+Dal7lI212/mqtFX8eKXL1LZUkleUh63TbotWlvWXmVzJfMWzWNrw1ayndm8duFrVHgqmL9iPhePuJhTC05lc/1mdnl28evPfo1CMS5jHA+f/jCPrHqEf+35F2aTmV+c8gs+r/6cE9JO4JITLomrdQqrcLQGZULWBE4rOI0XN79Ivbceq8nKWcVnseXAFrY3bmdqzlT+OPuPbG/Yzs+X/zxae6Sh8ctTf8kFwy4gEA5wxVtX8NWBrzBrZq4YdQVbGrawYt+K6MPdbXPz+JmPk5OUw8MrH6YwuZC7p92NRbdEr8WVVSt5Y9sbrK9dz6ziWTgtTp5Z+wzpjnTGZoxlTc0a6r31/HTGTzmr6Cyufudq9rXs48JhF1KYUsjG2o2s2b8m7gdBrMLkQi4feTl/3/J37ph6BzOLZ7Js7zLe2PYG14+7npHpI/m8+nOW7V3G3LFz2deyD4fZwXMbnuPvW/4ePe5rx13L2pq1+EI+ZhbP5Prx1/PQ8oeiacB44Fw37jpWV69mU90mrLqVkpQStjZsjQs07bqd/OR86rx1PHbmYzy55kmqWqpwmB24bW7mjp3LqQWn8vrW1/l478dcMuISTi88HU3TWLRrEfcvu59zS8/lZyf/jCZ/E+/vfJ9TC04l25nNDs8Olu1ZxieVn7C3eS/+kJ8UawrbGrfFPQwjD1swgnRd07lo+EXcNOGmaHNNa6CVa9+7lk11m+Le99iZj3FKwSnUe+uZ/bfZeENepuZMZWvDVhp9jTjNTs4fej63Tro1rnkDjB+Sr5a/yvra9dwx5Q6Srcnc8N4NbKjbwAVDL+Djyo/jfiiMyxhHvbeefS37mFM6h831m9nRuAOX1cWf5vyJYanDeOaLZ3jmi2c6/f5jjxPg2nHX0uhrpDilmEnZk/jDuj9wWuFpVLVUsbxyObVttfxkxk+YVTKLny//OX/76m/R9w5zD+PpWU+zdM9StjVsw6SZKHGVEAwHefaLZ2kONGPSTDxx1hNMyZnCde9eR/mBcpIsSbQEWuLOk8LkQi4ecTHp9nT+uOGP7GzcGQ2W7p52N3XeOs4sPJO1+9eyYMcCMh2ZXDnqSpwWJx/t+YgmfxNnFZ3FG9veYE3NGkakjWBsxlgmZU/iH1v+wbs73uXWSbfyp41/Yn/b/uhn23QbbqubmrYafveN33Fy/smdlltfSQBzlAOYiFA4RKO/kXR7OqFwiLd3vM3Whq3cNP4mkq3JHdKaNFNcO2wgFEDTtA5t/u1VtVSR4cjArJlpCjTR4G2gKdDE8NThWEwWlFKd9nepbK4k3Z6O3WxHKcWX9V9SkFyAx+dhfe16JmVPIj85n2e+eIZ3d7zL3dPu5rTC07rMhzfoZWXVSkakjog+SNu31/tDfqMfh81FqauUL/Z/wfLK5eQm5XLR8Ivi0obCobh8t/+3UootDVuMqL95H3lJeZxdfDYrq1aSakvFaXYSJkyJq6TLPG9r2MaS3Uv41rBvkeXMQilFSIXiytwb9KJQ7GzcSUughZykHIpSivCFfJgwGc1C5S/iD/kZnjqccZnj2Nm4k1J3KSPSRmDSOu8P/8X+LxjiGoLb5o6+VuGpIBAOUNNawyOrHuF7Y79Hmj2NxRWLOW/oeUzLmdbj/g/tNXgbeOWrV5hZPJNhqcO6TLe9cTsWzUKR61Dfi7q2OkIqFO3H1RWlFNsatlHiLsFishAMB9nZuJOClAIcZgd1bXW8u/Ndvln6TdLsaYDxvS6qWERLoIUxGWMYmT4yur/qlmqW7F7CmUVnkpOUg1KK5kAzKdaUuAdyb8Wel42+Rio8FYzPGg/AAe8Byg+Uc1LuSdHvLhAOsKNxBwXJBXy892M2128m1ZZKuiOd0wtPx2Xt/X3E4/fw541/ptHXyBlFZ3Bqwakd0gTCAV7e/DLra9eTakvlu2O/G+0jFSsYDuIP+dneuJ2FuxYyZ8icaN+avpwvXfVv644/5Mcf8mPRLZg1I7CvaKogEAowLHVYl/loDbTyzo53WFm1klJXKd8c+s24a3bBjgV8sf8Lvj/5+1h0C62BVpxmZzRI7YlgOMj+1v3kJefhDXr5uPJjdjbuJNuZzczimYDxfUT6orQGWtE0DYfZARjny2OrH+OVr17houEXMbN4JjnOHLKd2dh0GxVNFdS01pBhz2Bo6tAe5ysQDrD1wFZsuo0Uawrp9vQu+ya2BdvY27QXm26LXpu+kI9mfzMOs4M3t72J2WTmpNyTyE/O77Cf1kArdd46shxZcf2/+ipyP/b4PaytWUujr5EcZw7jMsfhtDhp8jdh021YdesRf1YsCWAGKIA5XvhDfjRN69DHQwghvk76GhCK/tPT57eMQhIA/R5BCyFEIpLgJXHIPDBCCCGESDgSwAghhBAi4RzTTUhPPfUUjz76KFVVVUycOJEnn3ySk046aVDz9NqaPazb08joPBdj8lwMz07GFwyzbk8DI3NTyE6xEw4r9hxoY8WOOgIhhd1ioqE1wMzR2WzY62H7/mZOLE3nQIufjGQbobBiS00TJw/LZPn2Ouqb/Zw8PAOHRWfVznpS7Ba+NTEfq9mIN5VShBW0+INs3tdEepKF9Xsbee7jnZw4JJ2pJWnUeLxs29/CKcMzmVKcyobKRrbWNHPOmFyWfrWfZl+Q00dk8cm2Wkozk5hUnIrLbsFmNrFq5wGafQH8wTDLt9UxvjCVb4zOYUddC4s31zC5OJX9Hh8eb4BTR2Sy90AbNrNOWCnqW/xMKkqlJMMZVxWrlOKDL2v415b9hMKKJJsZl92My2H0uVlb0UBxhpOzRmazvbaZkTkuttc20+ILcubIbHJcRoc0XzDEpkoPexvaGJfvZkhmEjUeL3/7fA/N3iAOi056spVUh5VmX4Adta1YdI3vTCtize4GvP4QRelOxha42LCnkbZAiKwUG6PzXLQFQuiaht2io5TiQGuA9CQruklDKUVdi58Uu5nd9W3UNHmZUJhKklVn3Z5GKhvacDksrNhRz576VsJKUZzu5MLJBXy+6wBVjV5G5KTgdlgYk+8i2Wam2RfEpMGfl+8iyapz5fRiPG1BVu6oJ81poSQziTUVB3BaddKcVnzBMBX1rbjsZtKTbDS2Bdi8z0OzL8gJOSkoYM+BVs4bn0dDW4A1FQeobPDitOok2cwMzUxiSkka/mCYzGQbDqvOsi21/O+y7ZxYms7FkwtIsVtYv6eRJJtOY1sAT1uQsDIGXCqlUArsFp2pJWnUNvtIsZspTDMm8PIGQvxm4VdsqvTwwAVjcB7cvzcQ4pvj88g++B3WNHn5fFcDdouJfY1erLqJM0dmkZFswxswhqNurWnm9bV7GZ6dzKSiNKo9XnbVtzI6N4Uqj5ddda24HRbSnFZ21bfQ2BZgSEYSZ43M5rNd9TR7g5w9KpvttS247BaGZSdR4/Hxfyt2ke60MntsLgVpDlbuqGd3fSulmUm4nRb+9tkeTh2RycurdrOlppn/vGgc00vT+aq6mYZWP2lJVtbvaWRHrfGZFt3E0KwkQmFFUbqDcQVuXlq5mxZfEE3TSHNauGhyATkuO7vrW6lp8jEmz0Vts49/bamlpslLaWYSw7KSKclwkmK3EA4r9ja0sb22hWSbTqrTyl+W72JycSrnT8hHN2lUNXp5edVuMpKtnDYik6Vf7WdMnothWcb9SKGobGgjFDbOiY2VHtKcFnJcdgIhhccb4IKJ+fzrq/3sPtCK2WRi7e4G0pOsDM9OJs1ppdrj5cQh6ZxUmo6mgQaYdRP+YJgdtS3UtfiYUpyG3aKzbk8DGys9zBiawWtr9rKjtoWSdCfJdjNJVp1h2cnMKM3AZDLuCV/sbuCTbXW0BULUeLykJVkZkZ1MKKw4qTSdkowkfMEQ22pa2FDZyIeba2jyBhlf6KYwzUEwpGhsC7CxspFPttZxUmk6V55UTCAUJtluZkpxGk6rTiCksOgaew604bJbqGny8vraSs4cmcXUkjQa2wKs2nmAVn+QIRlJjM13YdaN+2x9i5/6Fj/7m3ys3FHP2HwXZ43KJhRWfF5xgBZfkEAojMthYXppBrXNPnSTRprTyqZKD698thvdpDG5OJVvjs/DcnC/q3bW8/a6fXjaAphMGuML3EwtSePFlRVkJtuYOTqbXLedhZuqsegmThqSTkmGk/3NPtKdxv0IIBhWLNtaS5M3SK7LTp7bzlvr9pFsNzMmz4XdYuKTrXVkpdjwh8Lsb/JRkuGkzR/C7bAwqSiV9CQra3Y34LDoeAMhPiyvwWHRMesmclw2phans+SrGoZkJHHaiEw0TcMbCOELhKlu8rK1ppmTStPJTO5dZ/D+csx24n355Zf57ne/y7PPPsv06dN5/PHHefXVVykvLyc7u/tREnD0OvHe8n+rWbChKu41kwZhBVaziSEZTirqW/EGDj+Fdm8Upjn49zOG8dCbGwmE+vcrO21EJmlOK+9trKIwzcG2/S0d0mga9OZMsZpNpNjMmEwauS47DW1+dte3Hf6NXchMtpHmtLDnQBttgUNzLhSnO9nf5It77fAUxu348NwOCzkuG/savTR54+cp0TSwHLyh94bZpGE1m2j1hzCbNILhgxPOWUz9ft50pyjdwd4DbRz8eDQNrLoJXy+PZ1SuMZFVbbOP2mZjbgvdpBEKx58wTquO22GhpsnXYRtAdoqNuhZ/p9uOlNOqY9I0mn2HvsP0JCv1Ld1PYQ9GmfhDPSuT2O8zQjdppDos1PXks8wmUHT5eVazCbNJo9Xfm/O9/5RkGNdb5PPTnBaSbGb2HDj8tZ3jsjG+wE1Da4DPdnWcIDGW06rjD4Y7lGVPpdjMWM0m6lv9pDut1LX4sR4MICJl63ZYaPUH4+6nmgapjq6PyWU3Y9FNHb7LyA+SruS77QzJTKLFH+KL3Q2HzX/seWQ2aRRnONm+vwWb2YSmga5pOKx69Hrrq97cc3JcNqxmE3sOtMU9C353zVRmj+35rNY9kfCjkKZPn86JJ57Ib39rzFIaDocpKiri9ttv58c//vFh33+0Apiv/v4Q2q5PqPObSfLuwxz20aBS8JqTSQk1kEYTIUxsViU4k5IpooqMwD5MKkRl0EWL5sTuTGa310mGxYfN34BGmKDVja+tBZPFhsXpoqrVhEkFGWWuwhJoojlspXHcXKZs/BUAAcw0kEyLKQUVDmEmiDPZTTgYoFa50Ew6JaEKaoN22kIaNpPCrocJBgJoJhO6bqY1CHarFV/BdLbsa6C4bRMptLKHXHLNTRSG96J0K61hCy0hM16sWGwOGgI6SrcRNCdR1aoxwlpLGI0WLZmQbifc1oibJsyECGDGShArAdBM2J0phC1OfFixBDyYQj5q9SyGhHfTFgizJ5RGyObG5avCryeh6RbSfXsJoxHAzAGSOaBnUqA3khaoQidEvXIRtKXitipCCrxhHS3kx64FcJgCKH8bwVCIWj2bIm0/aaFaGlQSW01DabJmYfHVUxjeh07nF7LWbsIna4OZ3QAAExpJREFUTdMwaRqhsJG+XkslZHWREazCbtGxWKwoTcfjUzT4wgR1B/YkF41+HUJelL8Nu+bHgQ8bAQLmZAJKwxpqw4afJmsWacH9uJWHvZYhZIZrUeEQLZqToCWFFhx4wjZMKLJsIUKWZPa0mUkP11Oo9rHX76TBlEaOUyNLa8AU8uPR06CtHnuwmS8Zgotm3LQQwoTZmUpyoI7WQBgPSWi6lSxVR52eRaM1myTVQgArDtUGGjQHddz+Kuq1NBrDdlJpxq01k0oLySYfmklndzCVfWSQ7jCTEdqPO1DDHpVFi7Lhx0LAkYVV+UjVfSQF6nEEGghiolJlYtGC5Gt1aNYkPGEbtaFkWs2pZFh8FLSVE9IsNCUV0xa20BYykU8NLlqoCzkI+b34TXaCuoNwoI0UPYhF+QiFoQUHJlsSAXMSwZYDJNPGXj2fdLuG1lpLkmol2aIIBQKgm7FarLR5veiEOaC5COhOkkIevLZMrI4k0lQDTl8tNaTj1ZNJaqkgh3oqLKXk640oNKrCqShfEwqox41uMjFU7SKEjseaQ1tSIc3eACneSixhLxqKEDp7yKHA0oQt2ExAaeRY2vCHwiSpVlJo5QApmHWdcDiET5lpsmRiDTRhVgGUZsKnzOwxl9BscpFlamSYqQpbsIlqUzZ15lzMgSaUz0PYZMXpzsQcbGWY/0taLelUarkEw2HygpW0+oP4lU4YDStBbFoAC0FsBDFrIfxKx48FPxY03YIp5KXJ5MaemksgGCIcDhEOh2lq8xEOh9FQmAgTxExScgomi4MUzYvJ24A/FKbOlImrbTcWjGDAafJTZy3AlpyOzWKm0ReiNQCaSSczvJ/MQBVaUiY7fCkE/D6SNC/VIRcpwTqc+KLXbuS/VoK4dD/7wynGVPno1FqLSNJDpPgqSQq34MOKDwterOSaGsilDq8pibpwEvXhJBqUcQ7lmFtAM9HgN2EPt9CgktEJk6o1k0wbWnIWutlKvacZFQ5iIYiZEBZCpNk1HHoYwkF8Pi8mFcKuKxrNWez22gkrSLKZUSYzdW0KO34ytUa8WHHgw0KQVuz4TE6wJYOvmWy1H6vZhIYJX0gRVBo2i5mQ0lCahlnX8YY0ms1phIIBUv3VpGrNbNWK8SorOdSRbW6l2j6UBnMmetMeCkJ72W8pwBcIYlNegphRQIlWDWjssQ4lXHYbk8+Wieyi/H4/TqeTv/3tb1x00UXR1+fOnUtDQwOvv/56h/f4fD58vkMzQXo8HoqKivp/GPUrc2HTP/tvf70Q+sZ/oi/8Sf/v+IQ5qEAr2o6ez74phBBC8J0/w5gL+3WXCT2Mura2llAoRE5OTtzrOTk5bN68udP3zJ8/n5///OdHP3MzboER54C/GZJzwJYCbQfA2wDOTEjKAn8LVG8AFQZXPmSeACYzNFVBoAV8zdBaB3YXONJBMxnvNzsgHDC2B1pA0yFtCCRnQ6ANPWsUjLsEUBD0QVsDtNUb79etRp5MZvDshVAAcsdDoBXCYTDpxjaT2Xh/OAjhkPHnTEfzt8CMeWBNgtpysKZA4TRje7ANAl4IxvwFvODzGMeaNuTgMTQan2d3G8dl0o3P0a1gthnl4W81ji3gNX456FZoqIDMEWC2G3lvrQdXgbH/UMAoP80EIZ9Rhk1V4MoDdzHoFmitNcpCtxrHFgoYn2e2H/yvw3i9fgckZ0HWKGiugX1rjfdZk4zXzJ2143bS1BQ7zFKFjfxHysFkPli2AaPsQgEItBnfTaANLHawOMHiMP6rW43jVGEjH7oVGveCIw1ScmB/ObiLjPd5PUZar8coZzDe428xyt6WYhyHtxGaq428uArAbDXKzJpsnHNV6yEpG5Iyjby2NRifFf0O24xzu36b8V040iDkNz5LKWN7ahF4Ko1zwZEOznSwpxrfachvbPNUGudAcq5xHTTuhqDf+P6b9xv7s6UY703KMsqqYZeR77Qhh8qtuca4xiwOyBlrlGvjHuNzQgHj+kjONvJuthvvCfqM/7c4jP+ijOvK3wy+pkOfXbfNSJOUZZy3usW47tTB7y7y76ZK45x1ZhhlG/Ib6VPyjLL1Nxn7SC2G6o3G65oJWvYb6ZSCpn3G+/ImGt9d/XbjNaWM99lcxrkVaDPKPinL+B5CAaOM0MDqNPbXWm8ck6Yb6Zv2Gd+TxWGcS75mqNloXG92N2SdAPY049puqQVHqnH8kfuICkPRdKOcPXuN8yJjuHE+hvzGdrPN+HfkejaZjbyFfMb3Gg6AboPmKmOfJt0oA81kHFfk/9GMtP5W4/yxJht5DweMcyZtiJE3pYzyr99unOMo416mQkb+HOnGfaO13vhMk9nYV8t+o+wcaR2vWZPFKKPWWiO9rxkO7DSOx11klHPQd/CvzfhO0kuNdN4Go3zaDhjnkCPdKJeg17iuWuuN/DrSjfOrpdbIq8kCuvngfy3G5+qWg/+2HtoGxnntbzrUXh8OHrqHJmUa5WxxGPn1NRtpfc3Gv9OGGGWulJGv6H9j/kIBo6x0q3FvsKXAvi+M8on8u2q9cZ+xu437yYFdxj3EknTwvhY0zleljOdc0YzDPjaPlmOyBqayspKCggI++eQTysrKoq//6Ec/YunSpaxY0XGtkAGrgRFCCCHEUZPQNTCZmZnouk51dXXc69XV1eTmdt5ZyGazYbMNTk9oIYQQQgysY3IeGKvVytSpU1m0aFH0tXA4zKJFi+JqZIQQQgjx9XRM1sAA3HnnncydO5dp06Zx0kkn8fjjj9PS0sK111472FkTQgghxCA7ZgOYyy+/nP379/PAAw9QVVXFpEmTePfddzt07BVCCCHE188x2Ym3P8hq1EIIIUTi6enz+5jsAyOEEEII0R0JYIQQQgiRcCSAEUIIIUTCkQBGCCGEEAlHAhghhBBCJBwJYIQQQgiRcCSAEUIIIUTCkQBGCCGEEAnnmJ2J90hF5ufzeDyDnBMhhBBC9FTkuX24eXaP2wCmqakJgKKiokHOiRBCCCF6q6mpCbfb3eX243YpgXA4TGVlJSkpKWia1m/79Xg8FBUVsXv37q/1EgVSDgYpB4OUg5RBhJSDQcrB0JdyUErR1NREfn4+JlPXPV2O2xoYk8lEYWHhUdu/y+X6Wp+UEVIOBikHg5SDlEGElINBysHQ23LoruYlQjrxCiGEECLhSAAjhBBCiIQjAUwv2Ww2HnzwQWw222BnZVBJORikHAxSDlIGEVIOBikHw9Esh+O2E68QQgghjl9SAyOEEEKIhCMBjBBCCCESjgQwQgghhEg4EsAIIYQQIuFIACOEEEKIhCMBTC899dRTDBkyBLvdzvTp01m5cuVgZ+mo+dnPfoamaXF/o0aNim73er3MmzePjIwMkpOTufTSS6murh7EHPePjz76iAsuuID8/Hw0TeOf//xn3HalFA888AB5eXk4HA5mzZrFli1b4tLU19dz9dVX43K5SE1N5frrr6e5uXkAj+LIHa4cvve973U4P+bMmROXJtHLYf78+Zx44omkpKSQnZ3NRRddRHl5eVyanlwHFRUVnHfeeTidTrKzs7nnnnsIBoMDeShHpCflcOaZZ3Y4H26++ea4NIleDs888wwTJkyIzipbVlbGggULotu/DufC4cpgQM8DJXrspZdeUlarVf3xj39UGzduVDfeeKNKTU1V1dXVg521o+LBBx9UY8eOVfv27Yv+7d+/P7r95ptvVkVFRWrRokXqs88+UzNmzFAnn3zyIOa4f7zzzjvqP/7jP9Q//vEPBajXXnstbvvDDz+s3G63+uc//6m++OIL9a1vfUuVlpaqtra2aJo5c+aoiRMnqk8//VT961//UsOHD1dXXnnlAB/JkTlcOcydO1fNmTMn7vyor6+PS5Po5TB79mz13HPPqQ0bNqi1a9eqb37zm6q4uFg1NzdH0xzuOggGg2rcuHFq1qxZas2aNeqdd95RmZmZ6r777huMQ+qTnpTDGWecoW688ca486GxsTG6/XgohzfeeEO9/fbb6quvvlLl5eXq/vvvVxaLRW3YsEEp9fU4Fw5XBgN5HkgA0wsnnXSSmjdvXvTfoVBI5efnq/nz5w9iro6eBx98UE2cOLHTbQ0NDcpisahXX301+tqXX36pALV8+fIByuHR1/7BHQ6HVW5urnr00UejrzU0NCibzaZefPFFpZRSmzZtUoBatWpVNM2CBQuUpmlq7969A5b3/tRVAHPhhRd2+Z7jsRxqamoUoJYuXaqU6tl18M477yiTyaSqqqqiaZ555hnlcrmUz+cb2APoJ+3LQSnjwfWDH/ygy/ccj+WglFJpaWnqf/7nf76254JSh8pAqYE9D6QJqYf8fj+rV69m1qxZ0ddMJhOzZs1i+fLlg5izo2vLli3k5+czdOhQrr76aioqKgBYvXo1gUAgrjxGjRpFcXHxcV0eO3bsoKqqKu643W4306dPjx738uXLSU1NZdq0adE0s2bNwmQysWLFigHP89G0ZMkSsrOzGTlyJLfccgt1dXXRbcdjOTQ2NgKQnp4O9Ow6WL58OePHjycnJyeaZvbs2Xg8HjZu3DiAue8/7csh4q9//SuZmZmMGzeO++67j9bW1ui2460cQqEQL730Ei0tLZSVlX0tz4X2ZRAxUOfBcbsadX+rra0lFArFFTpATk4OmzdvHqRcHV3Tp0/n+eefZ+TIkezbt4+f//znnHbaaWzYsIGqqiqsViupqalx78nJyaGqqmpwMjwAIsfW2XkQ2VZVVUV2dnbcdrPZTHp6+nFVNnPmzOGSSy6htLSUbdu2cf/993PuueeyfPlydF0/7sohHA5zxx13cMoppzBu3DiAHl0HVVVVnZ4vkW2JprNyALjqqqsoKSkhPz+fdevWce+991JeXs4//vEP4Pgph/Xr11NWVobX6yU5OZnXXnuNMWPGsHbt2q/NudBVGcDAngcSwIgunXvuudH/nzBhAtOnT6ekpIRXXnkFh8MxiDkTx4Irrrgi+v/jx49nwoQJDBs2jCVLljBz5sxBzNnRMW/ePDZs2MCyZcsGOyuDqqtyuOmmm6L/P378ePLy8pg5cybbtm1j2LBhA53No2bkyJGsXbuWxsZG/va3vzF37lyWLl062NkaUF2VwZgxYwb0PJAmpB7KzMxE1/UOPcqrq6vJzc0dpFwNrNTUVE444QS2bt1Kbm4ufr+fhoaGuDTHe3lEjq278yA3N5eampq47cFgkPr6+uO6bIYOHUpmZiZbt24Fjq9yuO2223jrrbf48MMPKSwsjL7ek+sgNze30/Mlsi2RdFUOnZk+fTpA3PlwPJSD1Wpl+PDhTJ06lfnz5zNx4kSeeOKJr9W50FUZdOZongcSwPSQ1Wpl6tSpLFq0KPpaOBxm0aJFcW1/x7Pm5ma2bdtGXl4eU6dOxWKxxJVHeXk5FRUVx3V5lJaWkpubG3fcHo+HFStWRI+7rKyMhoYGVq9eHU2zePFiwuFw9GI+Hu3Zs4e6ujry8vKA46MclFLcdtttvPbaayxevJjS0tK47T25DsrKyli/fn1cMLdw4UJcLle02v1Yd7hy6MzatWsB4s6HRC+HzoTDYXw+39fmXOhMpAw6c1TPgz50OP7aeumll5TNZlPPP/+82rRpk7rppptUampqXG/q48ldd92llixZonbs2KE+/vhjNWvWLJWZmalqamqUUsaQweLiYrV48WL12WefqbKyMlVWVjbIuT5yTU1Nas2aNWrNmjUKUL/5zW/UmjVr1K5du5RSxjDq1NRU9frrr6t169apCy+8sNNh1JMnT1YrVqxQy5YtUyNGjEio4cNKdV8OTU1N6u6771bLly9XO3bsUB988IGaMmWKGjFihPJ6vdF9JHo53HLLLcrtdqslS5bEDQttbW2NpjncdRAZNnrOOeeotWvXqnfffVdlZWUl1NDZw5XD1q1b1UMPPaQ+++wztWPHDvX666+roUOHqtNPPz26j+OhHH784x+rpUuXqh07dqh169apH//4x0rTNPX+++8rpb4e50J3ZTDQ54EEML305JNPquLiYmW1WtVJJ52kPv3008HO0lFz+eWXq7y8PGW1WlVBQYG6/PLL1datW6Pb29ra1K233qrS0tKU0+lUF198sdq3b98g5rh/fPjhhwro8Dd37lyllDGU+qc//anKyclRNptNzZw5U5WXl8fto66uTl155ZUqOTlZuVwude2116qmpqZBOJq+664cWltb1TnnnKOysrKUxWJRJSUl6sYbb+wQzCd6OXR2/IB67rnnoml6ch3s3LlTnXvuucrhcKjMzEx11113qUAgMMBH03eHK4eKigp1+umnq/T0dGWz2dTw4cPVPffcEzf/h1KJXw7XXXedKikpUVarVWVlZamZM2dGgxelvh7nQndlMNDngaaUUr2rsxFCCCGEGFzSB0YIIYQQCUcCGCGEEEIkHAlghBBCCJFwJIARQgghRMKRAEYIIYQQCUcCGCGEEEIkHAlghBBCCJFwJIARQgghRMKRAEYIIYQQCUcCGCGEEEIkHAlghBBCCJFw/j/Bl1Lml+OUZQAAAABJRU5ErkJggg==",
-            "text/plain": [
-              "<Figure size 640x480 with 1 Axes>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "df.plot(title=\"Numeric features\")"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 75,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "Query job 2b3aba71-3b36-425a-835f-6c72fc79950a is DONE. 12.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:2b3aba71-3b36-425a-835f-6c72fc79950a&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job 013405ab-25b3-4ead-8fe7-41974af67752 is DONE. 23.8 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:013405ab-25b3-4ead-8fe7-41974af67752&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/plain": [
-              "<Axes: xlabel='species'>"
-            ]
-          },
-          "execution_count": 75,
-          "metadata": {},
-          "output_type": "execute_result"
-        },
-        {
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjAAAALECAYAAAAW8gpgAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/H5lhTAAAACXBIWXMAAA9hAAAPYQGoP6dpAACEdklEQVR4nOzdeVxN+eM/8NdtL3UraaVVSRHKmm0skXVsw1hGqBhG1kFjxr5PnzFirGMLw9gGYyfZhiJF2UOiUPZKSvvvD7/u150bw0x1Op3X8/Ho8XDPOffc123u1Ktz3ud9ZIWFhYUgIiIiEhE1oQMQERERfSoWGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0NoQOUloKCAjx69AgGBgaQyWRCxyEiIqKPUFhYiFevXsHKygpqau8/zlJhC8yjR49gbW0tdAwiIiL6F5KSklCtWrX3rq+wBcbAwADA22+AXC4XOA0RERF9jPT0dFhbWyt+j79PhS0wRaeN5HI5CwwREZHI/NPwDw7iJSIiItFhgSEiIiLRYYEhIiIi0amwY2A+Vn5+PnJzc4WOQVSiNDU1oa6uLnQMIqJSI9kCU1hYiJSUFKSmpgodhahUGBkZwcLCgvMgEVGFJNkCU1RezMzMoKenxx/yVGEUFhYiMzMTT548AQBYWloKnIiIqORJssDk5+cryouJiYnQcYhKnK6uLgDgyZMnMDMz4+kkIqpwJDmIt2jMi56ensBJiEpP0eebY7yIqCKSZIEpwtNGVJHx801EFZmkCwwRERGJEwsMERERiY4kB/G+j913B8r09e4t6FymrxcSEoKxY8eW+0vHW7VqhXr16iE4OFjoKDh58iRat26Nly9fwsjISOg4RET0//EIDNH/16pVK4wdO1boGERE9BFYYIiIiEh0WGBEpqCgAEFBQXB0dIS2tjZsbGwwd+5cnDx5EjKZTOn0UExMDGQyGe7du1fsvmbMmIF69eph3bp1sLGxgb6+Pr755hvk5+cjKCgIFhYWMDMzw9y5c5Wel5qaCn9/f5iamkIul6NNmzaIjY1V2e+mTZtgZ2cHQ0ND9O3bF69evfpX7zk7OxsTJkxA1apVUalSJTRu3BgnT55UrA8JCYGRkRGOHDkCFxcX6Ovro0OHDkhOTlZsk5eXh9GjR8PIyAgmJiYIDAzEoEGD0L17dwDA4MGDcerUKSxevBgymUzl+xYdHY0GDRpAT08PTZs2RVxc3Edl/7ffY5lMhlWrVqFLly7Q09ODi4sLIiIicOfOHbRq1QqVKlVC06ZNER8f/6++p0REYscxMCIzefJkrF69GosWLULz5s2RnJyMmzdv/uv9xcfH49ChQzh8+DDi4+PxxRdf4O7du6hRowZOnTqF8PBw+Pr6wsvLC40bNwYA9O7dG7q6ujh06BAMDQ2xatUqtG3bFrdu3ULlypUV+92zZw/279+Ply9fok+fPliwYIHKL+qPERAQgOvXr2Pr1q2wsrLC7t270aFDB1y5cgVOTk4AgMzMTPz000/YtGkT1NTU8NVXX2HChAnYvHkzAODHH3/E5s2bsX79eri4uGDx4sXYs2cPWrduDQBYvHgxbt26hdq1a2PWrFkAAFNTU0WJ+eGHH7Bw4UKYmppi+PDh8PX1xdmzZ0vtewwAs2fPxs8//4yff/4ZgYGB6N+/PxwcHDB58mTY2NjA19cXAQEBOHTo0Cd/T4lIHG7UdCnxfbrcvFHi+xTCJx2BmTFjhuKv06KvmjVrKta/efMGI0eOhImJCfT19dGrVy88fvxYaR+JiYno3Lkz9PT0YGZmhokTJyIvL09pm5MnT8LDwwPa2tpwdHRESEjIv3+HFcirV6+wePFiBAUFYdCgQahevTqaN28Of3//f73PgoICrFu3Dq6urujatStat26NuLg4BAcHw9nZGUOGDIGzszNOnDgBADhz5gwiIyOxY8cONGjQAE5OTvjpp59gZGSEnTt3Ku03JCQEtWvXRosWLTBw4ECEhYV9cr7ExESsX78eO3bsQIsWLVC9enVMmDABzZs3x/r16xXb5ebmYuXKlWjQoAE8PDwQEBCg9Hq//PILJk+ejB49eqBmzZpYunSp0qBcQ0NDaGlpQU9PDxYWFrCwsFCavXbu3Ln47LPP4Orqiu+++w7h4eF48+ZNqXyPiwwZMgR9+vRBjRo1EBgYiHv37mHAgAHw9vaGi4sLxowZo3QkiohISj75CEytWrVw7Nix/9uBxv/tYty4cThw4AB27NgBQ0NDBAQEoGfPnoq/VPPz89G5c2dYWFggPDwcycnJ8PHxgaamJubNmwcASEhIQOfOnTF8+HBs3rwZYWFh8Pf3h6WlJby9vf/r+xW1GzduIDs7G23bti2xfdrZ2cHAwEDx2NzcHOrq6lBTU1NaVnRfndjYWGRkZKjcgiErK0vpdMbf92tpaanYx6e4cuUK8vPzUaNGDaXl2dnZShn09PRQvXr1Yl8vLS0Njx8/RqNGjRTr1dXVUb9+fRQUFHxUjjp16ijtG3g7Tb+Njc0/PvdTv8fFvaa5uTkAwM3NTWnZmzdvkJ6eDrlc/lHvg4ioovjkAqOhoQELCwuV5WlpaVi7di22bNmCNm3aAIDicP25c+fQpEkTHD16FNevX8exY8dgbm6OevXqYfbs2QgMDMSMGTOgpaWFlStXwt7eHgsXLgQAuLi44MyZM1i0aJHkC0zR/W2KU/TLsLCwULHsY6aQ19TUVHosk8mKXVb0iz4jIwOWlpbF/uX/7hGND+3jU2RkZEBdXR3R0dEq9/PR19f/4Ou9+734r97df9EMtx/7fj71e/yh1/wvOYiIKpJPHsR7+/ZtWFlZwcHBAQMGDEBiYiKAt4Mcc3Nz4eXlpdi2Zs2asLGxQUREBAAgIiICbm5uir8mAcDb2xvp6em4du2aYpt391G0TdE+3ic7Oxvp6elKXxWNk5MTdHV1iz0VY2pqCgBKA1djYmJKPIOHhwdSUlKgoaEBR0dHpa8qVaqU+Ou5u7sjPz8fT548UXm94op0cQwNDWFubo4LFy4oluXn5+PixYtK22lpaSE/P79E8xMRUen4pALTuHFjhISE4PDhw1ixYgUSEhLQokULvHr1CikpKdDS0lKZ7Mvc3BwpKSkAgJSUFKXyUrS+aN2HtklPT0dWVtZ7s82fPx+GhoaKL2tr6095a6Kgo6ODwMBATJo0CRs3bkR8fDzOnTuHtWvXwtHREdbW1pgxYwZu376NAwcOKI5ilSQvLy94enqie/fuOHr0KO7du4fw8HD88MMPiIqKKvHXq1GjBgYMGAAfHx/s2rULCQkJiIyMxPz583HgwMdPPDhq1CjMnz8ff/75J+Li4jBmzBi8fPlS6X5BdnZ2OH/+PO7du4dnz57xyAYRUTn2SaeQOnbsqPh3nTp10LhxY9ja2mL79u0fPL1RFiZPnozx48crHqenp39yiSnrmXH/jalTp0JDQwPTpk3Do0ePYGlpieHDh0NTUxO///47RowYgTp16qBhw4aYM2cOevfuXaKvL5PJcPDgQfzwww8YMmQInj59CgsLC7Rs2VKleJaU9evXY86cOfj222/x8OFDVKlSBU2aNEGXLl0+eh+BgYFISUmBj48P1NXVMWzYMHh7eyudlpowYQIGDRoEV1dXZGVlISEhoTTeDhERlQBZ4X8cKNCwYUN4eXmhXbt2aNu2rcqU67a2thg7dizGjRuHadOmYe/evUqnNhISEuDg4ICLFy/C3d0dLVu2hIeHh9I08uvXr8fYsWORlpb20bnS09NhaGiItLQ0lQGOb968QUJCAuzt7aGjo/Nv3zqJWEFBAVxcXNCnTx/Mnj1b6Dilgp9zIvGT4mXUH/r9/a7/NJFdRkYG4uPjYWlpifr160NTU1NpfEZcXBwSExPh6ekJAPD09MSVK1eUrrYIDQ2FXC6Hq6urYpu/j/EIDQ1V7IPo37h//z5Wr16NW7du4cqVKxgxYgQSEhLQv39/oaMREdG/8EkFZsKECTh16pRi3EOPHj2grq6Ofv36wdDQEH5+fhg/fjxOnDiB6OhoDBkyBJ6enmjSpAkAoH379nB1dcXAgQMRGxuLI0eOYMqUKRg5ciS0tbUBAMOHD8fdu3cxadIk3Lx5E8uXL8f27dsxbty4kn/3VOYSExOhr6//3q+iQeElTU1NDSEhIWjYsCGaNWuGK1eu4NixY3Bx+W9/3dSqVeu976VoEj0iIip5nzQG5sGDB+jXrx+eP38OU1NTNG/eHOfOnVNcAbNo0SKoqamhV69eyM7Ohre3N5YvX654vrq6Ovbv348RI0bA09MTlSpVwqBBgxQznwKAvb09Dhw4gHHjxmHx4sWoVq0a1qxZI/lLqCsKKyurD14dZWVlVSqva21t/dEz536KgwcPvvdy9dIaE0RERCUwBqa84hgYkjp+zonEj2NgSmkMDBEREZEQWGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdD75btQV2gzDMn69j59ZuCSEhIRg7NixSE1NLdPXLQmtWrVCvXr1lGZoLi0ymQy7d+9G9+7dS/21iIjo3+ERGJKsGTNmoF69ekLHICKif4EFhoiIiESHBUZkCgoKEBQUBEdHR2hra8PGxgZz587FyZMnIZPJlE4PxcTEQCaT4d69e8Xuq+gIxLp162BjYwN9fX188803yM/PR1BQECwsLGBmZoa5c+cqPS81NRX+/v4wNTWFXC5HmzZtEBsbq7LfTZs2wc7ODoaGhujbty9evXr1Ue/x9evX8PHxgb6+PiwtLbFw4UKVbbKzszFhwgRUrVoVlSpVQuPGjXHy5EnF+pCQEBgZGWHPnj1wcnKCjo4OvL29kZSUpFg/c+ZMxMbGQiaTQSaTISQkRPH8Z8+eoUePHtDT04OTkxP27t37UdmL/jscOXIE7u7u0NXVRZs2bfDkyRMcOnQILi4ukMvl6N+/PzIzMxXPa9WqFUaNGoWxY8fC2NgY5ubmWL16NV6/fo0hQ4bAwMAAjo6OOHTo0EflICKq6FhgRGby5MlYsGABpk6diuvXr2PLli3/acr6+Ph4HDp0CIcPH8bvv/+OtWvXonPnznjw4AFOnTqFH3/8EVOmTMH58+cVz+ndu7fiF3J0dDQ8PDzQtm1bvHjxQmm/e/bswf79+7F//36cOnUKCxYs+KhMEydOxKlTp/Dnn3/i6NGjOHnyJC5evKi0TUBAACIiIrB161ZcvnwZvXv3RocOHXD79m3FNpmZmZg7dy42btyIs2fPIjU1FX379gUAfPnll/j2229Rq1YtJCcnIzk5GV9++aXiuTNnzkSfPn1w+fJldOrUCQMGDFB6f/9kxowZWLp0KcLDw5GUlIQ+ffogODgYW7ZswYEDB3D06FH88ssvSs/ZsGEDqlSpgsjISIwaNQojRoxA79690bRpU1y8eBHt27fHwIEDlYoPEZFUscCIyKtXr7B48WIEBQVh0KBBqF69Opo3bw5/f/9/vc+CggKsW7cOrq6u6Nq1K1q3bo24uDgEBwfD2dkZQ4YMgbOzM06cOAEAOHPmDCIjI7Fjxw40aNAATk5O+Omnn2BkZISdO3cq7TckJAS1a9dGixYtMHDgQJW7jBcnIyMDa9euxU8//YS2bdvCzc0NGzZsQF5enmKbxMRErF+/Hjt27ECLFi1QvXp1TJgwAc2bN8f69esV2+Xm5mLp0qXw9PRE/fr1sWHDBoSHhyMyMhK6urrQ19eHhoYGLCwsYGFhAV1dXcVzBw8ejH79+sHR0RHz5s1DRkYGIiMjP/r7OmfOHDRr1gzu7u7w8/PDqVOnsGLFCri7u6NFixb44osvFN/TInXr1sWUKVPg5OSEyZMnQ0dHB1WqVMHQoUPh5OSEadOm4fnz57h8+fJH5yAiqqh4FZKI3LhxA9nZ2Wjbtm2J7dPOzg4GBgaKx+bm5lBXV4eamprSsidPngAAYmNjkZGRARMTE6X9ZGVlIT4+/r37tbS0VOzjQ+Lj45GTk4PGjRsrllWuXBnOzs6Kx1euXEF+fj5q1Kih9Nzs7GylXBoaGmjYsKHicc2aNWFkZIQbN26gUaNGH8xRp04dxb8rVaoEuVz+UfmLe765uTn09PTg4OCgtOzvhejd56irq8PExARubm5KzwHwSTmIiCoqFhgRefcIwd8VFY537835vrskv0tTU1PpsUwmK3ZZQUEBgLdHSCwtLZXGmxQxMjL64H6L9vFfZWRkQF1dHdHR0VBXV1dap6+vXyKv8V/zv/v8f/qefug1/74fACX2fSQiEjOeQhIRJycn6OrqFnsqxtTUFACQnJysWBYTE1PiGTw8PJCSkgINDQ04OjoqfVWpUuU/77969erQ1NRUGnPz8uVL3Lp1S/HY3d0d+fn5ePLkiUoGCwsLxXZ5eXmIiopSPI6Li0NqaipcXN7e3VVLSwv5+fn/OTMREZU9FhgR0dHRQWBgICZNmoSNGzciPj4e586dw9q1a+Ho6Ahra2vMmDEDt2/fxoEDB4q9eue/8vLygqenJ7p3746jR4/i3r17CA8Pxw8//KBUFv4tfX19+Pn5YeLEiTh+/DiuXr2KwYMHK53SqlGjBgYMGAAfHx/s2rULCQkJiIyMxPz583HgwAHFdpqamhg1ahTOnz+P6OhoDB48GE2aNFGcPrKzs0NCQgJiYmLw7NkzZGdn/+f8RERUNngK6V1lPDPuvzF16lRoaGhg2rRpePToESwtLTF8+HBoamri999/x4gRI1CnTh00bNgQc+bMQe/evUv09WUyGQ4ePIgffvgBQ4YMwdOnT2FhYYGWLVv+p6uh3vW///0PGRkZ6Nq1KwwMDPDtt98iLU35v8369esxZ84cfPvtt3j48CGqVKmCJk2aoEuXLopt9PT0EBgYiP79++Phw4do0aIF1q5dq1jfq1cv7Nq1C61bt0ZqairWr1+PwYMHl8h7ICKi0iUrfHfQRAWSnp4OQ0NDpKWlQS6XK6178+YNEhISYG9vDx0dHYESUmkS820TSgo/50Tid6OmS4nv0+XmjRLfZ0n60O/vd/EUEhEREYkOCwyVqcTEROjr67/3KzExUeiIHzR8+PD3Zh8+fLjQ8YiIJIOnkHhovUzl5eW999YGwNuBtRoa5Xdo1pMnT5Cenl7sOrlcDjMzszJO9H78nBOJH08hvf8UUvn9TUEVUtHl12JlZmZWrkoKEZFU8RQSERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYkOr0J6h9sGtzJ9vSuDrnzycwoLC/H1119j586dePnyJQwNDTF48GAEBwcDeHsZ8tixYzF27NiSDVsKZDIZdu/eje7duwsdBTNmzMCePXtK5QaYRERU8ngERmQOHz6MkJAQ7N+/H8nJyahdu7bS+gsXLmDYsGECpRMHmUyGPXv2CB2DiIj+Ax6BEZn4+HhYWlqiadOmAKAy6ZupqakQsVTk5ORAS0tL6BhERFRB8QiMiAwePBijRo1CYmIiZDIZ7OzsVLaxs7NTnE4C3h5tWLFiBTp27AhdXV04ODhg586divX37t2DTCbD1q1b0bRpU+jo6KB27do4deqU0n6vXr2Kjh07Ql9fH+bm5hg4cCCePXumWN+qVSsEBARg7NixqFKlCry9vT/5/SUlJaFPnz4wMjJC5cqV0a1bN6VZewcPHozu3bvjp59+gqWlJUxMTDBy5Ejk5uYqtklOTkbnzp2hq6sLe3t7bNmyRel7UvQ969GjR7Hfw02bNsHOzg6Ghobo27cvXr169VHZW7VqhVGjRmHs2LEwNjaGubk5Vq9ejdevX2PIkCEwMDCAo6MjDh06pHjOyZMnIZPJcOTIEbi7u0NXVxdt2rTBkydPcOjQIbi4uEAul6N///7IzMz85O8nEVFFxgIjIosXL8asWbNQrVo1JCcn48KFCx/1vKlTp6JXr16IjY3FgAED0LdvX9y4oTyV9MSJE/Htt9/i0qVL8PT0RNeuXfH8+XMAQGpqKtq0aQN3d3dERUXh8OHDePz4Mfr06aO0jw0bNkBLSwtnz57FypUrP+m95ebmwtvbGwYGBvjrr79w9uxZ6Ovro0OHDsjJyVFsd+LECcTHx+PEiRPYsGEDQkJCEBISoljv4+ODR48e4eTJk/jjjz/w66+/4smTJ4r1Rd+z9evXq3wP4+PjsWfPHuzfvx/79+/HqVOnsGDBgo9+Dxs2bECVKlUQGRmJUaNGYcSIEejduzeaNm2Kixcvon379hg4cKBKGZkxYwaWLl2K8PBwRYkLDg7Gli1bcODAARw9ehS//PLLJ30/iYgqOhYYETE0NISBgQHU1dVhYWHx0aeLevfuDX9/f9SoUQOzZ89GgwYNVH4hBgQEoFevXnBxccGKFStgaGiItWvXAgCWLl0Kd3d3zJs3DzVr1oS7uzvWrVuHEydO4NatW4p9ODk5ISgoCM7OznB2dv6k97Zt2zYUFBRgzZo1cHNzg4uLC9avX4/ExEScPHlSsZ2xsTGWLl2KmjVrokuXLujcuTPCwsIAADdv3sSxY8ewevVqNG7cGB4eHlizZg2ysrIUzy/6nhkZGal8DwsKChASEoLatWujRYsWGDhwoGLfH6Nu3bqYMmUKnJycMHnyZOjo6KBKlSoYOnQonJycMG3aNDx//hyXL19Wet6cOXPQrFkzuLu7w8/PD6dOncKKFSvg7u6OFi1a4IsvvsCJEyc+6ftJRFTRcQyMBHh6eqo8/vvVNu9uo6GhgQYNGiiO0sTGxuLEiRPQ19dX2Xd8fDxq1KgBAKhfv/6/zhgbG4s7d+7AwMBAafmbN28QHx+veFyrVi2oq6srHltaWuLKlbdXc8XFxUFDQwMeHh6K9Y6OjjA2Nv6oDHZ2dkqvb2lpqXT05p/UqVNH8W91dXWYmJjAze3/rmwzNzcHAJV9vvs8c3Nz6OnpwcHBQWlZZGTkR+cgIpICFhj6RxkZGejatSt+/PFHlXWWlpaKf1eqVOk/vUb9+vWxefNmlXXvHiXR1NRUWieTyVBQUPCvX/dd/3XfxT3/3WUymQwAVPb5921K8z0SEVUUPIUkAefOnVN57OLi8t5t8vLyEB0drdjGw8MD165dg52dHRwdHZW+/ktpeZeHhwdu374NMzMzldcwNDT8qH04OzsjLy8Ply5dUiy7c+cOXr58qbSdpqYm8vPzSyQ3EREJgwVGAnbs2IF169bh1q1bmD59OiIjIxEQEKC0zbJly7B7927cvHkTI0eOxMuXL+Hr6wsAGDlyJF68eIF+/frhwoULiI+Px5EjRzBkyJASKwIDBgxAlSpV0K1bN/z1119ISEjAyZMnMXr0aDx48OCj9lGzZk14eXlh2LBhiIyMxKVLlzBs2DDo6uoqjn4Ab08VhYWFISUlRaXcEBGROPAU0jv+zcy4YjBz5kxs3boV33zzDSwtLfH777/D1dVVaZsFCxZgwYIFiImJgaOjI/bu3YsqVaoAAKysrHD27FkEBgaiffv2yM7Ohq2tLTp06AA1tZLpwHp6ejh9+jQCAwPRs2dPvHr1ClWrVkXbtm0hl8s/ej8bN26En58fWrZsCQsLC8yfPx/Xrl2Djo6OYpuFCxdi/PjxWL16NapWrap0qTYREYmDrLCwsFDoEKUhPT0dhoaGSEtLU/kF+ObNGyQkJMDe3l7pF1tF9E/T9d+7dw/29va4dOkS6tWrV6bZysKDBw9gbW2NY8eOoW3btkLHKVNS+pwTVVQ3arr880afyOXmjX/eSEAf+v39Lh6BoQrl+PHjyMjIgJubG5KTkzFp0iTY2dmhZcuWQkcjIqISxDEwVCo2b94MfX39Yr9q1apVaq+bm5uL77//HrVq1UKPHj1gamqKkydPqlzZ8ykSExPf+1709fWRmJhYgu+AiIg+Bo/AVHD/dIbQzs7uH7f5Nz7//HM0bty42HX/pUz8E29v7391G4MPsbKy+uBdqq2srEr09YiI6J+xwFCpMDAwUJmUTqw0NDTg6OgodAwiInoHTyERERGR6LDAEBERkeiwwBAREZHosMAQERGR6LDAEBERkejwKqR3lMaMhx/yqbMhtmrVCvXq1UNwcHCJZQgJCcHYsWORmppaYvskIiIqbTwCQ0RERKLDAkNERESiwwIjMnl5eQgICIChoSGqVKmCqVOnKmbSffnyJXx8fGBsbAw9PT107NgRt2/fVnp+SEgIbGxsoKenhx49euD58+eKdffu3YOamhqioqKUnhMcHAxbW1sUFBR8MNvJkychk8lw5MgRuLu7Q1dXF23atMGTJ09w6NAhuLi4QC6Xo3///sjMzFQ87/Dhw2jevDmMjIxgYmKCLl26ID4+XrE+JycHAQEBsLS0hI6ODmxtbTF//nwAb2canjFjBmxsbKCtrQ0rKyuMHj36o76XycnJ6Ny5M3R1dWFvb48tW7bAzs6uRE/RERFR6WCBEZkNGzZAQ0MDkZGRWLx4MX7++WesWbMGADB48GBERUVh7969iIiIQGFhITp16oTc3FwAwPnz5+Hn54eAgADExMSgdevWmDNnjmLfdnZ28PLywvr165Vec/369Rg8eDDU1D7u4zJjxgwsXboU4eHhSEpKQp8+fRAcHIwtW7bgwIEDOHr0KH755RfF9q9fv8b48eMRFRWFsLAwqKmpoUePHorCtGTJEuzduxfbt29HXFwcNm/eDDs7OwDAH3/8gUWLFmHVqlW4ffs29uzZAzc3t4/K6ePjg0ePHuHkyZP4448/8Ouvv+LJkycf9VwiIhIWB/GKjLW1NRYtWgSZTAZnZ2dcuXIFixYtQqtWrbB3716cPXsWTZs2BfD2horW1tbYs2cPevfujcWLF6NDhw6YNGkSAKBGjRoIDw/H4cOHFfv39/fH8OHD8fPPP0NbWxsXL17ElStX8Oeff350xjlz5qBZs2YAAD8/P0yePBnx8fFwcHAAAHzxxRc4ceIEAgMDAQC9evVSev66detgamqK69evo3bt2khMTISTkxOaN28OmUwGW1tbxbaJiYmwsLCAl5cXNDU1YWNjg0aNGv1jxps3b+LYsWO4cOECGjRoAABYs2YNnJycPvp9EhGRcHgERmSaNGkCmUymeOzp6Ynbt2/j+vXr0NDQULqBoomJCZydnXHjxturnW7cuKFyg0VPT0+lx927d4e6ujp2794N4O0pp9atWyuOeHyMOnXqKP5tbm4OPT09RXkpWvbukY7bt2+jX79+cHBwgFwuV7xW0V2eBw8ejJiYGDg7O2P06NE4evSo4rm9e/dGVlYWHBwcMHToUOzevRt5eXn/mDEuLg4aGhrw8PBQLHN0dISxsfFHv08iIhIOCwwp0dLSgo+PD9avX4+cnBxs2bIFvr6+n7SPd+82LZPJVO4+LZPJlMbTdO3aFS9evMDq1atx/vx5nD9/HsDbsS8A4OHhgYSEBMyePRtZWVno06cPvvjiCwBvj0jFxcVh+fLl0NXVxTfffIOWLVsqTpsREVHFxAIjMkW/3IucO3cOTk5OcHV1RV5entL658+fIy4uDq6urgAAFxeXYp//d/7+/jh27BiWL1+OvLw89OzZsxTeiXLGKVOmoG3btnBxccHLly9VtpPL5fjyyy+xevVqbNu2DX/88QdevHgBANDV1UXXrl2xZMkSnDx5EhEREbhy5coHX9fZ2Rl5eXm4dOmSYtmdO3eKfW0iIip/OAZGZBITEzF+/Hh8/fXXuHjxIn755RcsXLgQTk5O6NatG4YOHYpVq1bBwMAA3333HapWrYpu3boBAEaPHo1mzZrhp59+Qrdu3XDkyBGl8S9FXFxc0KRJEwQGBsLX1xe6urql9n6MjY1hYmKCX3/9FZaWlkhMTMR3332ntM3PP/8MS0tLuLu7Q01NDTt27ICFhQWMjIwQEhKC/Px8NG7cGHp6evjtt9+gq6urNE6mODVr1oSXlxeGDRuGFStWQFNTE99++y10dXWVTtEREVH5xALzjk+dGVcIPj4+yMrKQqNGjaCuro4xY8Zg2LBhAN5eLTRmzBh06dIFOTk5aNmyJQ4ePKg4hdOkSROsXr0a06dPx7Rp0+Dl5YUpU6Zg9uzZKq/j5+eH8PDwTz599KnU1NSwdetWjB49GrVr14azszOWLFmCVq1aKbYxMDBAUFAQbt++DXV1dTRs2BAHDx6EmpoajIyMsGDBAowfPx75+flwc3PDvn37YGJi8o+vvXHjRvj5+aFly5awsLDA/Pnzce3aNejo6JTiOyYiopIgKyyaRKSCSU9Ph6GhIdLS0iCXy5XWvXnzBgkJCbC3t+cvq/eYPXs2duzYgcuXLwsdpcw8ePAA1tbWOHbsGNq2bSt0nP+Mn3Mi8SuNW9yU9z/WP/T7+13/aQzMggULIJPJMHbsWMWyN2/eYOTIkTAxMYG+vj569eqFx48fKz0vMTERnTt3hp6eHszMzDBx4kSVK0dOnjwJDw8PaGtrw9HRESEhIf8lKn2kjIwMXL16FUuXLsWoUaOEjlOqjh8/jr179yIhIQHh4eHo27cv7Ozs0LJlS6GjERHRP/jXBebChQtYtWqV0iWzADBu3Djs27cPO3bswKlTp/Do0SOlQaD5+fno3LkzcnJyEB4ejg0bNiAkJATTpk1TbJOQkIDOnTujdevWiImJwdixY+Hv748jR47827j0kQICAlC/fn20atVK5fTR8OHDoa+vX+zX8OHDBUpcvL/++uu9WfX19QEAubm5+P7771GrVi306NEDpqamOHnypMpVU0REVP78q1NIGRkZ8PDwwPLlyzFnzhzFHZLT0tJgamqKLVu2KC5zvXnzJlxcXBAREYEmTZrg0KFD6NKlCx49egRzc3MAwMqVKxEYGIinT59CS0sLgYGBOHDgAK5evap4zb59+yI1NbXYQafF4SmkkvfkyROkp6cXu04ul8PMzKyME71fVlYWHj58+N71jo6OZZhGGPycE4kfTyG9/xTSvxrEO3LkSHTu3BleXl5KU9FHR0cjNzcXXl5eimU1a9aEjY2NosBERETAzc1NUV4AwNvbGyNGjMC1a9fg7u6OiIgIpX0UbfPuqaq/y87ORnZ2tuLx+37R0r9nZmZWrkrKh+jq6kqipBARSdUnF5itW7fi4sWLuHDhgsq6lJQUaGlpwcjISGm5ubk5UlJSFNu8W16K1het+9A26enpyMrKKvay3vnz52PmzJmf9F4q6PhlIgD8fBNRxfZJY2CSkpIwZswYbN68udwdkp48eTLS0tIUX0lJSe/dtmiMw7t3RCaqaIo+3xzTQ0QV0ScdgYmOjsaTJ0+U7h+Tn5+P06dPY+nSpThy5AhycnKQmpqqdBTm8ePHsLCwAABYWFggMjJSab9FVym9u83fr1x6/Pgx5HL5eydV09bWhra29ke9D3V1dRgZGSnux6Onp8fJy6jCKCwsRGZmJp48eQIjIyOoq6sLHYmIqMR9UoFp27atyhTtQ4YMQc2aNREYGAhra2toamoiLCxMcYfhuLg4JCYmKm4a6Onpiblz5+LJkyeK8RShoaGQy+WKKe89PT1x8OBBpdcJDQ1VufHgf1FUlt69qSBRRWJkZKT4nBMRVTSfVGAMDAxQu3ZtpWWVKlWCiYmJYrmfnx/Gjx+PypUrQy6XY9SoUfD09ESTJk0AAO3bt4erqysGDhyIoKAgpKSkYMqUKRg5cqTiCMrw4cOxdOlSTJo0Cb6+vjh+/Di2b9+OAwcOlMR7BvD2hoKWlpYwMzPjjf+owtHU1OSRFyKq0Er8VgKLFi2CmpoaevXqhezsbHh7e2P58uWK9erq6ti/fz9GjBgBT09PVKpUCYMGDcKsWbMU29jb2+PAgQMYN24cFi9ejGrVqmHNmjXw9vYu6bhQV1fnD3oiIiKRkeStBIiIiMSA88CU0q0EiIiIiITAAkNERESiwwJDREREosMCQ0RERKLDAkNERESiwwJDREREosMCQ0RERKLDAkNERESiwwJDREREosMCQ0RERKLDAkNERESiU+I3cyQiEquSvu9Meb/nDJGY8QgMERERiQ6PwJAgpHiHVSIiKjk8AkNERESiwwJDREREosMCQ0RERKLDAkNERESiwwJDREREosMCQ0RERKLDAkNERESiwwJDREREosMCQ0RERKLDAkNERESiwwJDREREosMCQ0RERKLDAkNERESiwwJDREREosMCQ0RERKLDAkNERESiwwJDREREosMCQ0RERKLDAkNERESiwwJDREREosMCQ0RERKLDAkNERESiwwJDREREosMCQ0RERKLDAkNERESiwwJDREREosMCQ0RERKLDAkNERESiwwJDREREosMCQ0RERKLDAkNERESiwwJDREREosMCQ0RERKLDAkNERESiwwJDREREosMCQ0RERKLDAkNERESiwwJDREREosMCQ0RERKLDAkNERESiwwJDREREosMCQ0RERKLDAkNERESiwwJDREREovNJBWbFihWoU6cO5HI55HI5PD09cejQIcX6N2/eYOTIkTAxMYG+vj569eqFx48fK+0jMTERnTt3hp6eHszMzDBx4kTk5eUpbXPy5El4eHhAW1sbjo6OCAkJ+ffvkIiIiCqcTyow1apVw4IFCxAdHY2oqCi0adMG3bp1w7Vr1wAA48aNw759+7Bjxw6cOnUKjx49Qs+ePRXPz8/PR+fOnZGTk4Pw8HBs2LABISEhmDZtmmKbhIQEdO7cGa1bt0ZMTAzGjh0Lf39/HDlypITeMhEREYmdrLCwsPC/7KBy5cr43//+hy+++AKmpqbYsmULvvjiCwDAzZs34eLigoiICDRp0gSHDh1Cly5d8OjRI5ibmwMAVq5cicDAQDx9+hRaWloIDAzEgQMHcPXqVcVr9O3bF6mpqTh8+PBH50pPT4ehoSHS0tIgl8v/y1ukUnCjpkuJ79Pl5o0S3ydJS0l/LvmZpP9Kij8rP/b3978eA5Ofn4+tW7fi9evX8PT0RHR0NHJzc+Hl5aXYpmbNmrCxsUFERAQAICIiAm5uboryAgDe3t5IT09XHMWJiIhQ2kfRNkX7eJ/s7Gykp6crfREREVHF9MkF5sqVK9DX14e2tjaGDx+O3bt3w9XVFSkpKdDS0oKRkZHS9ubm5khJSQEApKSkKJWXovVF6z60TXp6OrKyst6ba/78+TA0NFR8WVtbf+pbIyIiIpH45ALj7OyMmJgYnD9/HiNGjMCgQYNw/fr10sj2SSZPnoy0tDTFV1JSktCRiIiIqJRofOoTtLS04OjoCACoX78+Lly4gMWLF+PLL79ETk4OUlNTlY7CPH78GBYWFgAACwsLREZGKu2v6Cqld7f5+5VLjx8/hlwuh66u7ntzaWtrQ1tb+1PfDhEREYnQf54HpqCgANnZ2ahfvz40NTURFhamWBcXF4fExER4enoCADw9PXHlyhU8efJEsU1oaCjkcjlcXV0V27y7j6JtivZBRERE9ElHYCZPnoyOHTvCxsYGr169wpYtW3Dy5EkcOXIEhoaG8PPzw/jx41G5cmXI5XKMGjUKnp6eaNKkCQCgffv2cHV1xcCBAxEUFISUlBRMmTIFI0eOVBw9GT58OJYuXYpJkybB19cXx48fx/bt23HgwIGSf/dEREQkSp9UYJ48eQIfHx8kJyfD0NAQderUwZEjR9CuXTsAwKJFi6CmpoZevXohOzsb3t7eWL58ueL56urq2L9/P0aMGAFPT09UqlQJgwYNwqxZsxTb2Nvb48CBAxg3bhwWL16MatWqYc2aNfD29i6ht0xERERi95/ngSmvOA9M+SbFuQ2o/OM8MFTeSPFnZanPA0NEREQkFBYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISnU8qMPPnz0fDhg1hYGAAMzMzdO/eHXFxcUrbvHnzBiNHjoSJiQn09fXRq1cvPH78WGmbxMREdO7cGXp6ejAzM8PEiRORl5entM3Jkyfh4eEBbW1tODo6IiQk5N+9QyIiIqpwPqnAnDp1CiNHjsS5c+cQGhqK3NxctG/fHq9fv1ZsM27cOOzbtw87duzAqVOn8OjRI/Ts2VOxPj8/H507d0ZOTg7Cw8OxYcMGhISEYNq0aYptEhIS0LlzZ7Ru3RoxMTEYO3Ys/P39ceTIkRJ4y0RERCR2ssLCwsJ/++SnT5/CzMwMp06dQsuWLZGWlgZTU1Ns2bIFX3zxBQDg5s2bcHFxQUREBJo0aYJDhw6hS5cuePToEczNzQEAK1euRGBgIJ4+fQotLS0EBgbiwIEDuHr1quK1+vbti9TUVBw+fPijsqWnp8PQ0BBpaWmQy+X/9i1SKblR06XE9+ly80aJ75OkpaQ/l/xM0n8lxZ+VH/v7+z+NgUlLSwMAVK5cGQAQHR2N3NxceHl5KbapWbMmbGxsEBERAQCIiIiAm5uborwAgLe3N9LT03Ht2jXFNu/uo2ibon0UJzs7G+np6UpfREREVDH96wJTUFCAsWPHolmzZqhduzYAICUlBVpaWjAyMlLa1tzcHCkpKYpt3i0vReuL1n1om/T0dGRlZRWbZ/78+TA0NFR8WVtb/9u3RkREROXcvy4wI0eOxNWrV7F169aSzPOvTZ48GWlpaYqvpKQkoSMRERFRKdH4N08KCAjA/v37cfr0aVSrVk2x3MLCAjk5OUhNTVU6CvP48WNYWFgotomMjFTaX9FVSu9u8/crlx4/fgy5XA5dXd1iM2lra0NbW/vfvB0iIiISmU86AlNYWIiAgADs3r0bx48fh729vdL6+vXrQ1NTE2FhYYplcXFxSExMhKenJwDA09MTV65cwZMnTxTbhIaGQi6Xw9XVVbHNu/so2qZoH0RERCRtn3QEZuTIkdiyZQv+/PNPGBgYKMasGBoaQldXF4aGhvDz88P48eNRuXJlyOVyjBo1Cp6enmjSpAkAoH379nB1dcXAgQMRFBSElJQUTJkyBSNHjlQcQRk+fDiWLl2KSZMmwdfXF8ePH8f27dtx4MCBEn77REREJEafdARmxYoVSEtLQ6tWrWBpaan42rZtm2KbRYsWoUuXLujVqxdatmwJCwsL7Nq1S7FeXV0d+/fvh7q6Ojw9PfHVV1/Bx8cHs2bNUmxjb2+PAwcOIDQ0FHXr1sXChQuxZs0aeHt7l8BbJiIiIrH7T/PAlGecB6Z8k+LcBlT+cR4YKm+k+LOyTOaBISIiIhICCwwRERGJDgsMERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYkOCwwRERGJzicXmNOnT6Nr166wsrKCTCbDnj17lNYXFhZi2rRpsLS0hK6uLry8vHD79m2lbV68eIEBAwZALpfDyMgIfn5+yMjIUNrm8uXLaNGiBXR0dGBtbY2goKBPf3dERERUIX1ygXn9+jXq1q2LZcuWFbs+KCgIS5YswcqVK3H+/HlUqlQJ3t7eePPmjWKbAQMG4Nq1awgNDcX+/ftx+vRpDBs2TLE+PT0d7du3h62tLaKjo/G///0PM2bMwK+//vov3iIRERFVNBqf+oSOHTuiY8eOxa4rLCxEcHAwpkyZgm7dugEANm7cCHNzc+zZswd9+/bFjRs3cPjwYVy4cAENGjQAAPzyyy/o1KkTfvrpJ1hZWWHz5s3IycnBunXroKWlhVq1aiEmJgY///yzUtEhIiIiaSrRMTAJCQlISUmBl5eXYpmhoSEaN26MiIgIAEBERASMjIwU5QUAvLy8oKamhvPnzyu2admyJbS0tBTbeHt7Iy4uDi9fviz2tbOzs5Genq70RURERBVTiRaYlJQUAIC5ubnScnNzc8W6lJQUmJmZKa3X0NBA5cqVlbYpbh/vvsbfzZ8/H4aGhoova2vr//6GiIiIqFyqMFchTZ48GWlpaYqvpKQkoSMRERFRKSnRAmNhYQEAePz4sdLyx48fK9ZZWFjgyZMnSuvz8vLw4sULpW2K28e7r/F32trakMvlSl9ERERUMZVogbG3t4eFhQXCwsIUy9LT03H+/Hl4enoCADw9PZGamoro6GjFNsePH0dBQQEaN26s2Ob06dPIzc1VbBMaGgpnZ2cYGxuXZGQiIiISoU8uMBkZGYiJiUFMTAyAtwN3Y2JikJiYCJlMhrFjx2LOnDnYu3cvrly5Ah8fH1hZWaF79+4AABcXF3To0AFDhw5FZGQkzp49i4CAAPTt2xdWVlYAgP79+0NLSwt+fn64du0atm3bhsWLF2P8+PEl9saJiIhIvD75MuqoqCi0bt1a8bioVAwaNAghISGYNGkSXr9+jWHDhiE1NRXNmzfH4cOHoaOjo3jO5s2bERAQgLZt20JNTQ29evXCkiVLFOsNDQ1x9OhRjBw5EvXr10eVKlUwbdo0XkJNREREAABZYWFhodAhSkN6ejoMDQ2RlpbG8TDl0I2aLiW+T5ebN0p8nyQtJf255GeS/isp/qz82N/fFeYqJCIiIpIOFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0WGCIiIhIdFhgiIiISHQ2hAxAREVUEbhvcSnyf20t8jxUHCwwRiRJ/WRBJGwsMfZSS/mXBXxRERPRfcAwMERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYkOCwwRERGJDgsMERERiQ4LDBEREYlOuS4wy5Ytg52dHXR0dNC4cWNERkYKHYmIiIjKgXI7E++2bdswfvx4rFy5Eo0bN0ZwcDC8vb0RFxcHMzMzoeOVGLvvDpT4Pu8t6Fzi+yRpKenPJT+T9F/xZyX9Xbk9AvPzzz9j6NChGDJkCFxdXbFy5Uro6elh3bp1QkcjIiIigZXLIzA5OTmIjo7G5MmTFcvU1NTg5eWFiIiIYp+TnZ2N7OxsxeO0tDQAQHp6eumG/Y8KsjNLfJ/pk+Ulvs9822olur+M/PwS3R9Q/v9bi0lJfy7F8JkESv5zyc9kyRHDz0oxfCaB8v+5LMpXWFj4we3KZYF59uwZ8vPzYW5urrTc3NwcN2/eLPY58+fPx8yZM1WWW1tbl0rG8sywVPZ6o0T31qhE9/b/GZbOO6f/TgyfSaAUPpf8TJZrJf9fRwSfSUA0n8tXr17B8ANZy2WB+TcmT56M8ePHKx4XFBTgxYsXMDExgUwmEzCZ+KWnp8Pa2hpJSUmQy0v+L2miT8XPJJU3/EyWnMLCQrx69QpWVlYf3K5cFpgqVapAXV0djx8/Vlr++PFjWFhYFPscbW1taGtrKy0zMjIqrYiSJJfL+T8mlSv8TFJ5w89kyfjQkZci5XIQr5aWFurXr4+wsDDFsoKCAoSFhcHT01PAZERERFQelMsjMAAwfvx4DBo0CA0aNECjRo0QHByM169fY8iQIUJHIyIiIoGV2wLz5Zdf4unTp5g2bRpSUlJQr149HD58WGVgL5U+bW1tTJ8+XeUUHZFQ+Jmk8oafybInK/yn65SIiIiIyplyOQaGiIiI6ENYYIiIiEh0WGCIiIhIdFhgiIiISHRYYIiIiEh0yu1l1FQ+ZGdn87JAElxCQgL++usv3L9/H5mZmTA1NYW7uzs8PT2ho6MjdDySIH4mhccCQ0oOHTqErVu34q+//kJSUhIKCgpQqVIluLu7o3379hgyZMg/3p+CqKRs3rwZixcvRlRUFMzNzWFlZQVdXV28ePEC8fHx0NHRwYABAxAYGAhbW1uh45IE8DNZfnAeGAIA7N69G4GBgXj16hU6deqERo0aKf2PefXqVfz111+IiIjA4MGDMXv2bJiamgodmyowd3d3aGlpYdCgQejatavKneWzs7MRERGBrVu34o8//sDy5cvRu3dvgdKSFPAzWb6wwBAAwNPTE1OmTEHHjh2hpvb+oVEPHz7EL7/8AnNzc4wbN64ME5LUHDlyBN7e3h+17fPnz3Hv3j3Ur1+/lFORlPEzWb6wwBAREZHocAwMvVdOTg4SEhJQvXp1aGjwo0Llw5s3b5CTk6O0TC6XC5SGiJ9JofAyalKRmZkJPz8/6OnpoVatWkhMTAQAjBo1CgsWLBA4HUlRZmYmAgICYGZmhkqVKsHY2Fjpi6is8TMpPBYYUjF58mTExsbi5MmTSpcDenl5Ydu2bQImI6maOHEijh8/jhUrVkBbWxtr1qzBzJkzYWVlhY0bNwodjySIn0nhcQwMqbC1tcW2bdvQpEkTGBgYIDY2Fg4ODrhz5w48PDyQnp4udESSGBsbG2zcuBGtWrWCXC7HxYsX4ejoiE2bNuH333/HwYMHhY5IEsPPpPB4BIZUPH36FGZmZirLX79+DZlMJkAikroXL17AwcEBwNuxBS9evAAANG/eHKdPnxYyGkkUP5PCY4EhFQ0aNMCBAwcUj4tKy5o1a+Dp6SlULJIwBwcHJCQkAABq1qyJ7du3AwD27dsHIyMjAZORVPEzKTxeWkIq5s2bh44dO+L69evIy8vD4sWLcf36dYSHh+PUqVNCxyMJGjJkCGJjY/HZZ5/hu+++Q9euXbF06VLk5ubi559/FjoeSRA/k8LjGBgqVnx8PBYsWIDY2FhkZGTAw8MDgYGBcHNzEzoaEe7fv4/o6Gg4OjqiTp06Qsch4mdSACwwREREJDo8hUQfxAmaqDwYPXo0HB0dMXr0aKXlS5cuxZ07dxAcHCxMMJKsWbNmfXD9tGnTyiiJdPEIDKnIzMzEpEmTsH37djx//lxlfX5+vgCpSMqqVq2KvXv3qtxX5uLFi/j888/x4MEDgZKRVLm7uys9zs3NRUJCAjQ0NFC9enVcvHhRoGTSwSMwpGLixIk4ceIEVqxYgYEDB2LZsmV4+PAhVq1axZl4SRDPnz+HoaGhynK5XI5nz54JkIik7tKlSyrL0tPTMXjwYPTo0UOARNLDy6hJxb59+7B8+XL06tULGhoaaNGiBaZMmYJ58+Zh8+bNQscjCXJ0dMThw4dVlh86dEgxFweR0ORyOWbOnImpU6cKHUUSeASGVHxogqYRI0YIGY0kavz48QgICMDTp0/Rpk0bAEBYWBgWLlzI8S9UrqSlpSEtLU3oGJLAAkMqiiZosrGxUUzQ1KhRI07QRILx9fVFdnY25s6di9mzZwMA7OzssGLFCvj4+AicjqRoyZIlSo8LCwuRnJyMTZs2oWPHjgKlkhYO4iUVixYtgrq6OkaPHo1jx46ha9euKCwsVEzQNGbMGKEjkoQ9ffoUurq60NfXFzoKSZi9vb3SYzU1NZiamqJNmzaYPHkyDAwMBEomHSww9I84QRMREZU3LDBEVC55eHggLCwMxsbGcHd3/+CNRHnJKgkpKSkJAGBtbS1wEmnhGBgC8PZ87rBhw6Cjo6Nybvfv/j6ZGFFp6NatG7S1tRX/5p3QqTzJy8vDzJkzsWTJEmRkZAAA9PX1MWrUKEyfPh2ampoCJ6z4eASGALw9nxsVFQUTExOVc7vvkslkuHv3bhkmIyIqf0aMGIFdu3Zh1qxZ8PT0BABERERgxowZ6N69O1asWCFwwoqPBYaIyj0HBwdcuHABJiYmSstTU1Ph4eHBUk1lztDQEFu3blW54ujgwYPo168fL6UuA5zIjojKvXv37hV7C4vs7GzeRoAEoa2tDTs7O5Xl9vb20NLSKvtAEsQxMATg7URhH+vnn38uxSRE/2fv3r2Kfx85ckTpdgL5+fkICwv74ClPotISEBCA2bNnY/369YqxWkVzFQUEBAicThp4CokAAK1bt/6o7WQyGY4fP17KaYjeUlN7e5BYJpPh7z+qNDU1YWdnh4ULF6JLly5CxCMJ69GjB8LCwqCtrY26desCAGJjY5GTk4O2bdsqbbtr1y4hIlZ4PAJDAIATJ04IHYFIRUFBAYC3h+UvXLiAKlWqCJyI6C0jIyP06tVLaRkvoy5bPAJD73Xnzh3Ex8ejZcuW0NXVRWFhIS9lJSKicoGDeEnF8+fP0bZtW9SoUQOdOnVCcnIyAMDPzw/ffvutwOlIikaPHl3s/ERLly7F2LFjyz4QEQmOBYZUjBs3DpqamkhMTISenp5i+ZdffonDhw8LmIyk6o8//kCzZs1Uljdt2hQ7d+4UIBERsHPnTvTp0wdNmjSBh4eH0heVPhYYUnH06FH8+OOPqFatmtJyJycn3L9/X6BUJGXPnz9XugKpiFwux7NnzwRIRFK3ZMkSDBkyBObm5rh06RIaNWoEExMT3L17l3ejLiMsMKTi9evXSkdeirx48UJxuSBRWXJ0dCz26N+hQ4fg4OAgQCKSuuXLl+PXX3/FL7/8Ai0tLUyaNAmhoaEYPXo0J7ErI7wKiVS0aNECGzduxOzZswG8vYS1oKAAQUFBH325NVFJGj9+PAICAvD06VO0adMGABAWFoaFCxciODhY2HAkSYmJiWjatCkAQFdXF69evQIADBw4EE2aNMHSpUuFjCcJLDCkIigoCG3btkVUVBRycnIwadIkXLt2DS9evMDZs2eFjkcS5Ovrq5gkrKhY29nZYcWKFfDx8RE4HUmRhYUFXrx4AVtbW9jY2ODcuXOoW7cuEhISVOYsotLBU0ikonbt2rh16xaaN2+Obt264fXr1+jZsycuXbqE6tWrCx2PJCYvLw8bN25Ez5498eDBAzx+/Bjp6em4e/cuywsJpk2bNoqZoocMGYJx48ahXbt2+PLLL9GjRw+B00kD54EhonJPT08PN27cgK2trdBRiAC8nWSxoKAAGhpvT2Rs3boV4eHhcHJywtdff837IZUBFhgCAFy+fPmjt61Tp04pJiFS1apVK4wdOxbdu3cXOgoRlRMcA0MAgHr16inuN/PubLtF/fbdZcXdFZioNH3zzTf49ttv8eDBA9SvXx+VKlVSWs9STUJ4+fIl1q5dixs3bgAAXF1dMWTIEFSuXFngZNLAIzAEAErzu1y6dAkTJkzAxIkT4enpCQCIiIjAwoULERQUxL+CqcwV3dTxXe8WbpZqKmunT5/G559/DrlcjgYNGgAAoqOjkZqain379qFly5YCJ6z4WGBIRaNGjTBjxgx06tRJafnBgwcxdepUREdHC5SMpOqfJlDk2Bgqa25ubvD09MSKFSugrq4O4O3R6W+++Qbh4eG4cuWKwAkrPhYYUqGrq4uLFy/CxcVFafmNGzfg4eGBrKwsgZIREZUPurq6iImJgbOzs9LyuLg41KtXjz8nywDHwJAKFxcXzJ8/H2vWrFGMpM/JycH8+fNVSg1RWbp+/ToSExORk5OjtPzzzz8XKBFJlYeHB27cuKFSYG7cuIG6desKlEpaWGBIxcqVK9G1a1dUq1ZNMTjy8uXLkMlk2Ldvn8DpSIru3r2LHj164MqVK4qxL8D/DS7nGBgqa6NHj8aYMWNw584dNGnSBABw7tw5LFu2DAsWLFC6spODzEsHTyFRsV6/fo3Nmzfj5s2bAN4elenfv7/K1R9EZaFr165QV1fHmjVrYG9vj8jISDx//hzffvstfvrpJ7Ro0ULoiCQxxQ0sfxcHmZc+FhgiKveqVKmC48ePo06dOjA0NERkZCScnZ1x/PhxfPvtt7h06ZLQEUli/mlg+bs4yLx08BQSvRfHG1B5kZ+fDwMDAwBvy8yjR4/g7OwMW1tbxMXFCZyOpIilRHgsMKSC4w2ovKlduzZiY2Nhb2+Pxo0bIygoCFpaWvj111/h4OAgdDwiEgBv5kgqxowZA3t7ezx58gR6enq4du0aTp8+jQYNGuDkyZNCxyMJmjJlCgoKCgAAs2bNQkJCAlq0aIGDBw9i8eLFAqcjIiFwDAyp4HgDEoMXL17A2NhY6TYXRCQdPAJDKoobbwCA4w1IML6+vnj16pXSssqVKyMzMxO+vr4CpSIiIbHAkIqi8QYAFOMNzp49i1mzZnG8AQliw4YNxc5smpWVhY0bNwqQiKQuKSkJDx48UDyOjIzE2LFj8euvvwqYSlpYYEjFh8YbLFmyROB0JCXp6elIS0tDYWEhXr16hfT0dMXXy5cvcfDgQZiZmQkdkySof//+OHHiBAAgJSUF7dq1Q2RkJH744QfMmjVL4HTSwDEw9FE43oCEoKam9sHPnEwmw8yZM/HDDz+UYSoiwNjYGOfOnYOzszOWLFmCbdu24ezZszh69CiGDx+Ou3fvCh2xwuNl1PRRKleuLHQEkqATJ06gsLAQbdq0wR9//KH0OdTS0oKtrS2srKwETEhSlZubC21tbQDAsWPHFPNj1axZE8nJyUJGkwwWGCIqtz777DMAQEJCAqytrf9x+naislKrVi2sXLkSnTt3RmhoKGbPng0AePToEUxMTAROJw08hUREopCamorIyEg8efJEMUariI+Pj0CpSKpOnjyJHj16ID09HYMGDcK6desAAN9//z1u3ryJXbt2CZyw4mOBIaJyb9++fRgwYAAyMjIgl8uVxsXIZDK8ePFCwHQkVfn5+UhPT4exsbFi2b1796Cnp8fB5WWABYaIyr0aNWqgU6dOmDdvHvT09ISOQ0TlAAsMqdiwYQOqVKmCzp07AwAmTZqEX3/9Fa6urvj99995EzMqc5UqVcKVK1c4DxEJysPDA2FhYTA2Noa7u/sHr5C7ePFiGSaTJg7iJRXz5s3DihUrAAARERFYtmwZFi1ahP3792PcuHE8t0tlztvbG1FRUSwwJKhu3boprjzq3r27sGGIR2BIlZ6eHm7evAkbGxsEBgYiOTkZGzduxLVr19CqVSs8ffpU6IgkMWvXrsWsWbMwZMgQuLm5QVNTU2l90SWsRCQdPAJDKvT19fH8+XPY2Njg6NGjGD9+PABAR0en2OnciUrb0KFDAaDYGU5lMhny8/PLOhIRCYwFhlS0a9cO/v7+cHd3x61bt9CpUycAwLVr12BnZydsOJKkv182TSSET5mNnFfGlT4WGFKxbNkyTJkyBUlJSfjjjz8UkzJFR0ejX79+AqcjIhJGcHCw0BHoHRwDQ0Si8Pr1a5w6dQqJiYnIyclRWjd69GiBUhGRUFhgCABw+fJl1K5dG2pqarh8+fIHt61Tp04ZpSJ669KlS+jUqRMyMzPx+vVrVK5cGc+ePVNMGMYb55EQ4uPjsX79esTHx2Px4sUwMzPDoUOHYGNjg1q1agkdr8JjgSEAb+/6m5KSAjMzM8UdgN/9aBQ95oBJEkKrVq1Qo0YNrFy5EoaGhoiNjYWmpia++uorjBkzBj179hQ6IknMqVOn0LFjRzRr1gynT5/GjRs34ODggAULFiAqKgo7d+4UOmKFxwJDAID79+/DxsYGMpkM9+/f/+C2nMiOypqRkRHOnz8PZ2dnGBkZISIiAi4uLjh//jwGDRqEmzdvCh2RJMbT0xO9e/fG+PHjYWBggNjYWDg4OCAyMhI9e/bEgwcPhI5Y4XEQLwFQLiUsKFTeaGpqKu5EbWZmhsTERLi4uMDQ0BBJSUkCpyMpunLlCrZs2aKy3MzMDM+ePRMgkfSwwBAAYO/evR+9LScNo7Lm7u6OCxcuwMnJCZ999hmmTZuGZ8+eYdOmTahdu7bQ8UiCjIyMkJycDHt7e6Xlly5dQtWqVQVKJS08hUQAoPjr9p9wDAwJISoqCq9evULr1q3x5MkT+Pj4IDw8HE5OTli3bh3q1q0rdESSmAkTJuD8+fPYsWMHatSogYsXL+Lx48fw8fGBj48Ppk+fLnTECo8FhoiI6BPl5ORg5MiRCAkJQX5+PjQ0NJCfn4/+/fsjJCQE6urqQkes8Fhg6IPevHkDHR0doWMQEZVLSUlJuHLlCjIyMuDu7g4nJyehI0kGCwypyM/Px7x587By5Uo8fvwYt27dgoODA6ZOnQo7Ozv4+fkJHZGIiCTu4wY+kKTMnTsXISEhCAoKgpaWlmJ57dq1sWbNGgGTERGVD7169cKPP/6osjwoKAi9e/cWIJH0sMCQio0bN+LXX3/FgAEDlM7j1q1bl/NtEBEBOH36tOJGt+/q2LEjTp8+LUAi6WGBIRUPHz6Eo6OjyvKCggLk5uYKkIhIVWpqqtARSMIyMjKUjlAX0dTURHp6ugCJpIcFhlS4urrir7/+Ulm+c+dOuLu7C5CIpO7HH3/Etm3bFI/79OkDExMTVK1aFbGxsQImI6lyc3NT+kwW2bp1K1xdXQVIJD2cyI5UTJs2DYMGDcLDhw9RUFCAXbt2IS4uDhs3bsT+/fuFjkcStHLlSmzevBkAEBoaitDQUBw6dAjbt2/HxIkTcfToUYETktRMnToVPXv2RHx8PNq0aQMACAsLw++//44dO3YInE4aeBUSFeuvv/7CrFmzEBsbi4yMDHh4eGDatGlo37690NFIgnR1dXHr1i1YW1tjzJgxePPmDVatWoVbt26hcePGePnypdARSYIOHDiAefPmISYmBrq6uqhTpw6mT5+Ozz77TOhoksACQ0TlnpWVFXbu3ImmTZvC2dkZc+bMQe/evREXF4eGDRtyzAGRBPEUEqm4cOECCgoK0LhxY6Xl58+fh7q6Oho0aCBQMpKqnj17on///nBycsLz58/RsWNHAG/vO1PcgHOi0paUlASZTIZq1aoBACIjI7Flyxa4urpi2LBhAqeTBg7iJRUjR44s9g6/Dx8+xMiRIwVIRFK3aNEiBAQEwNXVFaGhodDX1wcAJCcn45tvvhE4HUlR//79ceLECQBASkoKvLy8EBkZiR9++AGzZs0SOJ008BQSqdDX18fly5fh4OCgtDwhIQF16tTBq1evBEpGRFQ+GBsb49y5c3B2dsaSJUuwbds2nD17FkePHsXw4cNx9+5doSNWeDyFRCq0tbXx+PFjlQKTnJwMDQ1+ZKhs7N27Fx07doSmpib27t37wW0///zzMkpF9FZubi60tbUBAMeOHVN8BmvWrInk5GQho0kGj8CQin79+iE5ORl//vknDA0NAbydNKx79+4wMzPD9u3bBU5IUqCmpoaUlBSYmZlBTe39Z7tlMhny8/PLMBkR0LhxY7Ru3RqdO3dG+/btce7cOdStWxfnzp3DF198gQcPHggdscJjgSEVDx8+RMuWLfH8+XPFxHUxMTEwNzdHaGgorK2tBU5IRCSskydPokePHkhPT8egQYOwbt06AMD333+PmzdvYteuXQInrPhYYKhYr1+/xubNmxEbG6uY36Bfv37Q1NQUOhoRUbmQn5+P9PR0GBsbK5bdu3cPenp6MDMzEzCZNLDAEFG5tGTJko/edvTo0aWYhOj9nj59iri4OACAs7MzTE1NBU4kHSwwpGLDhg2oUqUKOnfuDACYNGkSfv31V7i6uuL333+Hra2twAlJCuzt7T9qO5lMxis+qMy9fv0ao0aNwsaNG1FQUAAAUFdXh4+PD3755Rfo6ekJnLDiY4EhFc7OzlixYgXatGmDiIgItG3bFsHBwdi/fz80NDR4bpeIJO/rr7/GsWPHsHTpUjRr1gwAcObMGYwePRrt2rXDihUrBE5Y8bHAkAo9PT3cvHkTNjY2CAwMRHJyMjZu3Ihr166hVatWePr0qdARSaJycnKQkJCA6tWr85J+ElSVKlWwc+dOtGrVSmn5iRMn0KdPH/6cLAOciZdU6Ovr4/nz5wCAo0ePol27dgAAHR0dZGVlCRmNJCozMxN+fn7Q09NDrVq1kJiYCAAYNWoUFixYIHA6kqLMzEyYm5urLDczM0NmZqYAiaSHBYZUtGvXDv7+/vD398etW7fQqVMnAMC1a9dgZ2cnbDiSpMmTJyM2NhYnT56Ejo6OYrmXlxe2bdsmYDKSKk9PT0yfPh1v3rxRLMvKysLMmTPh6ekpYDLp4DFYUrFs2TJMmTIFSUlJ+OOPP2BiYgIAiI6ORr9+/QROR1K0Z88ebNu2DU2aNIFMJlMsr1WrFuLj4wVMRlK1ePFieHt7o1q1aqhbty4AIDY2Fjo6Ojhy5IjA6aSBY2CIqNzT09PD1atX4eDgAAMDA8TGxsLBwQGxsbFo2bIl0tLShI5IEpSZmYnNmzfj5s2bAAAXFxcMGDAAurq6AieTBh6BoWKlpqZi7dq1uHHjBoC3f+n6+voqbi1AVJYaNGiAAwcOYNSoUQCgOAqzZs0aHq4nwejp6WHo0KFCx5AsHoEhFVFRUfD29oauri4aNWoEALhw4QKysrJw9OhReHh4CJyQpObMmTPo2LEjvvrqK4SEhODrr7/G9evXER4ejlOnTqF+/fpCRySJed8NRmUyGXR0dODo6PjRcxnRv8MCQypatGgBR0dHrF69WnGpal5eHvz9/XH37l2cPn1a4IQkRfHx8ViwYAFiY2ORkZEBDw8PBAYGws3NTehoJEFqamqQyWT4+6/QomUymQzNmzfHnj17lG41QCWHBYZU6Orq4tKlS6hZs6bS8uvXr6NBgwa8RJCIJC8sLAw//PAD5s6dqzhSHRkZialTp2LKlCkwNDTE119/jcaNG2Pt2rUCp62YOAaGVMjlciQmJqoUmKSkJBgYGAiUiqTs4MGDUFdXh7e3t9LyI0eOoKCgAB07dhQoGUnVmDFj8Ouvv6Jp06aKZW3btoWOjg6GDRuGa9euITg4GL6+vgKmrNg4Dwyp+PLLL+Hn54dt27YhKSkJSUlJ2Lp1K/z9/XkZNQniu+++Q35+vsrywsJCfPfddwIkIqmLj4+HXC5XWS6XyxX35nJycsKzZ8/KOppk8AgMqfjpp58gk8ng4+ODvLw8AICmpiZGjBjBWU9JELdv34arq6vK8po1a+LOnTsCJCKpq1+/PiZOnIiNGzcq7kD99OlTTJo0CQ0bNgTw9nNrbW0tZMwKjQWGVGhpaWHx4sWYP3++YpKw6tWr8+6qJBhDQ0PcvXtXZSboO3fuoFKlSsKEIklbu3YtunXrhmrVqilKSlJSEhwcHPDnn38CADIyMjBlyhQhY1ZoHMRLROXe119/jYiICOzevRvVq1cH8La89OrVCw0bNsSaNWsETkhSVFBQgKNHj+LWrVsAAGdnZ7Rr1w5qahydURZYYEhFjx49lKZrL/Lu/Ab9+/eHs7OzAOlIitLS0tChQwdERUWhWrVqAIAHDx6gRYsW2LVrF4yMjIQNSJJz9+5dODg4CB1D0lhgSMXgwYOxZ88eGBkZKSYIu3jxIlJTU9G+fXvExsbi3r17CAsLQ7NmzQROS1JRWFiI0NBQxMbGQldXF3Xq1EHLli2FjkUSpaamhs8++wx+fn744osvlG4ySmWDBYZUfPfdd0hPT8fSpUsVh0ILCgowZswYGBgYYO7cuRg+fDiuXbuGM2fOCJyWpCo1NZVHXkgwMTExWL9+PX7//Xfk5OTgyy+/hK+vLxo3bix0NMlggSEVpqamOHv2LGrUqKG0/NatW2jatCmePXuGK1euoEWLFkhNTRUmJEnKjz/+CDs7O3z55ZcAgD59+uCPP/6AhYUFDh48qLgbMFFZy8vLw969exESEoLDhw+jRo0a8PX1xcCBAxVXJ1Hp4EgjUpGXl6e4u+q7bt68qZiLQ0dHp9hxMkSlYeXKlYorPUJDQxEaGopDhw6hY8eOmDhxosDpSMo0NDTQs2dP7NixAz/++CPu3LmDCRMmwNraGj4+PkhOThY6YoXFy6hJxcCBA+Hn54fvv/9eMZ/BhQsXMG/ePPj4+AAATp06hVq1agkZkyQkJSVFUWD279+PPn36oH379rCzs+MhexJUVFQU1q1bh61bt6JSpUqYMGEC/Pz88ODBA8ycORPdunVDZGSk0DErJBYYUrFo0SKYm5sjKCgIjx8/BgCYm5tj3LhxCAwMBAC0b98eHTp0EDImSYixsTGSkpJgbW2Nw4cPY86cOQDeDuwtboZeotL2888/Y/369YiLi0OnTp2wceNGdOrUSTFu0N7eHiEhISpzF1HJ4RgY+qD09HQAKHbKbKKyEhAQgP3798PJyQmXLl3CvXv3oK+vj61btyIoKAgXL14UOiJJjJOTE3x9fTF48GBYWloWu01OTg5+//13DBo0qIzTSQMLDKmYPn06fH19YWtrK3QUIgBAbm4uFi9ejKSkJAwePBju7u4A3h4tNDAwgL+/v8AJiaisscCQinr16uHq1auKOQ569eoFbW1toWMREQnu9evXmDBhAvbu3YucnBy0bdsWv/zyC684EgALDBXr0qVLijkO8vLy0LdvX/j6+ioG9RKVtfj4eAQHB+PGjRsAAFdXV4wdO5azoVKZGj9+PH799VcMGDAAOjo6+P3339GsWTPs3r1b6GiSwwJDH5Sbm4t9+/Zh/fr1OHLkCGrWrAk/Pz8MHjwYhoaGQscjiThy5Ag+//xz1KtXTzH789mzZxEbG4t9+/ahXbt2AickqbC3t0dQUBB69+4NAIiOjkaTJk2QlZUFDQ1eF1OWWGDog3JycrB7926sW7cOx48fR9OmTfHo0SM8fvwYq1evVkwsRlSa3N3d4e3tjQULFigt/+6773D06FEO4qUyo6mpifv378PKykqxTE9PDzdv3oSNjY2AyaSHE9lRsaKjoxEQEABLS0uMGzcO7u7uuHHjBk6dOoXbt29j7ty5GD16tNAxSSJu3LgBPz8/leW+vr64fv26AIlIqgoKCqCpqam0TENDg5fzC4DHu0iFm5sbbt68ifbt22Pt2rXo2rUr1NXVlbbp168fxowZI1BCkhpTU1PExMTAyclJaXlMTAzMzMwESkVSVFhYiLZt2yqdLsrMzETXrl2hpaWlWMajgqWPBYZU9OnTB76+vqhatep7t6lSpQoKCgrKMBVJ2dChQzFs2DDcvXsXTZs2BfB2DMyPP/6I8ePHC5yOpGT69Okqy7p16yZAEuIYGFKSnp6O8+fPIycnB40aNeKlgVQuFBYWIjg4GAsXLsSjR48AAFZWVpg4cSJGjx7N+3IRSRALDCnExMSgU6dOePz4MQoLC2FgYIDt27fD29tb6GhECq9evQIAGBgYCJyEiITEQbykEBgYCHt7e5w5cwbR0dFo27YtAgIChI5FpMTAwIDlhQTRoUMHnDt37h+3e/XqFX788UcsW7asDFJJF4/AkEKVKlVw9OhReHh4AABSU1NRuXJlpKam8l5IJCh3d/diTxPJZDLo6OjA0dERgwcPRuvWrQVIR1Kxdu1aTJs2DYaGhujatSsaNGgAKysr6Ojo4OXLl7h+/TrOnDmDgwcPonPnzvjf//7HS6tLEQsMKaipqSElJUXpqg4DAwNcvnwZ9vb2AiYjqZs8eTJWrFgBNzc3NGrUCABw4cIFXL58GYMHD8b169cRFhaGXbt2cUAllars7Gzs2LED27Ztw5kzZ5CWlgbgbZl2dXWFt7c3/Pz84OLiInDSio8FhhTU1NRw/PhxVK5cWbGsadOm2L59O6pVq6ZYVqdOHSHikYQNHToUNjY2mDp1qtLyOXPm4P79+1i9ejWmT5+OAwcOICoqSqCUJEVpaWnIysqCiYmJyvwwVLpYYEhBTU0NMpkMxX0kipbLZDJO2ERlztDQENHR0XB0dFRafufOHdSvXx9paWm4efMmGjZsqBjkS0QVG+eBIYWEhAShIxAVS0dHB+Hh4SoFJjw8HDo6OgDezpBa9G8iqvhYYEjB1tZW6AhExRo1ahSGDx+O6OhoxR3RL1y4gDVr1uD7778H8PaGj/Xq1RMwJRGVJZ5CIgBAYmLiJ42Wf/jw4Qdn6iUqaZs3b8bSpUsRFxcHAHB2dsaoUaPQv39/AEBWVpbiqiQiqvhYYAgAYG5uju7du8Pf31/xF+7fpaWlYfv27Vi8eDGGDRvGmzkSEZFgeAqJAADXr1/H3Llz0a5dO+jo6KB+/foq8xtcu3YNHh4eCAoKQqdOnYSOTBIyaNAg+Pn5oWXLlkJHIVKSk5ODJ0+eqNwbjvO/lD4egSElWVlZOHDgAM6cOYP79+8jKysLVapUgbu7O7y9vVG7dm2hI5IEde/eHQcPHoStrS2GDBmCQYMG8RQmCer27dvw9fVFeHi40nJerVl2WGCISBSePn2KTZs2YcOGDbh+/Tq8vLzg5+eHbt26cf4NKnPNmjWDhoYGvvvuO1haWqrMFF23bl2BkkkHCwwRic7Fixexfv16rFmzBvr6+vjqq6/wzTffwMnJSehoJBGVKlVCdHQ0atasKXQUyeLNHIlIVJKTkxEaGorQ0FCoq6ujU6dOuHLlClxdXbFo0SKh45FEuLq64tmzZ0LHkDQegSGici83Nxd79+7F+vXrcfToUdSpUwf+/v7o37+/4kaju3fvhq+vL16+fClwWpKC48ePY8qUKZg3bx7c3NxUTmPyBriljwWGiMq9KlWqoKCgAP369cPQoUOLnbAuNTUV7u7unFGayoSa2tsTGH8f+8JBvGWHBYaIyr1Nmzahd+/enKSOyo1Tp059cP1nn31WRkmkiwWGinX79m2cOHGi2PkNpk2bJlAqkqJ79+4hNDQUubm5+Oyzz1CrVi2hIxFROcACQypWr16NESNGoEqVKrCwsFA6RCqTyXDx4kUB05GUnDhxAl26dEFWVhYAQENDA+vWrcNXX30lcDKSosuXL6N27dpQU1PD5cuXP7htnTp1yiiVdLHAkApbW1t88803CAwMFDoKSVzz5s1RpUoVrFixAjo6OpgyZQp2796NR48eCR2NJEhNTQ0pKSkwMzODmpoaZDIZivsVyjEwZYMFhlTI5XLExMTAwcFB6CgkcUZGRggPD4erqysAIDMzE3K5HI8fP4aJiYnA6Uhq7t+/DxsbG8hkMty/f/+D29ra2pZRKuligSEVfn5+aNiwIYYPHy50FJK4d//iLWJgYIDY2FgWbCKJ480cSYWjoyOmTp2Kc+fOFTu/Ae9CTWXpyJEjMDQ0VDwuKChAWFgYrl69qlj2+eefCxGNJGzjxo0fXO/j41NGSaSLR2BIhb29/XvXyWQy3L17twzTkJQVzbXxIRxvQEIwNjZWepybm4vMzExoaWlBT08PL168ECiZdPAIDKngRGBUXvz9En6i8qK4GZ9v376NESNGYOLEiQIkkh4egSEiIiohUVFR+Oqrr3Dz5k2ho1R4PAJDAIDx48dj9uzZqFSpEsaPH//BbX/++ecySkVSdu7cOTRp0uSjts3MzERCQgInuSPBaWho8DL/MsICQwCAS5cuITc3V/Hv9/n7fT+ISsvAgQPh4OAAf39/dOrUCZUqVVLZ5vr16/jtt9+wfv16/PjjjywwVGb27t2r9LiwsBDJyclYunQpmjVrJlAqaeEpJCIql3Jzc7FixQosW7YMd+/eRY0aNWBlZQUdHR28fPkSN2/eREZGBnr06IHvv/8ebm5uQkcmCfn7AHOZTAZTU1O0adMGCxcuhKWlpUDJpIMFhojKvaioKJw5cwb3799HVlYWqlSpAnd3d7Ru3RqVK1cWOh4RCYAFhlS0bt36g6eKjh8/XoZpiIiIVHEMDKmoV6+e0uPc3FzExMTg6tWrGDRokDChiIjKkfdd7CCTyaCjowNHR0d069aNRwhLEY/A0EebMWMGMjIy8NNPPwkdhYhIUK1bt8bFixeRn58PZ2dnAMCtW7egrq6OmjVrIi4uDjKZDGfOnFHcy4tKFgsMfbQ7d+6gUaNGnGGSiCQvODgYf/31F9avXw+5XA4ASEtLg7+/P5o3b46hQ4eif//+yMrKwpEjRwROWzGxwNBH27RpEwIDAznHARFJXtWqVREaGqpydOXatWto3749Hj58iIsXL6J9+/Z49uyZQCkrNo6BIRU9e/ZUelw0v0FUVBSmTp0qUCoiovIjLS0NT548USkwT58+RXp6OgDAyMgIOTk5QsSTBBYYUvHunX+Bt/MdODs7Y9asWWjfvr1AqUjqwsLCEBYWhidPnqjcI2ndunUCpSKp6tatG3x9fbFw4UI0bNgQAHDhwgVMmDAB3bt3BwBERkaiRo0aAqas2HgKiYjKvZkzZ2LWrFlo0KABLC0tVS7z3717t0DJSKoyMjIwbtw4bNy4EXl5eQDe3kZg0KBBWLRoESpVqoSYmBgAqld2UslggSGics/S0hJBQUEYOHCg0FGIlGRkZODu3bsAAAcHB+jr6wucSDpYYEiFsbFxsRPZvTu/weDBgzFkyBAB0pEUmZiYIDIyEtWrVxc6ChGVExwDQyqmTZuGuXPnomPHjmjUqBGAt+dyDx8+jJEjRyIhIQEjRoxAXl4ehg4dKnBakgJ/f39s2bKFg8ip3Hj9+jUWLFjw3nFZRUdlqPSwwJCKM2fOYM6cORg+fLjS8lWrVuHo0aP4448/UKdOHSxZsoQFhsrEmzdv8Ouvv+LYsWOoU6cONDU1ldb//PPPAiUjqfL398epU6cwcODAYsdlUenjKSRSoa+vj5iYGDg6Oiotv3PnDurVq4eMjAzEx8ejTp06eP36tUApSUpat2793nUymYz356IyZ2RkhAMHDqBZs2ZCR5EsHoEhFZUrV8a+ffswbtw4peX79u1T3Nfj9evXMDAwECIeSdCJEyeEjkCkxNjYmPc5EhgLDKmYOnUqRowYgRMnTijGwFy4cAEHDx7EypUrAQChoaH47LPPhIxJRCSY2bNnY9q0adiwYQP09PSEjiNJPIVExTp79iyWLl2KuLg4AICzszNGjRqFpk2bCpyMpKJnz54ICQmBXC5XmR3673bt2lVGqYjecnd3R3x8PAoLC2FnZ6cyLuvixYsCJZMOHoGhYjVr1ozndklQhoaGioGRf58dmkhoRbPtknB4BIaKVVBQgDt37hR7eWDLli0FSkVERPQWj8CQinPnzqF///64f/8+/t5vZTIZ8vPzBUpGRFR+pKamYufOnYiPj8fEiRNRuXJlXLx4Eebm5qhatarQ8So8HoEhFfXq1UONGjUwc+bMYuc34OF8Kmv29vYfnGeDk4ZRWbt8+TK8vLxgaGiIe/fuIS4uDg4ODpgyZQoSExOxceNGoSNWeDwCQypu376NnTt3qswDQySUsWPHKj3Ozc3FpUuXcPjwYUycOFGYUCRp48ePx+DBgxEUFKQ0pUSnTp3Qv39/AZNJBwsMqWjcuDHu3LnDAkPlxpgxY4pdvmzZMkRFRZVxGqK3U0usWrVKZXnVqlWRkpIiQCLpYYEhFaNGjcK3336LlJQUuLm5qVweWKdOHYGSESnr2LEjJk+ejPXr1wsdhSRGW1sb6enpKstv3boFU1NTARJJD8fAkAo1NTWVZTKZDIWFhRzES+VKUFAQli9fjnv37gkdhSTG398fz58/x/bt21G5cmVcvnwZ6urq6N69O1q2bIng4GChI1Z4LDCk4v79+x9cb2trW0ZJiN5yd3dXGsRbWFiIlJQUPH36FMuXL8ewYcMETEdSlJaWhi+++AJRUVF49eoVrKyskJKSAk9PTxw8eBCVKlUSOmKFxwJDROXezJkzlR6rqanB1NQUrVq1Qs2aNQVKRQScOXMGly9fRkZGBjw8PODl5SV0JMlggaFibdq0CStXrkRCQgIiIiJga2uL4OBg2Nvbo1u3bkLHIyIiiVMd7ECSt2LFCowfPx6dOnVCamqqYsyLkZERz+uSINLT04v9evXqFXJycoSORxIVFhaGLl26oHr16qhevTq6dOmCY8eOCR1LMlhgSMUvv/yC1atX44cffoC6urpieYMGDXDlyhUBk5FUGRkZwdjYWOXLyMgIurq6sLW1xfTp01Vue0FUWpYvX44OHTrAwMAAY8aMwZgxYyCXy9GpUycsW7ZM6HiSwMuoSUVCQgLc3d1Vlmtra+P169cCJCKpCwkJwQ8//IDBgwejUaNGAIDIyEhs2LABU6ZMwdOnT/HTTz9BW1sb33//vcBpSQrmzZuHRYsWISAgQLFs9OjRaNasGebNm4eRI0cKmE4aWGBIhb29PWJiYlSuNjp8+DBcXFwESkVStmHDBixcuBB9+vRRLOvatSvc3NywatUqhIWFwcbGBnPnzmWBoTKRmpqKDh06qCxv3749AgMDBUgkPTyFRCrGjx+PkSNHYtu2bSgsLERkZCTmzp2LyZMnY9KkSULHIwkKDw8v9qigu7s7IiIiAADNmzdHYmJiWUcjifr888+xe/duleV//vknunTpIkAi6eERGFLh7+8PXV1dTJkyBZmZmejfvz+srKywePFi9O3bV+h4JEHW1tZYu3YtFixYoLR87dq1sLa2BgA8f/4cxsbGQsQjCXJ1dcXcuXNx8uRJeHp6AgDOnTuHs2fP4ttvv8WSJUsU244ePVqomBUaL6MmFdnZ2cjLy0OlSpWQmZmJjIwMmJmZCR2LJGzv3r3o3bs3atasiYYNGwIAoqKicPPmTezcuRNdunTBihUrcPv2bfz8888CpyUpsLe3/6jtZDIZ75ZeSlhgSOHp06fw8fHBsWPHUFBQgIYNG2Lz5s2oXr260NGIkJCQgFWrVuHWrVsAAGdnZ3z99dews7MTNhgRCYIFhhR8fX1x6NAhjB49Gjo6Oli1ahUsLS1x4sQJoaMREREpYYEhBWtra6xZswbe3t4AgNu3b8PFxQWvX7+Gtra2wOlI6lJTUxEZGYknT56ozPfi4+MjUCoiEgoLDCmoq6vj4cOHsLCwUCyrVKkSrl27xsP0JKh9+/ZhwIAByMjIgFwuV7qxo0wmw4sXLwRMR0RC4GXUpOTdmXeLHrPjktC+/fZb+Pr6IiMjA6mpqXj58qXii+WFSJp4BIYU1NTUYGhoqPTXbWpqKuRyOdTU/q/r8hcGlbVKlSrhypUrcHBwEDoKEZUTnAeGFNavXy90BKJieXt7IyoqigWGypXU1FSsXbsWN27cAADUqlULvr6+MDQ0FDiZNPAIDBGVe2vXrsWsWbMwZMgQuLm5QVNTU2n9559/LlAykqqoqCh4e3tDV1dXcX+uCxcuICsrC0ePHoWHh4fACSs+FhgiKvfePYX5dzKZDPn5+WWYhgho0aIFHB0dsXr1amhovD2ZkZeXB39/f9y9exenT58WOGHFxwJDRET0iXR1dXHp0iXUrFlTafn169fRoEEDZGZmCpRMOngVEhGJyps3b4SOQAS5XF7szUOTkpJgYGAgQCLpYYEhonIvPz8fs2fPRtWqVaGvr6+4t8zUqVOxdu1agdORFH355Zfw8/PDtm3bkJSUhKSkJGzduhX+/v7o16+f0PEkgQWG3isnJwdxcXHIy8sTOgpJ3Ny5cxESEoKgoCBoaWkplteuXRtr1qwRMBlJ1U8//YSePXvCx8cHdnZ2sLOzw+DBg/HFF1/gxx9/FDqeJHAMDKnIzMzEqFGjsGHDBgDArVu34ODggFGjRqFq1ar47rvvBE5IUuPo6IhVq1ahbdu2MDAwQGxsLBwcHHDz5k14enri5cuXQkckicrMzER8fDwAoHr16tDT0xM4kXTwCAypmDx5MmJjY3Hy5Eno6Ogolnt5eWHbtm0CJiOpevjwIRwdHVWWFxQUIDc3V4BERG/p6enB2NgYxsbGLC9ljAWGVOzZswdLly5F8+bNlWblrVWrluIvDaKy5Orqir/++ktl+c6dO+Hu7i5AIpK6goICzJo1C4aGhrC1tYWtrS2MjIwwe/ZslZuNUungTLyk4unTpzAzM1NZ/vr1a6VCQ1RWpk2bhkGDBuHhw4coKCjArl27EBcXh40bN2L//v1CxyMJ+uGHH7B27VosWLAAzZo1AwCcOXMGM2bMwJs3bzB37lyBE1Z8HANDKlq2bInevXtj1KhRMDAwwOXLl2Fvb49Ro0bh9u3bOHz4sNARSYL++usvzJo1C7GxscjIyICHhwemTZuG9u3bCx2NJMjKygorV65UmQX6zz//xDfffIOHDx8KlEw6eASGVMybNw8dO3bE9evXkZeXh8WLF+P69esIDw/HqVOnhI5HEtWiRQuEhoYKHYMIwNub2v59EjsAqFmzJm94W0Y4BoZUNG/eHDExMcjLy4ObmxuOHj0KMzMzREREoH79+kLHIwmLiorCpk2bsGnTJkRHRwsdhySsbt26WLp0qcrypUuXom7dugIkkh6eQiKicu/Bgwfo168fzp49CyMjIwBv7wTctGlTbN26FdWqVRM2IEnOqVOn0LlzZ9jY2MDT0xMAEBERgaSkJBw8eBAtWrQQOGHFxyMwBABIT09X+veHvojKmr+/P3Jzc3Hjxg28ePECL168wI0bN1BQUAB/f3+h45EEffbZZ7h16xZ69OiB1NRUpKamomfPnoiLi2N5KSM8AkMAAHV1dSQnJ8PMzAxqamrFXm1UWFjIO/+SIHR1dREeHq5yyXR0dDRatGjBG+dRmUtMTIS1tXWxPysTExNhY2MjQCpp4SBeAgAcP34clStXBgCcOHFC4DREyqytrYudsC4/Px9WVlYCJCKps7e3V/zR967nz5/D3t6ef+iVARYYAvD2cGhx/yYqD/73v/9h1KhRWLZsGRo0aADg7YDeMWPG4KeffhI4HUlR0RHpv8vIyFCawZxKD08hEQDg8uXLH71tnTp1SjEJkSpjY2NkZmYiLy8PGhpv/+4q+nelSpWUtuUlrFSaxo8fDwBYvHgxhg4dqnT7gPz8fJw/fx7q6uo4e/asUBElg0dgCABQr149yGQy/FOf5RgYEkJwcLDQEYgAAJcuXQLw9gjMlStXlO6OrqWlhbp162LChAlCxZMUHoEhAMD9+/c/eltbW9tSTEJEVP4NGTIEixcvhlwuFzqKZLHAEBERkehwHhgq1qZNm9CsWTNYWVkpjs4EBwfjzz//FDgZEZHwXr9+jalTp6Jp06ZwdHSEg4OD0heVPo6BIRUrVqzAtGnTMHbsWMydO1cx5sXIyAjBwcHo1q2bwAmJiITl7++PU6dOYeDAgbC0tCz2iiQqXTyFRCpcXV0xb948dO/eHQYGBoiNjYWDgwOuXr2KVq1a4dmzZ0JHJCISlJGREQ4cOIBmzZoJHUWyeAqJVCQkJKjMeAoA2traeP36tQCJiP5PUlISkpKShI5BEmdsbKyY/JOEwQJDKuzt7RETE6Oy/PDhw3BxcSn7QCR5eXl5mDp1KgwNDWFnZwc7OzsYGhpiypQpxc7QS1TaZs+ejWnTpvE2FgLiGBhSMX78eIwcORJv3rxBYWEhIiMj8fvvv2P+/PlYs2aN0PFIgkaNGoVdu3YhKChI6c6/M2bMwPPnz7FixQqBE5LULFy4EPHx8TA3N4ednR00NTWV1l+8eFGgZNLBMTBUrM2bN2PGjBmIj48HAFhZWWHmzJnw8/MTOBlJkaGhIbZu3YqOHTsqLT948CD69euHtLQ0gZKRVM2cOfOD66dPn15GSaSLBYY+KDMzExkZGSo3LCMqS2ZmZjh16pTKKcwbN26gZcuWePr0qUDJiEgoHANDH6Snp8fyQoILCAjA7NmzkZ2drViWnZ2NuXPnIiAgQMBkJGWpqalYs2YNJk+erLgH18WLF/Hw4UOBk0kDj8AQAMDd3f2j5zHguV0qaz169EBYWBi0tbVRt25dAEBsbCxycnLQtm1bpW137dolRESSmMuXL8PLywuGhoa4d+8e4uLi4ODggClTpiAxMREbN24UOmKFx0G8BADo3r274t9v3rzB8uXL4erqqhgwee7cOVy7dg3ffPONQAlJyoyMjNCrVy+lZdbW1gKlIXp7scPgwYMRFBQEAwMDxfJOnTqhf//+AiaTDh6BIRX+/v6wtLTE7NmzlZZPnz4dSUlJWLdunUDJiIjKB0NDQ1y8eBHVq1dXmvDz/v37cHZ2xps3b4SOWOFxDAyp2LFjB3x8fFSWf/XVV/jjjz8ESEREVL5oa2sjPT1dZfmtW7dgamoqQCLp4SkkUqGrq4uzZ8/CyclJafnZs2eho6MjUCqSup07d2L79u1ITExETk6O0jqOy6Ky9vnnn2PWrFnYvn07AEAmkyExMRGBgYEqpzupdPAIDKkYO3YsRowYgdGjR+O3337Db7/9hlGjRmHkyJEYN26c0PFIgpYsWYIhQ4bA3Nwcly5dQqNGjWBiYoK7d++qzA1DVBYWLlyomGIiKysLn332GRwdHWFgYIC5c+cKHU8SOAaGirV9+3YsXrwYN27cAAC4uLhgzJgx6NOnj8DJSIpq1qyJ6dOno1+/fkrjDaZNm4YXL15g6dKlQkckiTpz5gwuX76MjIwMeHh4wMvLS+hIksECQ5/k6tWrqF27ttAxSGL09PRw48YN2NrawszMDKGhoahbty5u376NJk2a4Pnz50JHJKIyxjEw9I9evXqF33//HWvWrEF0dDTy8/OFjkQSY2FhgRcvXsDW1hY2NjY4d+4c6tati4SEBPBvMCpLWVlZCAsLQ5cuXQAAkydPVppgUV1dHbNnz+Z4wTLAAkPvdfr0aaxZswa7du2ClZUVevbsiWXLlgkdiySoTZs22Lt3L9zd3TFkyBCMGzcOO3fuRFRUFHr27Cl0PJKQDRs24MCBA4oCs3TpUtSqVQu6uroAgJs3b8LKyorjBcsATyGRkpSUFISEhGDt2rVIT09Hnz59sHLlSsTGxsLV1VXoeCRRBQUFKCgogIbG27+5tm7divDwcDg5OeHrr7+GlpaWwAlJKlq0aIFJkyaha9euAKA0JgsAfvvtNyxbtgwRERFCxpQEFhhS6Nq1K06fPo3OnTtjwIAB6NChA9TV1aGpqckCQ4LJy8vDvHnz4Ovri2rVqgkdhyTO0tISERERsLOzAwCYmpriwoULise3bt1Cw4YNeYf0MsDLqEnh0KFD8PPzw8yZM9G5c2eoq6sLHYkIGhoaCAoKQl5entBRiJCamqo05uXp06eK8gK8PVr47noqPSwwpHDmzBm8evUK9evXR+PGjbF06VI8e/ZM6FhEaNu2LU6dOiV0DCJUq1YNV69efe/6y5cv80hhGeEpJFLx+vVrbNu2DevWrUNkZCTy8/Px888/w9fXV+mmZURlZeXKlZg5cyYGDBiA+vXro1KlSkrrP//8c4GSkdSMGTMGx44dQ3R0tMqVRllZWWjQoAG8vLywePFigRJKBwsMfVBcXBzWrl2LTZs2ITU1Fe3atcPevXuFjkUSo6b2/oPFMpmMl/ZTmXn8+DHq1asHLS0tBAQEoEaNGgDe/qxcunQp8vLycOnSJZibmwuctOJjgaGPkp+fj3379mHdunUsMEQkaQkJCRgxYgRCQ0MV8xDJZDK0a9cOy5cvV1yRRKWLBYaIyr2NGzfiyy+/hLa2ttLynJwcbN26tdi7pxOVthcvXuDOnTsAAEdHR1SuXFngRNLCAkNE5Z66ujqSk5NhZmamtPz58+cwMzPjKSQiCeJVSERU7hUWFkImk6ksf/DgAQwNDQVIRERC460EiKjccnd3h0wmg0wmQ9u2bRUz8QJvx2UlJCSgQ4cOAiYkIqGwwBBRudW9e3cAQExMDLy9vaGvr69Yp6WlBTs7O/Tq1UugdEQkJI6BIaJyb8OGDejbt6/KIF4iki4WGCIq95KSkiCTyRQznEZGRmLLli1wdXXFsGHDBE5HRELgIF4iKvf69++PEydOAHh7x3QvLy9ERkbihx9+wKxZswROR0RCYIEhonLv6tWraNSoEQBg+/btcHNzQ3h4ODZv3oyQkBBhwxGRIFhgiKjcy83NVYx/OXbsmOLeRzVr1kRycrKQ0YhIICwwRFTu1apVCytXrsRff/2F0NBQxaXTjx49gomJicDpiEgILDBEVO79+OOPWLVqFVq1aoV+/fqhbt26AIC9e/cqTi0RkbTwKiQiEoX8/Hykp6fD2NhYsezevXvQ09NTucUAEVV8LDBEREQkOjyFRETl3uPHjzFw4EBYWVlBQ0MD6urqSl9EJD28lQARlXuDBw9GYmIipk6dCktLy2Jv7EhE0sJTSERU7hkYGOCvv/5CvXr1hI5CROUETyERUblnbW0N/q1FRO9igSGici84OBjfffcd7t27J3QUIioneAqJiMo9Y2NjZGZmIi8vD3p6etDU1FRa/+LFC4GSEZFQOIiXiMq94OBgoSMQUTnDIzBEREQkOjwCQ0TlUnp6OuRyueLfH1K0HRFJB4/AEFG5pK6ujuTkZJiZmUFNTa3YuV8KCwshk8mQn58vQEIiEhKPwBBRuXT8+HFUrlwZAHDixAmB0xBRecMjMERERCQ6PAJDRKKQmpqKyMhIPHnyBAUFBUrrfHx8BEpFRELhERgiKvf27duHAQMGICMjA3K5XGk8jEwm4zwwRBLEAkNE5V6NGjXQqVMnzJs3D3p6ekLHIaJygAWGiMq9SpUq4cqVK3BwcBA6ChGVE7wXEhGVe97e3oiKihI6BhGVIxzES0Tl0t69exX/7ty5MyZOnIjr16/Dzc1N5V5In3/+eVnHIyKB8RQSEZVLamofd4CYE9kRSRMLDBEREYkOx8AQERGR6LDAEFG5dfz4cbi6uhZ7M8e0tDTUqlULp0+fFiAZEQmNBYaIyq3g4GAMHTq02LtNGxoa4uuvv8aiRYsESEZEQmOBIaJyKzY2Fh06dHjv+vbt2yM6OroMExFRecECQ0Tl1uPHj1UumX6XhoYGnj59WoaJiKi8YIEhonKratWquHr16nvXX758GZaWlmWYiIjKCxYYIiq3OnXqhKlTp+LNmzcq67KysjB9+nR06dJFgGREJDTOA0NE5dbjx4/h4eEBdXV1BAQEwNnZGQBw8+ZNLFu2DPn5+bh48SLMzc0FTkpEZY0FhojKtfv372PEiBE4cuQIin5cyWQyeHt7Y9myZbC3txc4IREJgQWGiETh5cuXuHPnDgoLC+Hk5ARjY2OhIxGRgFhgiIiISHQ4iJeIiIhEhwWGiIiIRIcFhoiIiESHBYaIiIhEhwWGiCqcwYMHo3v37kLHIKJSxKuQiKjCSUtLQ2FhIYyMjISOQkSlhAWGiIiIRIenkIioVOzcuRNubm7Q1dWFiYkJvLy88Pr1a8XpnZkzZ8LU1BRyuRzDhw9HTk6O4rkFBQWYP38+7O3toauri7p162Lnzp1K+7927Rq6dOkCuVwOAwMDtGjRAvHx8QBUTyH90/5evnyJAQMGwNTUFLq6unBycsL69etL9xtERP+JhtABiKjiSU5ORr9+/RAUFIQePXrg1atX+OuvvxS3AggLC4OOjg5OnjyJe/fuYciQITAxMcHcuXMBAPPnz8dvv/2GlStXwsnJCadPn8ZXX30FU1NTfPbZZ3j48CFatmyJVq1a4fjx45DL5Th79izy8vKKzfNP+5s6dSquX7+OQ4cOoUqVKrhz5w6ysrLK7PtFRJ+Op5CIqMRdvHgR9evXx71792Bra6u0bvDgwdi3bx+SkpKgp6cHAFi5ciUmTpyItLQ05ObmonLlyjh27Bg8PT0Vz/P390dmZia2bNmC77//Hlu3bkVcXBw0NTVVXn/w4MFITU3Fnj17kJ2d/Y/7+/zzz1GlShWsW7eulL4jRFTSeASGiEpc3bp10bZtW7i5ucHb2xvt27fHF198obh/Ud26dRXlBQA8PT2RkZGBpKQkZGRkIDMzE+3atVPaZ05ODtzd3QEAMTExaNGiRbHl5e/u3Lnzj/sbMWIEevXqhYsXL6J9+/bo3r07mjZt+p++B0RUulhgiKjEqaurIzQ0FOHh4Th69Ch++eUX/PDDDzh//vw/PjcjIwMAcODAAVStWlVpnba2NgBAV1f3o7N8zP46duyI+/fv4+DBgwgNDUXbtm0xcuRI/PTTTx/9OkRUtlhgiKhUyGQyNGvWDM2aNcO0adNga2uL3bt3AwBiY2ORlZWlKCLnzp2Dvr4+rK2tUblyZWhrayMxMRGfffZZsfuuU6cONmzYgNzc3H88CuPq6vqP+wMAU1NTDBo0CIMGDUKLFi0wceJEFhiicowFhohK3Pnz5xEWFob27dvDzMwM58+fx9OnT+Hi4oLLly8jJycHfn5+mDJlCu7du4fp06cjICAAampqMDAwwIQJ/6+d+1VRLQgAMP6BIFiOgphNImIRBYv/gsk30OQLWIQ1HIMIBpMg+BLazQZB8CnEV9B2itx22YULd1l272Xg+/UZhkkfM8y8MZ1Oeb1etNttHo8Hl8uFKIoYj8dMJhN2ux3D4ZA4jslms1yvV5rNJuVy+cNaPjPfYrGg0WhQrVZJkoTj8UilUvlPuyfpMwwYSd8uiiLO5zPb7Zbn80mxWGSz2TAYDDgcDvT7fUqlEt1ulyRJGI1GLJfL3+NXqxWFQoH1es3tdiOXy1Gv15nP5wDk83lOpxOz2Yxer0cqlaJWq9Fqtf64nr/Nl06nieOY+/1OJpOh0+mw3+9/fJ8kfZ2vkCT9U+9fCEnSV/mRnSRJCo4BI0mSguMVkiRJCo4nMJIkKTgGjCRJCo4BI0mSgmPASJKk4BgwkiQpOAaMJEkKjgEjSZKCY8BIkqTg/ALCmM69OcjNSgAAAABJRU5ErkJggg==",
-            "text/plain": [
-              "<Figure size 640x480 with 1 Axes>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "means = df.groupby(\"species\").mean(numeric_only=True)\n",
-        "means.plot.bar()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Integration with open source visualizations\n",
-        "\n",
-        "BigQuery Dataframes is also compatible with several open source visualization packages, such as `matplotlib`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 79,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "Query job 61a0ba75-d130-445a-b412-e0b4bc0af31e is DONE. 12.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:61a0ba75-d130-445a-b412-e0b4bc0af31e&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job fc75ea4f-4296-4c93-9f58-55acb67946c9 is DONE. 12.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:fc75ea4f-4296-4c93-9f58-55acb67946c9&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job d4a76bed-2722-488d-8a8a-a4301bb589fd is DONE. 12.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:d4a76bed-2722-488d-8a8a-a4301bb589fd&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job 9c8f68a5-c141-4f3d-b1e8-ca6b5964ec96 is DONE. 12.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:9c8f68a5-c141-4f3d-b1e8-ca6b5964ec96&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job ae0a5e44-e566-453f-bd97-3c5c8532e79f is DONE. 12.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:ae0a5e44-e566-453f-bd97-3c5c8532e79f&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "image/png": "iVBORw0KGgoAAAANSUhEUgAAAyUAAAGFCAYAAADjF1xYAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMywgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy/H5lhTAAAACXBIWXMAAA9hAAAPYQGoP6dpAABqp0lEQVR4nO3dd1hTZ/8G8DsJe++hoogg4gBxj9aFCq5WX1utWqvVumfd/mytVm21jlbraGutWut+bau11l19FScquBARwQkiU3Ygye8PampkCDKehNyf6+LS5Jw85z4hQL55xpGoVCoViIiIiIiIBJGKDkBERERERPqNRQkREREREQnFooSIiIiIiIRiUUJEREREREKxKCEiIiIiIqFYlBARERERkVAsSoiIiIiISCgWJUREREREJBSLEiIiIiIiEopFCRERERERCcWihIiIiIiIhGJRQkREREREQrEoISIiIiIioViUEBERERGRUCxKiIiIiIhIKBYlREREREQkFIsSIiIiIiISikUJEREREREJxaKEiIiIiIiEYlFCRERERERCsSghIiIiIiKhWJQQEREREZFQLEqIiIiIiEgoFiVERERERCQUixIiIiIiIhKKRQkREREREQnFooSIiIiIiIRiUUJERELNmzcPjRs3LvH+MTExkEgkCA0NBQCcOHECEokEKSkpFZJP23To0AGTJ08uczuJiYlwcnJCTExMmdvSJRKJBL///juAgq+lyvA6x3z5e+7u7o5vvvmmXHO1atUKe/bsKdc2iUqDRQkREZWrs2fPQiaToUePHpVyvDZt2iA2NhbW1tav3camTZsgkUggkUgglUpRo0YNfPjhh4iPjy/HpOXj119/xYIFC8rczqJFi/D222/D3d0dwL9vlp9/2dvbo2vXrrhy5UqZj6Wt3NzcEBsbi4YNG4qOUioXL17EyJEjy7XNTz75BLNmzYJSqSzXdolKikUJERGVqw0bNmDChAn43//+h8ePH1f48YyMjODi4gKJRFKmdqysrBAbG4uHDx9i/fr1+OuvvzB48OBySll+7OzsYGlpWaY2MjMzsWHDBgwfPrzAtqNHjyI2NhaHDh1Ceno6unXrVmV7oWQyGVxcXGBgYCA6Sqk4OjrCzMysXNvs1q0b0tLS8Ndff5Vru0QlxaKEiIjKTXp6Onbu3IkxY8agR48e2LRpU4F9Fi9eDGdnZ1haWmL48OHIzs4usM+PP/4IHx8fmJiYoF69eli7dm2Rxyxs+Nbp06fx5ptvwtTUFG5ubpg4cSIyMjKKzS6RSODi4oJq1aqhW7dumDhxIo4ePYqsrKxXZnrey/Drr7+iY8eOMDMzg5+fH86ePatxjPXr18PNzQ1mZmbo06cPVqxYARsbG/X2oUOHonfv3hqPmTx5Mjp06KC+XdhQni+++ALDhg2DpaUlatasiR9++KHYcz1w4ACMjY3RqlWrAtvs7e3h4uKCZs2aYdmyZXjy5AnOnz+Pzz//vNAehcaNG+PTTz8FAOTl5WHixImwsbGBvb09Zs6ciSFDhmicU05ODiZOnAgnJyeYmJjgjTfewMWLF9Xbk5OTMWjQIDg6OsLU1BReXl7YuHGjevvDhw8xYMAA2NnZwdzcHM2aNcP58+fV2/fu3YsmTZrAxMQEHh4emD9/PvLy8gp9Hl4eSvWqY7/s4MGDeOONN9Tn27NnT0RFRWnsc+HCBfj7+8PExATNmjUrtOfp+vXr6NatGywsLODs7IzBgwcjISGhyOO+PHxrxYoVaNSoEczNzeHm5oaxY8ciPT1d4zGv+pmQyWTo3r07duzYUeRxiSoSixIiIio3u3btQr169eDt7Y33338fP/30E1Qqlcb2efPm4YsvvkBISAhcXV0LFBxbt27F3LlzsWjRIoSHh+OLL77Ap59+is2bN5coQ1RUFIKCgtC3b19cvXoVO3fuxOnTpzF+/PhSnYupqSmUSiXy8vJKnGnOnDmYNm0aQkNDUbduXQwYMED9hjg4OBijR4/GpEmTEBoaii5dumDRokWlylSU5cuXq9/wjh07FmPGjEFERESR+586dQpNmzZ9ZbumpqYAALlcjmHDhiE8PFyjgLhy5QquXr2KDz/8EACwZMkSbN26FRs3bkRwcDCePXumnr/x3IwZM7Bnzx5s3rwZly9fhqenJwIDA5GUlAQA+PTTT3Hz5k389ddfCA8Px7p16+Dg4AAgv+ht3749Hj16hH379iEsLAwzZsxQDzk6deoUPvjgA0yaNAk3b97E999/j02bNpX4eS7u2IXJyMjAlClTEBISgmPHjkEqlaJPnz7qPOnp6ejZsyfq16+PS5cuYd68eZg2bZpGGykpKejUqRP8/f0REhKCgwcP4smTJ+jXr1+JMgOAVCrFqlWrcOPGDWzevBnHjx/HjBkz1NtL+jPRokULnDp1qsTHJSpXKiIionLSpk0b1TfffKNSqVSq3NxclYODg+rvv/9Wb2/durVq7NixGo9p2bKlys/PT327Tp06qm3btmnss2DBAlXr1q1VKpVKFR0drQKgunLlikqlUqn+/vtvFQBVcnKySqVSqYYPH64aOXKkxuNPnTqlkkqlqqysrEJzb9y4UWVtba2+ffv2bVXdunVVzZo1K1WmH3/8Ub39xo0bKgCq8PBwlUqlUvXv31/Vo0cPjTYGDRqkcdwhQ4ao3n77bY19Jk2apGrfvr36dvv27VWTJk1S365Vq5bq/fffV99WKpUqJycn1bp16wo9V5VKpXr77bdVw4YN07jv5ec1OTlZ1adPH5WFhYUqLi5OpVKpVN26dVONGTNG/ZgJEyaoOnTooL7t7OysWrp0qfp2Xl6eqmbNmupzSk9PVxkaGqq2bt2q3kcul6uqVaum+uqrr1QqlUrVq1cv1Ycfflho7u+//15laWmpSkxMLHR7QECA6osvvtC4b8uWLSpXV1f1bQCq3377rdBzLu7YJfH06VMVANW1a9fUee3t7TVed+vWrdM45oIFC1Rdu3bVaOfBgwcqAKqIiAiVSlX49/zrr78uMsfu3btV9vb26tsl/ZnYu3evSiqVqhQKRanOm6g8sKeEiIjKRUREBC5cuIABAwYAAAwMDNC/f39s2LBBvU94eDhatmyp8bjWrVur/5+RkYGoqCgMHz4cFhYW6q+FCxcWGBZTlLCwMGzatEnj8YGBgVAqlYiOji7ycampqbCwsICZmRm8vb3h7OyMrVu3liqTr6+v+v+urq4AoJ4sHxERgRYtWmjs//Lt1/XicZ8PQytukn5WVhZMTEwK3damTRtYWFjA1tYWYWFh2LlzJ5ydnQEAI0aMwPbt25GdnQ25XI5t27Zh2LBhAPKfvydPnmick0wm0+iRiYqKQm5uLtq2bau+z9DQEC1atEB4eDgAYMyYMdixYwcaN26MGTNm4MyZM+p9Q0ND4e/vDzs7u0Kzh4WF4fPPP9f4Po0YMQKxsbHIzMws8vl4rrhjFyYyMhIDBgyAh4cHrKys1IsG3L9/H0D+693X11fjuX7x9f48899//62RuV69eurnqySOHj2KgIAAVK9eHZaWlhg8eDASExPV51zSn4nnvYM5OTklOi5RedKtmV1ERKS1NmzYgLy8PFSrVk19n0qlgrGxMVavXl2i1bGej4Nfv359geJFJpOVKEd6ejpGjRqFiRMnFthWs2bNIh9naWmJy5cvQyqVwtXVVT106cmTJyXOZGhoqP7/84n3pVnNSCqVagx3A4Dc3NxXPu7F4z4/dnHHdXBwQHJycqHbdu7cifr168Pe3l5jvgsA9OrVC8bGxvjtt99gZGSE3NxcvPPOO6/MVxrdunXDvXv3cODAARw5cgQBAQEYN24cli1bpv6eFCU9PR3z58/Hf/7znwLbiirCSnrswvTq1Qu1atXC+vXrUa1aNSiVSjRs2BByubxkJ/tP5l69emHJkiUFtj0vbIsTExODnj17YsyYMVi0aBHs7Oxw+vRpDB8+HHK5HGZmZiX+mUhKSoK5ufkrn2eiisCihIiIyiwvLw8///wzli9fjq5du2ps6927N7Zv347Ro0fDx8cH58+fxwcffKDefu7cOfX/nZ2dUa1aNdy9exeDBg16rSxNmjTBzZs34enpWarHSaXSQh9THpkAwNvbW2M+BoACtx0dHXH9+nWN+0JDQwsUHWXl7++PX375pdBtbm5uqFOnTqHbDAwMMGTIEGzcuBFGRkZ477331G9gra2t4ezsjIsXL6Jdu3YAAIVCgcuXL6uvQ1OnTh0YGRkhODgYtWrVApBfdF28eFFj8r6joyOGDBmCIUOG4M0338T06dOxbNky+Pr64scff0RSUlKhvSVNmjRBREREqb/3Lyrq2C9LTExEREQE1q9fjzfffBNA/mTyF/n4+GDLli3Izs5WF0Uvvt6fZ96zZw/c3d1faxWwS5cuQalUYvny5ZBK8wfA7Nq1q8AxSvIzcf36dfj7+5c6A1F5YFFCRERltn//fiQnJ2P48OEFekT69u2LDRs2qCd5Dx06FM2aNUPbtm2xdetW3LhxAx4eHur958+fj4kTJ8La2hpBQUHIyclBSEgIkpOTMWXKlFdmmTlzJlq1aoXx48fjo48+grm5OW7evIkjR45g9erVr3V+Zc0EABMmTEC7du2wYsUK9OrVC8ePH8dff/2lsZRxp06dsHTpUvz8889o3bo1fvnllwp5oxgYGIjZs2cjOTkZtra2pXrsRx99BB8fHwD5k/dfNGHCBHz55Zfw9PREvXr18O233yI5OVl9jubm5hgzZgymT58OOzs71KxZE1999RUyMzPVyxPPnTsXTZs2RYMGDZCTk4P9+/erjzdgwAB88cUX6N27N7788ku4urriypUrqFatGlq3bo25c+eiZ8+eqFmzJt555x1IpVKEhYXh+vXrWLhw4SvPrbhjv8zW1hb29vb44Ycf4Orqivv372PWrFka+wwcOBBz5szBiBEjMHv2bMTExBQocMaNG4f169djwIABmDFjBuzs7HDnzh3s2LEDP/744yt7CD09PZGbm4tvv/0WvXr1QnBwML777juNfUr6M3Hq1KkCHyoQVRbOKSEiojLbsGEDOnfuXOgQrb59+yIkJARXr15F//798emnn2LGjBlo2rQp7t27hzFjxmjs/9FHH+HHH3/Exo0b0ahRI7Rv3x6bNm1C7dq1S5TF19cXJ0+exO3bt/Hmm2/C398fc+fO1RhWVlplzQQAbdu2xXfffYcVK1bAz88PBw8exMcff6wxrCgwMFD9/DRv3hxpaWkavUrlpVGjRmjSpEmBT9RLwsvLC23atEG9evUKDGebOXMmBgwYgA8++ACtW7dWz1148RwXL16Mvn37YvDgwWjSpAnu3LmDQ4cOqYsjIyMjzJ49G76+vmjXrh1kMpl6mVojIyMcPnwYTk5O6N69Oxo1aoTFixer37gHBgZi//79OHz4MJo3b45WrVrh66+/VvfKvEpxx36ZVCrFjh07cOnSJTRs2BAff/wxli5dqrGPhYUF/vjjD1y7dg3+/v6YM2dOgWFa1apVQ3BwMBQKBbp27YpGjRph8uTJsLGxUfd8FMfPzw8rVqzAkiVL0LBhQ2zduhVffvmlxj4l+Zl49OgRzpw5o15JjaiySVQvD14lIiKiSjFixAjcunVLyDKsf/75J6ZPn47r16+X6M3vcyqVCl5eXhg7duwre4mUSiV8fHzQr1+/crkKPVWcmTNnIjk5+ZXXuCGqKBy+RUREVEmWLVuGLl26wNzcHH/99Rc2b95c7IUhK1KPHj0QGRmJR48ewc3NrUSPefr0KXbs2IG4uLhCP1G/d+8eDh8+jPbt2yMnJwerV69GdHQ0Bg4cWN7xqZw5OTmVeCgiUUVgTwkREVEl6devH06cOIG0tDR4eHhgwoQJGD16tOhYJSaRSODg4ICVK1cWWmg8ePAA7733Hq5fvw6VSoWGDRti8eLF6onvRERFYVFCRERERERCcaI7EREREREJxaKEiIiIiIiEYlFCRERERERCcfUtIiItlp2rQFKGHEkZciRn/vNvhhxJmblIzZQjT6mCVCKBVAJIpZJ//y+RQPLC/6WS/EnKRgZS2JsbwdHSGE6WJnC0NIaDhREMZPyMioiIxGFRQkQkSHauAnfi0xEZn4bIJ+l4lJKlLj6SM3KRlCFHVq6iwnNIJYCtWX6h8mKx4vTP7Wo2pvBytoCViWGFZyEiIv3E1beIiCpYljy/+Lj9JA2R8emI/Offh8mZUOrQb2BXaxN4OVuirpMF6rpYwtvZEt4uljAxlImORkREOo5FCRFROUrLzsWF6CRcjEnG7SdpuP0kDY9SslBVf9MaSCXwdLJAo+rWaFTDGg2rW6O+qxULFSIiKhUWJUREZZAlVyDkXhLORCXiTFQirj9KhUKXuj8qgIFUgobVrdGuriPa13VAYzdbyKQS0bGIiEiLsSghIioFeZ4Sl+8n42xUIs5GJSL0QQrkCqXoWFrNysQAbT0d0K6uI9rVdUR1G1PRkYiISMuwKCEieoWIuDQcDX+CM1EJuHQvGdm5LELKwsPRHO28HNG+riNaedjD1IhDvYiI9B2LEiKiQjxIysS+sMfYF/oYEU/SRMepsowMpGjubouO3k54q3E1OFmaiI5EREQCsCghIvpHQnoO/rwai72hj3D5foroOHpHJpWgnZcD3mnqhs71nWBswB4UIiJ9waKEiPRaek4eDl6Pw97QRzgTlaj3k9S1hbWpIXr5uaJvkxrwr2krOg4REVUwFiVEpHfkeUocv/UEe0Mf4/iteOTkcY6INqvjaI6+TWvgP/414GLN4V1ERFURixIi0hspmXL8cu4eNp+9h6dpOaLjUClJJUBbTwe807QGAhu48FooRERVCIsSIqry7idmYsPpu9h96SEy5QrRcagc2JoZYkgbd3zYpjaszQxFxyEiojJiUUJEVdale8n48dRdHLoRB04VqZrMjWQY1KoWPnqjNpysOLSLiEhXsSghoipFqVTh8M04/PC/u1xBS48YGUjxTtMaGN2uDmram4mOQ0REpcSihIiqhCy5ArsvPcBPp6MRk5gpOg4JIpNK0NPXFWM7eMLbxVJ0HCIiKiEWJUSk03LyFNh8JgbrTkQhOTNXdBzSEhIJEFDPCWM7eqIJlxQmItJ6LEqISCcplSr8duURVhy5jUcpWaLjkBZr7WGPGUHevN4JEZEWY1FCRDrn74h4LPnrFm7FpYmOQjpCIgH+418DM7t5w8mSE+KJiLQNixIi0hm34p5hwf6bCL6TKDoK6ShLYwNMCPDEh21rw1AmFR2HiIj+waKEiLReSqYcyw/fxrYL96Hg2r5UDjwczTG3Z3108HYSHYWIiMCihIi0mEKpwi/n7uHro7eRwknsVAEC6jlhbq/6qGVvLjoKEZFeY1FCRFopJCYJc367jognnDdCFcvIQIrhb9TGhE6eMDMyEB2HiEgvsSghIq2Sk6fA8sO38eOpu7wKO1UqFysTzOpWD739q4uOQkSkd1iUEJHWuP4oFVN2heL2k3TRUUiPBdRzwpJ3fOFgYSw6ChGR3mBRQkTC5SmUWPN3FFb/HYlcBX8lkXgOFkb46h1fdKrnLDoKEZFeYFFCRELdiU/DlF1huPowVXQUogIGt6qFOT18YGIoEx2FiKhKY1FCREIolSpsOB2NZYcjkJOnFB2HqEieThZY+V5jNKhmLToKEVGVxaKEiCrdg6RMTN0dhgvRSaKjEJWIkUyKqV3rYsSbHpBKJaLjEBFVOSxKiKhSbb9wHwv330SGXCE6ClGptfawx4r+fnC1NhUdhYioSmFRQkSVQp6nxJzfrmH3pYeioxCVibWpIRb1aYievtVERyEiqjJYlBBRhXualoPRv1zCpXvJoqMQlZsBLdzw+dsNYSiTio5CRKTzWJQQUYW69jAVI7eEIDY1W3QUonLXysMO373fFDZmRqKjEBHpNBYlRFRh9oY+wsw9V5Gdy9W1qOqq7WCOn4Y2R20Hc9FRiIh0FosSIip3SqUKSw9HYN2JKNFRiCqFjZkh1g1qitZ17EVHISLSSSxKiKhcpWXnYvKOUBy7FS86ClGlMpRJsKh3I/Rr7iY6ChGRzmFRQkTlJiYhAx/9HII78emioxAJM6q9B2YF1YNEwuuZEBGVFIsSIioXpyMTMG7bZaRm5YqOQiRcYANnfNPfH6ZGMtFRiIh0AosSIiqzv67FYuKOK8hV8NcJ0XMNq1thw5DmcLYyER2FiEjrsSghojLZG/oIU3eFIU/JXyVEL3OxMsHGD5vDx9VKdBQiIq3GooSIXtueSw8x/b9hYD1CVDQ7cyNsG9ES9VxYmBARFYWXoSWi17Ljwn0WJEQlkJQhx6D153H7SZroKEREWotFCRGV2pazMZj92zUWJEQllJghx8D15xDJwoSIqFAcvkVEpbLhdDQW7L8pOgaRTnKwMMaOkS3h6WQpOgoRkVZhUUJEJbbuRBSWHLwlOgaRTnO0NMb2Ea3g6WQhOgoRkdZgUUJEJbLyaCS+PnpbdAyiKsHR0hg7RrZCHUcWJkREAIsSIiqB5Ycj8O3xO6JjEFUpTv8UJh4sTIiIONGdiIq3MTiaBQlRBYhPy8GA9ecQnZAhOgoRkXAsSoioSEduPuGkdqIK9ORZDgb8cA73EzNFRyEiEopFCREV6trDVEzacYXL/hJVsLhn2Ri68QJSMuWioxARCcOihIgKeJSShWGbLyJTrhAdhUgv3E3IwKgtlyDPU4qOQkQkBIsSItKQlp2LYRsv4mlajugoRHrlfHQSZv16VXQMIiIhWJQQkVqeQomxWy8jgledJhLi18uPsOpYpOgYRESVjkUJEanN+e06TkUmiI5BpNdWHLmNvaGPRMcgIqpULEqICACw5u872BnyQHQMIgIwc89VXH+UKjoGEVGlYVFCRNgX9hjLDkeIjkFE/8jOVWLkzyFISOfcLiLSD7yiO5GeC32Qgn7fn+WqP1VE6rndSDm5GZZN34Jd55Ea21QqFeJ3z0N29CU49pkDs7qtC21DpchDyqktyIoKQV5qHKTG5jCp5Qeb9kNhYGmfv09eLhIPrkJm5DnIzG1h13UsTN0b/5vj/B4onj2FXZfRFXau+qCFux22jmgJQxk/QySiqo2/5Yj0WFp2LiZuv8KCpIrIib2NtNCDMHR0L3R7WsheQPLqdlR5OZDHRcG6zXtwHbISjr3/D7lJj/D01wX/thV2EPK4O3B5fxks/IKQ8MdSPP+MKzclDulhh2DT7oPyOC29diEmCZ//wQuYElHVx6KESI99+vt13E/ilaSrAqU8Cwl/LIN90ARITSwKbJc/uYtnF36DQ7fJr2xLamwO5/cWwtznTRja14Bx9Xqw6zIa8rg7yHsWDwDITXwAU8+WMHKsBcsmPaDMTIUy6xkAIOnwWth2GAqpsVm5nqO+2nLuHnZevC86BhFRhWJRQqSnfr38EL+HPhYdg8pJ0pF1MK3TXGMI1XPK3Gwk/LEUdl3HQGZh+1rtK3MyAUggNc4veIycaiPn4U0oc3OQHX0ZMgs7SE2tkH7jb0gMjGBWt00ZzoZeNm/fTUQnZIiOQURUYViUEOmhe4kZmLv3hugYVE4ybp6EPC4Ktu2HFLo9+diPMK7uAzOvVq/VvipPjpQTG2FWv52698OiURcYOtXG4w1jkXp2FxzenglldjpST2+FXedRSP7fFjz6fgSe7PwUeWlcZrqssnIVmLwzFHkKDrUkoqqJRQmRnslVKDFx+xWk5+SJjkLlIO/ZUyQdWw+HXtMgMTAqsD0z8jyy74fBNmDEa7WvUuTh6d7FAAD7ruPU90tkBrDvOgY1Rm+A65CvYVKjAZKPb4Bl016QP7mLrMizcP3wWxhXq4fkoz+83smRhrAHKVjzd5ToGEREFYKrbxHpmcV/3cJ3J/nGpqrIvH0WT39bBEhe+IxJpQQgASQSWPp3R9rlPwGJRHO7RArjGvXhMnBxkW0/L0jyUuLgPOALyEytitw3+95VJJ/cCJf3lyH5758gkcpg23EY5E/v4cm2WXCbtL0czpYMpBL8OrYNfGvYiI5CRFSuDEQHIKLKE3wnAd//jwVJVWJSyw+uw1Zr3Jd4YCUM7WvAqmVfyEytYdE4SGN77E/jYdvpI5h6tiiyXXVBkvwYzgO+LLYgUeXJkXRkXX5vjVQGqJT5dREAKBVQqTjkqLzkKVWYvDMUBya+CRNDmeg4RETlhsO3iPREUoYcH+8MBftGqxapsRmMHN01viSGxpCaWMLI0R0yC9sC2wHAwMoRhjYu6nYerR+NzNtnAPxTkPz+JeRxd+DQaxqgVEKRngxFejJUitwCGVLO7ICpRzMYOdcBABhXr4/M22cgj49G2uX9MKnuU/FPhB65+zQDXx4IFx2DiKhcsaeESE9M3x2G+DReHZoKl5f08J8VtgBFeiKy7pwHAMRunKixn/OAL2BS01d9W/40Bpm3TsF16Lfq+8zqtUX2g2uI2zoThvbV4dBreiWcgX75+dw9BPg4o11dR9FRiIjKBeeUEOmBzWdi8Nk+rrZFVJU4Wxnj0OR2sDEruMABEZGu4fAtoiouNjULSw7eEh2DiMrZk2c5+OT366JjEBGVCxYlRFXcwj/DkSlXiI5BRBVg/9VY7A19JDoGEVGZsSghqsKC7yTgz6uxomMQUQWau/cGkjLkomMQEZUJixKiKipXocTcvRzaQVTVpWblYsWRCNExiIjKhEUJURX10+loRD3NEB2DiCrB9gsPEBGXJjoGEdFrY1FCVAXFpWZj1bFI0TGIqJIolCos2H9TdAwiotfGooSoClr4501kcHI7kV45fScBR28+ER2DiOi1sCghqmLO3EnAfk5uJ9JLiw6EI1ehFB2DiKjUWJQQVSG5CiUvkkikx6ITMrD5TIzoGEREpcaihKgK2Rgcjcj4dNExiEiglcciuUQwEekcFiVEVUT8s2ysOnZHdAwiEiwtOw/LD3OJYCLSLSxKiKqItSeikJ6TJzoGEWmBHRcf4FbcM9ExiIhKjEUJURXwNC0H2y/cFx2DiLQElwgmIl3DooSoClh/6i5y8rjiDhH9K/hOIv6OiBcdg4ioRFiUEOm4pAw5fjl3T3QMItJC605EiY5ARFQiLEqIdNyG03eRyQslElEhLkQn4fL9ZNExiIheiUUJkQ5LzcrFz2fYS0JERfv+JHtLiEj7sSgh0mGbgmOQxhW3iKgYR24+wd2nvH4REWk3FiVEOio9Jw8bz0SLjkFEWk6pAn74313RMYiIisWihEhHbTl7DymZuaJjEJEO+PXKI8SnZYuOQURUJBYlRDooS67AhtP85JOISkaep8RPp2NExyAiKhKLEiIdtO3CfSSky0XHICIdsvX8PaRzDhoRaSkWJUQ6Jk+hxI+n2EtCRKWTlp2Hbee5Wh8RaScWJUQ65titeMSmcmw4EZXeT6djIM9Tio5BRFQAixIiHbP9wn3REYhIR8U9y8bvoY9ExyAiKoBFCZEOeZicif/dfio6BhHpsK3n+cEGEWkfFiVEOmTnxQdQqkSnICJdFvYghRdTJCKtw6KESEcolCrsCnkgOgYRVQG/X+EQLiLSLixKiHREetRZDLO9BlOZQnQUItJxv4U+gkrFblci0h4sSoh0hPXldRj1ZB5uWH2MP7z+RFeHJNGRiEhHPUjKQsi9ZNExiIjUJCp+VEKk/bKSgWV1AYXmBRMzHXxxxLgLFj9qhNhsI0HhiEgXDWxZE1/0aSQ6BhERABYlRLrh4o/An1OL3KwyMMVDl074OetN/PjYDSqVpBLDEZEusjY1xIU5ATA2kImOQkTEooRIJ6wPAB6FlGjXPCs3XLQOwtL4ZricalnBwYhIl333fhMENXQVHYOIiEUJkdZLigZWNS71w1SQINWlNfZKOmHZg7pIyzMo/2xEpNMCGzjj+8HNRMcgIuJEdyKtF3HgtR4mgQo2cWcwJHYhrppPwCGv39HHOb6cwxGRLvv71lOkZMpfvSMRUQVjUUKk7SL+KnMTkpxUeD/Yha9TJ+NWtQX4zvM8PMyyyyEcEekyuUKJ/VdjRccgIuLwLSKtlpUCLK0DKPPKvWmVzAhPXDpgu7wd1j6qjVwlJ8cT6aNmtWzx3zFtRMcgIj3HooRIm137L7BneIUfRmHuglC7IHyd2BKnk6wr/HhEpD0kEiBkTmfYWxiLjkJEeozDt4i02WvOJyktWUYcmj7YhF8yx+BazRVY4nEV9ka5lXJsIhJLpQKCoxJFxyAiPceihEhbKXKBO0cr/bCW8SHo/3gxQkzG4rjnbgx0fVzpGYiocgVHJoiOQER6jsO3iLTV3ZPAz2+JTgEAkNvUQbBlEL6K9Ud4upnoOERUzqrbmCJ4VifRMYhIj7GnhEhblcOqW+XFKCUKHR+swQHFKITU/gGzat2GqUwhOhYRlZNHKVmITsgQHYOI9BiLEiJtdVt7ipLnJCoFHGJPYPSTebhh9TH+8PoTXRySRMcionJw+g6HcBGROBy+RaSNEiKB1bpzleUMBz8cMe6CJY8aIjbbSHQcInoNQQ1c8N3gpqJjEJGeMhAdgIgKcf+s6ASlYp4Qht4Iw9sGpnjoGYCfs97Aj4/doFLx2idEuuJMVAKUShWkUv7cElHl4/AtIm304LzoBK9FkpcFt4f7MSdxFiIdZ2Gb1wk0sU4XHYuISuBZdh6uPkoVHYOI9BSLEiJt9OCC6ARlZvDsAdo8+AF75KNxxX0N5tUOh6VB+V+ZnojKTzDnlRCRIJxTQqRtMpOArzwAVL0fTaWJDW47BmLds9bY+8RJdBwiekkrDzvsGNladAwi0kMsSoi0ze1DwLZ+olNUuGz7+vjbtAuWPPJDTJaJ6DhEBMDIQIqwuV1haiQTHYWI9AyHbxFpm/vnRCeoFCaJN9Ht4Ur8LR2Ns3U2YWLNuzCU8jMSIpHkeUpceZAsOgYR6SEWJUTapgrMJykNiUIO10eHMSX+E9yym4Y9XkfQ1paTbYlEuRWbJjoCEekhFiVE2kSRBzy+LDqFMLL0WDR9sBFbs8bgas2vsdjjGuyNckXHItIrEXEsSoio8vE6JUTaJO4qkJspOoVWsIq/iPdwEf1NLHC3Zlf8mNEG22OriY5FVOXdesKihIgqH3tKiLTJwxDRCbSORJ6OOg9/xZfJ03DbZS5+8gpGPQsWbkQVJfJJGrgGDhFVNvaUEGmTp7dEJ9BqRil30CnlDjpKDZBQ+03sVnbAtw89kKXgSkFE5SVTrsD9pEzUsjcXHYWI9Ah7Soi0ScJt0Ql0gkSZB8fYvzH2yWe4Yf0x9nkdQIB9kuhYRFXGLc4rIaJKxqKESJsk3hGdQOdIMxPg++AXbMgYjxs1luDrOpfhYiwXHYtIp3GyOxFVNg7fItIWOWlAWqzoFDrNPCEMfRCG3oameODWGT9nvYENj2tApZKIjkakU1iUEFFlY08JkbZIiBSdoMqQ5GWh5sM/8EniTEQ6zsY2rxNobJUuOhaRzrgV90x0BCLSMyxKiLQFh25VCINn99HmwQ/4LXc0rrivwWfu4TA3UIiORaTVYhIzkZ3LnxMiqjwsSoi0BSe5VyiJSgnbuGB8GLcA1ywm4KDXXrzlFC86FpFWUihVuBPP3kUiqjwsSoi0BYdvVRppdgrqPdiJVc8mI7z6IqzzvAB302zRsYi0CueVEFFl4kR3Im3B4VtCmCbeQDfcQJDMCHF1OmKbvB3WPqwFhYqf2ZB+e5icJToCEekR/tUl0gYqFZAYJTqFXpMo5HB9dAhTn87BbfsZ+K/XEbS2TRUdi0iYhPQc0RGISI+wKCHSBplJQB4/ldQWsvTHaPZgI7ZljcXVWt/gC49rsDXMEx2LqFIlZrAoIaLKw+FbRNogM0F0AiqEBCpYPbmAgbiAAaYWiHIPxI/pbbAj1lV0NKIKl5DGi5ASUeVhTwmRNshgUaLtJPJ0eD7Yg8XJU3HbZS5+8gpGXXP2blHVlcCeEiKqROwpIdIG7CnRKUYpd9Ap5Q46Sg2Q4NEOuxTtsepBHeQo+TkPVR0JaSxKiKjy8C8okTbIeCo6Ab0GiTIPjo+PY9yTzxBu8zH2ev2FAPsk0bGIysWz7DzI85SiYxCRnmBRQqQNMhJFJ6AykmY+hd+DLdiQMR433L7CijpX4GLMMfmk2zjZnYgqC4dvEWkDDt+qUsyfhuI/CEUfIzPcd+uMzVltsfFxDahUEtHRiEolMV0OV2tT0TGISA+wp4RIG3Cie5Ukyc1ErYf7MDdxJm47/h+2ep1EY6t00bGISuwpr1VCRJWEPSVE2oA9JVWe4bN7aPvse7SRSJHs3ga/STpixYO6yMiTiY5GVKTEdA5BJKLKwaKESBtwTonekKiUsIs7jeE4jQ8tbBHhGIg1Ka2x/6mj6GhEBfCq7kRUWTh8i0gbZKeKTkACSLOT4fNgB1anTUJ49UVY53kBNU2zRcciUkvKYE8JEVUO9pQQaQNlnugEJJhp4g10ww0EyYwRW6cjtsrb4buHNaFQ8bMjEic7VyE6AhHpCf61I9IGKv7hp3wSRQ6qPTqI6U//DxEOM7Hb6yha27InjcTIU6pERyAiPcGihEgbKFmUUEEGaY/Q/MFP2JY1FmG1VuKL2tdga8heNao8CgWLEiKqHBy+RaQN2FNCxZBABesn5zEQ5zHAzBJRTl3xQ1pb7IpzER2NqjiFikUJEVUO9pQQaQOlUnQC0hGSnDR4PtiDr1Km4LbrZ9jgdQZ1zbNEx6IqSsHhW0RUSdhTQqQN2FNCr8EoORIByZHoJDXAU4922JXXAd8+9ECOkp83UfngnBIiqiwsSoi0AeeUUBlIlHlwenwc43EcQx1r4v1aPlCArykqOyfn1gD8RccgIj3AooRIG6g4fIvKh0XqfThI6+J86m3RUagKqO/gKToCEekJ9vETaQMO36Jy1C1XdAKqKmQSmegIRKQnWJQQaQP2lFA56hx9CQZSdoRT2cmkLEqIqHKwKCHSBoZmohNQFWKdmYxWVhx2Q2XHnhIiqiwsSoi0gbGV6ARUxXTL5pBAKjuphG8TiKhy8LcNkTYwYVFC5atT9EUYSY1ExyAdZ2bAXlwiqhwsSoi0AXtKqJxZZD9DWw7hojKyMbERHYGI9ASLEiJtwJ4SqgDdsrJFRyAdZ2tsKzoCEekJFiVE2oA9JVQB2t+9CFOZiegYpMPYU0JElYVFCZE2YE8JVQAzeQbetKojOgbpMPaUEFFlYVFCpA3YU0IVpFt6uugIpMPYU0JElYVFCZE2MLEWnYCqqDfvXoQ5V1Ci18SeEiKqLCxKiLQBe0qoghjnZaODpYfoGKSDpBIprI35gQkRVQ4WJUTawNxBdAKqwro9SxUdgXSQlZEVL55IRJWGv22ItIGtu+gEVIW1ib4IS0ML0TFIx9gY24iOQER6hEUJkTZgUUIVyFAhR4BFbdExSMfYmnA+CRFVHhYlRNrA3AEw4ifZVHG6pSSKjkA6xsGUw0qJqPKwKCHSFja1RCegKqxFTAhsjThpmUqulhV/JxFR5WFRQqQtbPkGgCqOgTIPnc1rio5BOqS2NYf8EVHlYVFCpC04r4QqWLekeNERSIfUtmJRQkSVh0UJkbbg8C2qYE3vXYKjiZ3oGKQj2FNCRJWJRQmRtmBPCVUwqUqJLibVRccgHeBk6gQLLr5BRJWIRQmRtuCcEqoE3RIei45AOoC9JERU2ViUEGkLW3eAV0+mCub3IBQupo6iY5CWc7d2Fx2BiPQM3wERaQtDU8DOQ3QKquIkUCHQ2EV0DNJy7CkhosrGooRIm7j4ik5AeqBb/H3REUjLsSghosrGooRIm7iyKKGK1+DRNbiZsbeEiuZhzV5bIqpcLEqItAl7SqiSBBpyXgkVzszADM5mzqJjEJGeYVFCpE1c/UQnID0RFHdXdATSUo0cGkEikYiOQUR6hkUJkTYxdwBsaopOQXrAOy4ctc15zRIqqIlzE9ERiEgPsSgh0jbVm4lOQHoiSGYrOgJpIRYlRCQCixIibVOjuegEpCeCYm+LjkBaxkBiAF8Hzm0josrHooRI29RgTwlVDo/4O6hrweGC9K96dvVgZmgmOgYR6SEWJUTaxtUPkBmJTkF6IkhqKToCaREO3SIiUViUEGkbA2OgRgvRKUhPBD28KToCaREWJUQkCosSIm3kGSA6AekJt8R7aGDFq3cTIIEETZxYlBCRGCxKiLQRixKqREEqU9ERSAvUtq4NWxOuyEZEYrAoIdJGLr6AuZPoFKQngu5fhwS8WJ6+83fyFx2BiPQYixIibSSRAHU6iU5BesIl5SH8rDxExyDBmjo3FR2BiPQYixIibcUhXFSJghRc8U2fSSVStKnWRnQMItJjLEqItFWdTgCH1FAl6Xo/DFIJ/yToq8aOjWFvai86BhHpMf4FItJW5g751ywhqgSOz+LQ1KqO6BgkSJdaXURHICI9x6KESJtxCBdVoqBc/knQV51rdRYdgYj0HP8CEWkzT75RoMrTJeYyDCQGomNQJWtg3wAu5i6iYxCRnmNRQqTN3FoCFs6iU5CesM1IRAtrDuHSN+wlISJtwI/EiLSZVAY07AucWys6CemJoBwVzogO8YKMiAwkHEhA1r0s5KXkoeaEmrBqaqXenpeah7hdcUi/kQ5FpgLmdc3h+r4rjF2Mi2034VACkv5OQm5iLmSWMlg3s4bzO86QGuV/VpdyJgVx/42DMlsJ2zdt4TrAVf1Y+VM5YpbFoM68OpCZyirmxCtR55osSohIPPaUEGm7Ru+KTkB6JCD6IgylhqJjqClzlDCpaYJqg6sV2KZSqXBv1T3In8pRc2JNeM73hKGDIWKWxkCZoyyyzZSzKXiy+wmc3naC1xdeqD6sOlIvpOLJnicAgLy0PDza+Aiu/V3hPs0dKWdS8Cz0mfrxj7c8hvO7zlWiIKljXQfu1u6iYxARsSgh0nrVmwD2XqJTkJ6wykpFGytP0THULH0t4dzXWaN35Dn5EzmyorJQbUg1mHmYwdjVGNU+qAalXImUcylFtpl5JxNmXmawaW0DI0cjWDa0hHVLa2Tdzcpv96kcMlMZrFtaw8zDDOY+5sh5nAMASDmXAolMAutm1hVyvpWNQ7eISFuwKCHSBb79RCcgPRKYJRcdoURUuSoAgMTw3+v5SKQSSAwlyLydWeTjzDzNkBWThcy7+fvI4+VIv5oOC18LAICxszGUcmX+kLH0PGRFZ8HEzQSKDAXif42H6/uuRbata1iUEJG24JwSIl3Q6B3g70WiU5Ce6BQdAmM3F+QockRHKZaxqzEM7Q3xZPcTVB9aHRJjCRIPJSIvKQ95qXlFPs6mtQ0U6QpEL4qGCipAAdh1tINTLycAgMxchhojauDh+odQyVWwaWMDy0aWeLjhIewC7JCbkIv7K+9DpVDBqbcTrJvrZq9JDYsaqGdXT3QMIiIALEqIdIOdB1CjOfDwougkpAfMc9LwptUbOJp8Q3SUYkkMJKg5oSYebXiE8HHhgBSwqG+R3+OhKvpx6eHpePrHU7h+4AozDzPI4+WI3RqL+L3xcHo7vzCxamqlMWQs41YGch7moNr71XB75m24jXaDgbUBoj6Pgrm3OQysdO/PaW/P3qIjEBGp6d5vUSJ95dufRQlVmsD0TBwVHaIETN1N4bnAE4pMBVR5KhhY5RcKpu6mRT4m/rd42LSxgV17OwCAiZsJlDlKPNr0CI69HCGRSjT2V+Yq8fjnx6gxsgbk8XKoFCqY1zMHABi7GCMzKhNW/gXnvGgzA6kB+tbtKzoGEZEa55QQ6YoG/wGk/ByBKkf7mIswNSj6jb22kZnJYGBlgJy4HGRFZ8GyiWWR+ypzlAX/+hXz1/DpvqewaGQBU3dTqJQq4IWFvVR5mrd1RUe3jnAwdRAdg4hIjUUJka4wt+cV3qnSmMoz0cFS/IUUFdkKZN3LQta9f1bGSpAj614W5In5k/FTL6QiPTwd8ng5nl1+hpilMbBqYgXLhv8WJQ9/eIi43XHq25aNLZF0PAkp51IgfypH+vV0xP8aD8vGlgV6SbIfZSP1Qiqc/5N/EVNjV2NAAiSdTEJaaBpyYnNg6qE7xdtz/b37i45ARKSBH7sS6ZJmw4HbB0WnID0RmPYMfwnOkBWdhZglMerbcdvziwubtjaoMaIG8lLzELsjFopUBQxsDGDTxgaObztqtCFPlAMv1BpObzlBIpEg/td45CbnwsDSAJaN85cefpFKpcLjTY/hMsAFUuP8z/CkRlJU/6g6YrfEQpWrgutgVxjaas91XUrC3codLV1bio5BRKRBolKpipkOSERaRaUCVjcHEiNFJyk36y7KsS5EjpiU/DEwDZxkmNvOCN28/n2jd/ZBHuYcz8H5RwrIJEBjFxkOvW8GU0NJUc1izQU5lp7JQVy6Cn4uUnzbzRQtqv97sbsph7KxKVQOcyMJFgeYYJDvv8fbfSMXP1/NxR8DzCrgjHWHXGaMDnXqIC03XXQUKkfTm03HBw0+EB2DiEgDh28R6RKJBGg5SnSKclXDSoLFnY1xaaQ5Qkaao5O7DG/vyMKNeAWA/IIkaGsmutYxwIWPzHFxhDnGtzCCtOh6BDuv52LK4Wx81t4Yl0eZw89ZhsBfMhCfkV/4/BGRi23XcnF4sDm+6myCj/7IQkJm/rbUbBXmHM/Bmu4mFX7u2s5IkYOOFrVFx6ByZCIzwdueb4uOQURUAIsSIl3TeCBgYiM6Rbnp5W2I7l6G8LKXoa69DIsCTGBhBJx7mF+UfHwoBxNbGGHWG8Zo4CSDt4MM/RoYwtig6KpkxbkcjGhiiA/9jVDfUYbveprAzFCCn67kAgDCE5To4C5Ds2oyDGhkCCtjCaKT8zuNZxzJxphmhqhpzV+PABCYmiQ6ApWjru5dYW2sm9dVIaKqjX91iXSNkTnQdIjoFBVCoVRhx/VcZOQCrd1kiM9Q4vwjBZzMpWizIQPOy9LQflMGTt8v+sJ4coUKlx4r0dnj3ylzUokEnT0McPafQsfPWYaQxwokZ6lw6bECWbkqeNpJcfp+Hi7HKTCxpVGFn6uuaB0dAmsj3VrulorGCe5EpK1YlBDpohYjq9TywNeeKGDxxTMYL0zD6P1Z+K2/Keo7ynA3OX9I1byT+T0fBweZoYmLDAE/ZyIyUVFoWwmZKihUgLO5Zk+Ks7kEcen57QV6GuB9X0M0X5+OoXuzsLm3KcyNgDF/ZuO7HqZYF5IL79XpaPtThnoYmb4yVOais3kt0TGoHPjY+cDX0Vd0DCKiQrEoIdJF1jUAn16iU5QbbwcpQkdb4PxH5hjTzAhDfs/GzacKKP9ZhmNU0/yhWP6uMnwdZAJve6l6KNbrmtfBBHcmWuLaGAv08THEl6fk6FzbAIYyYOH/cnD6QzN85G+ID37PKocz1G1ByU9FR6ByMKDeANERiIiKxKKESFe1Gic6QbkxkkngaSdF02oyfNnZBH7OUqw8J4erRf6vqPqOmr+qfByluP+s8CvWOZhJIJMATzI0FxZ8kqGCi0Xhv/JuJSjwy7VcLOhkjBMxeWhXSwZHcyn6NTDE5Vgl0nL0e5HC5jGXYGdsKzoGlUF1i+roVafqfJBBRFUPixIiXeXWHKjeTHSKCqFUATkKwN1GgmqWEkQkaBYgtxOVqFXERHQjmQRNq0lx7O6/806UKhWO3c1D6xqyAvurVCqM2p+NFV2NYWEkgUIJ5P5zuOf/KvS7JoFMpUAXsxqiY1AZjPIdBYMqNOSTiKoeFiVEuqztJNEJymz20Wz8714eYlKUuPZEgdlHs3EiRoFBjQwhkUgwvY0RVl2Q4783c3EnSYlPj2fjVoISw/3/nYwe8HMGVl+Qq29PaWWM9ZdzsTlUjvCnCozZn42MXBU+bFzwInc/Xs6Fo5kEvbzzt7WtaYDj0Xk49zAPX5/NQX1HKWxMill/WE90S4h79U6klWpY1GAvCRFpPX5sQqTLfHoBro2B2FDRSV5bfIYKH/yWhdh0FayNJfB1luLQ+2boUif/19PkVsbIzgM+PpSNpCwV/JxlODLYDHXs/v1MJSpJqb7OCAD0b2iIp5kqzD2Rf/HExi5SHBxkBueXhm89SVdi0akcnBlurr6vRXUZprY2Ro9tWXAyl2Bzb9MKfgZ0Q5P7l+Hk44/47ATRUaiURvqOZC8JEWk9XtGdSNfdOQr80ld0CtIDS/x74JeUa6JjUCm4WbphX+99LEqISOtx+BaRrvPsDNR6Q3QK0gPdnj4UHYFKib0kRKQrWJQQVQUBc0UnID3g+zAM1c2cRcegEqppWRO9PDiXhIh0A4sSoqqgZkugbpDoFKQHuho5iY5AJTTSdyRk0oIrzhERaSMWJURVRadPAXCVKKpY3eKiRUegEqhlVQs9PXqKjkFEVGIsSoiqCpeGQENOeKeK5RN7E7XMq4mOQa8wyncUe0mISKewKCGqSjr+H8BJrVTBAg3sRUegYjR2bMxeEiLSOSxKiKoS+zpAkyGiU1AV1y32jugIVASZRIZPWn0CiYRDOYlIt7AoIapqAj4FzBxEp6AqzPNJBDwt3ETHoEL09+4Pbztv0TGIiEqNRQlRVWNqCwQuEp2CqrhAqbXoCPQSB1MHjPcfLzoGEdFrYVFCVBX5vQe4vyk6BVVh3R7dEh2BXjKl6RRYGlmKjkFE9FpYlBBVVT2/BmRGolNQFVUr4S58LGuJjkH/aOrcFL3q8EKJRKS7WJQQVVUOXkDbyaJTUBUWCAvREQiAgcQAc1rOER2DiKhMWJQQVWVvTgXsPESnoCoq6OEN0REIwECfgfCy9RIdg4ioTFiUEFVlhiZAj+WiU1AVVT3pPnytWPSK5GTqhLGNx4qOQURUZixKiKq6Op14pXeqMIFKE9ER9NqMFjNgbmguOgYRUZmxKCHSB4FfAqZ2olNQFRR4/yok4IX6ROhWuxsC3QNFxyAiKhcsSoj0gaUz8PYa0SmoCnJOfQx/6zqiY+gdZzNnfNLqE9ExiIjKDYsSIn1RrzvQ/CPRKagKCsozEB1Br0ggwaI3FsHKyEp0FCKicsOihEifdF0EOPqITkFVTNeYK5BJZKJj6I1BPoPQ0rWl6BhEROWKRQmRPjE0Ad75CTDg5GQqP/bpT9GMQ7gqRV3bupjcdLLoGERE5Y5FCZG+ca4PdF0oOgVVMUFy0QmqPlMDUyxtvxTGMmPRUYiIyh2LEiJ91GIE4N1ddAqqQrpEX4KBlHNLKtLsFrPhYV2x14WRSCT4/fffi9x+4sQJSCQSpKSkVGgOKtrQoUPRu3fvMrcjl8vh6emJM2fOlD2UDnF3d8c333yjvv2q17w+mDdvHho3blxu7R08eBCNGzeGUqks1eNYlBDpq7fXAJauolNQFWGdmYxWVp6iY1RZ3Wt3Rx+vPmVqIy4uDhMmTICHhweMjY3h5uaGXr164dixYyVuo02bNoiNjYW1tXWZsjxX3m+G9MHKlSuxadOmMrfz3XffoXbt2mjTpo36PolEov6ytrZG27Ztcfz48TIfS5vFxsaiW7duwo5f2YV+YUXYtGnTSvV74FWCgoJgaGiIrVu3lupxLEqI9JWZHdDne0DCXwNUPoKyFaIjVElulm6Y23pumdqIiYlB06ZNcfz4cSxduhTXrl3DwYMH0bFjR4wbN67E7RgZGcHFxQUSSeVemyY3N7dSj6fNrK2tYWNjU6Y2VCoVVq9ejeHDhxfYtnHjRsTGxiI4OBgODg7o2bMn7t69W6bjaTMXFxcYG1eNIZGv+3NiYWEBe3v7cs0ydOhQrFq1qlSP4bsRIn3m0R4IKNubHaLnAqIvwkhqJDpGlWJhaIFvO31b5qu2jx07FhKJBBcuXEDfvn1Rt25dNGjQAFOmTMG5c+c09k1ISECfPn1gZmYGLy8v7Nu3T73t5U91N23aBBsbGxw6dAg+Pj6wsLBAUFAQYmNjNR7TokULmJubw8bGBm3btsW9e/ewadMmzJ8/H2FhYepP55/3AEgkEqxbtw5vvfUWzM3NsWjRIigUCgwfPhy1a9eGqakpvL29sXLlSo3sz4c2zZ8/H46OjrCyssLo0aMhlxc96en5Ofz+++/w8vKCiYkJAgMD8eDBA4399u7diyZNmsDExAQeHh6YP38+8vLy1NslEgl+/PHHIp87ANi3b5/6GB07dsTmzZs1ns/Ceo6++eYbuLu7FzjH5zp06ICJEydixowZsLOzg4uLC+bNm1fk+QLApUuXEBUVhR49ehTYZmNjAxcXFzRs2BDr1q1DVlYWjhw5gp9//hn29vbIycnR2L93794YPHiw+vbChQvh5OQES0tLfPTRR5g1a5bGOSmVSnz++eeoUaMGjI2N0bhxYxw8eFC9XS6XY/z48XB1dYWJiQlq1aqFL7/8Ur09JSUFo0aNgrOzM0xMTNCwYUPs379fvf306dN48803YWpqCjc3N0ycOBEZGRlFPhcv9hy86tgvu3jxIrp06QIHBwdYW1ujffv2uHz5coH2i3pdxMTEoGPHjgAAW1tbSCQSDB06FED+EKg33ngDNjY2sLe3R8+ePREVFaVuNyYmBhKJBDt37kT79u1hYmKi7pn46aef0KBBAxgbG8PV1RXjx48HAPXrqE+fPpBIJOrbhb3uimoDAFasWIFGjRrB3Nwcbm5uGDt2LNLT0zUe36tXL4SEhGhkfhUWJUT67o2PAb+BolNQFWCR/QxtrTmEq7zIJDIsbb8UdWzKtrJZUlISDh48iHHjxsHcvGBx8/Kn7vPnz0e/fv1w9epVdO/eHYMGDUJSUlKR7WdmZmLZsmXYsmUL/ve//+H+/fuYNm0aACAvLw+9e/dG+/btcfXqVZw9exYjR46ERCJB//79MXXqVDRo0ACxsbGIjY1F//791e3OmzcPffr0wbVr1zBs2DAolUrUqFEDu3fvxs2bNzF37lz83//9H3bt2qWR59ixYwgPD8eJEyewfft2/Prrr5g/f36xz1FmZiYWLVqEn3/+GcHBwUhJScF7772n3n7q1Cl88MEHmDRpEm7evInvv/8emzZtwqJFi0r83EVHR+Odd95B7969ERYWhlGjRmHOnDnF5iqpzZs3w9zcHOfPn8dXX32Fzz//HEeOHCly/1OnTqFu3bqwtLQstl1TU1MA+W/W3333XSgUCo1CKz4+Hn/++SeGDRsGANi6dSsWLVqEJUuW4NKlS6hZsybWrVun0ebKlSuxfPlyLFu2DFevXkVgYCDeeustREZGAgBWrVqFffv2YdeuXYiIiMDWrVvVb56VSiW6deuG4OBg/PLLL7h58yYWL14MmSx/SfKoqCgEBQWhb9++uHr1Knbu3InTp09rvKEuTnHHLkxaWhqGDBmC06dP49y5c/Dy8kL37t2RlpamsV9Rrws3Nzfs2bMHABAREYHY2Fh1oZ2RkYEpU6YgJCQEx44dg1QqRZ8+fQrM05g1axYmTZqE8PBwBAYGYt26dRg3bhxGjhyJa9euYd++ffD0zP+9fPHiRQD/9oY9v/2y4toAAKlUilWrVuHGjRvYvHkzjh8/jhkzZmi0UbNmTTg7O+PUqVMleObzcVYiEQG9VgJJd4EH5169L1ExgjKz8bfoEFXE9ObT8Ub1N8rczp07d6BSqVCvXr0S7T906FAMGDAAAPDFF19g1apVuHDhAoKCggrdPzc3F9999x3q1MkvnsaPH4/PP/8cAPDs2TOkpqaiZ8+e6u0+Pv9eK8nCwgIGBgZwcXEp0O7AgQPx4Ycfatz3YnFRu3ZtnD17Frt27UK/fv3U9xsZGeGnn36CmZkZGjRogM8//xzTp0/HggULIJUW/llsbm4uVq9ejZYt86//snnzZvj4+ODChQto0aIF5s+fj1mzZmHIkCEAAA8PDyxYsAAzZszAZ599VqLn7vvvv4e3tzeWLl0KAPD29sb169cLFDavw9fXV53Dy8sLq1evxrFjx9ClS5dC97937x6qVatWbJuZmZn45JNPIJPJ0L59e5iammLgwIHYuHEj3n33XQDAL7/8gpo1a6JDhw4AgG+//RbDhw9Xf9/mzp2Lw4cPa3yKvmzZMsycOVNd9C1ZsgR///03vvnmG6xZswb379+Hl5cX3njjDUgkEtSqVUv92KNHj+LChQsIDw9H3bp1AeR/L5778ssvMWjQIEyePFn9XKxatQrt27fHunXrYGJS/HL4xR27MJ06ddK4/cMPP8DGxgYnT55Ez5491fcX97qws7MDADg5OWl8QNC3b1+Ntn/66Sc4Ojri5s2baNiwofr+yZMn4z//+Y/69sKFCzF16lRMmjRJfV/z5s0BAI6OjgD+7Q0rSnFtPD/mc+7u7li4cCFGjx6NtWvXarRTrVo13Lt3r8jjvIw9JUQEGBgB720FrGuKTkI6rsPdizCV8To4ZdWvbj8M8hlULm2pVKpS7e/r66v+v7m5OaysrBAfH1/k/mZmZuqCAwBcXV3V+9vZ2WHo0KEIDAxEr169sHLlSo2hXcVp1qxZgfvWrFmDpk2bwtHRERYWFvjhhx9w//59jX38/PxgZmamvt26dWukp6cXGI71IgMDA403XfXq1YONjQ3Cw8MBAGFhYfj8889hYWGh/hoxYgRiY2ORmZmpflxxz11ERITGMQCgRYsWJXkqXunF4wKa34PCZGVlFfkGfcCAAbCwsIClpSX27NmDDRs2qNsfMWIEDh8+jEePHgHIH/o2dOhQ9RyjiIiIAuf04u1nz57h8ePHaNu2rcY+bdu2VT/XQ4cORWhoKLy9vTFx4kQcPnxYvV9oaChq1KihLkheFhYWhk2bNml8nwIDA6FUKhEdHV3k8/FccccuzJMnTzBixAh4eXnB2toaVlZWSE9PL/CaLO3PFABERkZiwIAB8PDwgJWVlbrH5uW2X/w5iY+Px+PHjxEQEPDKcy1KSdo4evQoAgICUL16dVhaWmLw4MFITEzU+FkA8nvaXr6vOCxKiCifuQMwcAdgVHx3PlFxzOQZeNOKF1Isi1aurTC75exya8/LywsSiQS3bt0q0f6GhoYatyUSSbFLexa2/4uF0MaNG3H27Fm0adMGO3fuRN26dQvMYynMy0PNduzYgWnTpmH48OE4fPgwQkND8eGHHxY7X6S8pKenY/78+QgNDVV/Xbt2DZGRkRpv7kv73L1MKpUWKCJLMnm5tMd1cHBAcnJyodu+/vprhIaGIi4uDnFxcereIQDw9/eHn58ffv75Z1y6dAk3btxQz4EoL02aNEF0dDQWLFiArKws9OvXD++88w6Af4eTFSU9PR2jRo3S+D6FhYUhMjJSo3B+nWMXZsiQIQgNDcXKlStx5swZhIaGwt7evsBr8nVeF7169UJSUhLWr1+P8+fP4/z58wBQoO0Xf05e9fyUxKvaiImJQc+ePeHr64s9e/bg0qVLWLNmTaHZkpKS1L0zJcGihIj+5dwA6PsjV+SiMgl6acIjlZy7lTuWd1hertd8sbOzQ2BgINasWVPohN/KWIrU398fs2fPxpkzZ9CwYUNs27YNQP5QK4WiZKu2BQcHo02bNhg7diz8/f3h6elZ6CTasLAwZGVlqW+fO3cOFhYWcHNzK7LtvLw8hISEqG9HREQgJSVFPdSsSZMmiIiIgKenZ4GvooaEvczb21vjGAAKjOl3dHREXFycRmESGhpaovZLw9/fH7du3Sq0F83FxQWenp5Fvpn86KOPsGnTJmzcuBGdO3fWeF69vb0LnNOLt62srFCtWjUEBwdr7BMcHIz69etr7Ne/f3+sX78eO3fuxJ49e5CUlARfX188fPgQt2/fLjRbkyZNcPPmzUK/T0ZGJVuEo6hjFyY4OBgTJ05E9+7d1ZPCExISSnSc557nevHnIDExEREREfjkk08QEBAAHx+fIovIF1laWsLd3b3Y5X0NDQ2L/Zl7VRuXLl2CUqnE8uXL0apVK9StWxePHz8usF92djaioqLg7+//ytzP8Z0HEWnyDgI6Fz8plKg47e5ehLmB2at3JA3WxtZYE7AGVkZW5d72mjVroFAo0KJFC+zZsweRkZEIDw/HqlWr0Lp163I/3nPR0dGYPXs2zp49i3v37uHw4cOIjIxUv9l3d3dHdHQ0QkNDkZCQUGBlpxd5eXkhJCQEhw4dwu3bt/Hpp58WOlFXLpdj+PDhuHnzJg4cOIDPPvsM48ePL7Z4MDQ0xIQJE3D+/HlcunQJQ4cORatWrdRDj+bOnYuff/4Z8+fPx40bNxAeHo4dO3bgk08+KfFzMWrUKNy6dQszZ87E7du3sWvXLo3VxoD8lbSePn2Kr776ClFRUVizZg3++uuvEh+jpDp27Ij09HTcuHGj1I8dOHAgHj58iPXr16snuD83YcIEbNiwAZs3b0ZkZCQWLlyIq1evaiwhPX36dCxZsgQ7d+5EREQEZs2ahdDQUPX8hRUrVmD79u24desWbt++jd27d8PFxQU2NjZo37492rVrh759++LIkSOIjo7GX3/9pV69a+bMmThz5gzGjx+P0NBQREZGYu/evSWe6F7csQvj5eWFLVu2IDw8HOfPn8egQYNK3VtRq1YtSCQS7N+/H0+fPkV6ejpsbW1hb2+PH374AXfu3MHx48cxZcqUErU3b948LF++HKtWrUJkZCQuX76Mb7/9Vr39ecERFxdXZKFTXBuenp7Izc3Ft99+i7t372LLli347rvvCrRx7tw5GBsbl+r3C4sSIiqo7UTA/33RKUhHGedlo4NlxV55vKoxkBrg6w5fo6ZVxczr8vDwwOXLl9GxY0dMnToVDRs2RJcuXXDs2LECqyOVJzMzM9y6dUu9DPHIkSMxbtw4jBo1CkD+ZN6goCB07NgRjo6O2L59e5FtjRo1Cv/5z3/Qv39/tGzZEomJiRg7dmyB/QICAuDl5YV27dqhf//+eOutt165RK6ZmRlmzpyJgQMHom3btrCwsMDOnTvV2wMDA7F//34cPnwYzZs3R6tWrfD111+/ciL0i2rXro3//ve/+PXXX+Hr64t169apV996fp0MHx8frF27FmvWrIGfnx8uXLigXsmsPNnb26NPnz6lvrgdkH+dlL59+8LCwqLAleUHDRqE2bNnY9q0aeqhUEOHDtUY4jZx4kRMmTIFU6dORaNGjXDw4EH1UslA/if1X331FZo1a4bmzZsjJiYGBw4cUBeVe/bsQfPmzTFgwADUr18fM2bMUH/y7+vri5MnT+L27dt488034e/vj7lz575yUv9zrzr2yzZs2IDk5GQ0adIEgwcPxsSJE+Hk5FSq57N69erqhRScnZ3VBfSOHTtw6dIlNGzYEB9//LF6gYRXGTJkCL755husXbsWDRo0QM+ePdUrmwHA8uXLceTIEbi5uRXZi1FcG35+flixYgWWLFmChg0bYuvWrYUum7x9+3YMGjRIY37Xq0hUpZ0BR0T6QZEL7BgIRBY/0Y+oMCc822KCouiJxaTp8zafl/mK7ZQ/UTklJaXAFauLs2nTJkyePLnSrqj9okWLFuG7774rdhJ+Rbl69Sq6dOmCqKgoWFhYlOqxAQEBaNCgQYkujtelSxe4uLhgy5YtrxuVdExCQoJ6uGLt2rVL/DguCUxEhZMZAv1+Bn55B7h3WnQa0jFtoy/Cso4n0nI5v+RVZrWYxYJET6xduxbNmzeHvb09goODsXTp0hIPLSpvvr6+WLJkCaKjo9GoUaMSPSY5ORknTpzAiRMnCiz/CuQvI/zdd98hMDAQMpkM27dvx9GjR4u9ZgpVPTExMVi7dm2pChKARQkRFcfQNH9Frs1vAY8vv3p/on8YKuQIsKiN35OviY6i1aY1m1ZuS/+S9ns+zyIpKQk1a9bE1KlTMXt2+a20VlqlXTnL398fycnJWLJkCby9vQtsl0gkOHDgABYtWoTs7Gx4e3tjz5496Ny5czklJl3QrFmzQpf0fhUO3yKiV8tMAjb1AOJvik5COiTYoyVGq0p2TQp99HHTjzGs4bBX70hEpAc40Z2IXs3MDvhgH+BQ8JMxoqK0jLkEWyNr0TG00kT/iSxIiIhewKKEiErGwhEY8gdg7yU6CekIA2UeOptXzGpSumys31iM8B0hOgYRkVZhUUJEJWfpnF+Y2PGK3VQyQUnxoiNolZG+IzGm8RjRMYiItA6LEiIqHStXYOh+wN5TdBLSAc3uXYKjiZ3oGFphWMNhmOA/QXQMIiKtxKJEB8XExEAikSA0NLTMbW3YsAFdu3YteygdsmnTJo2rs86bNw+NGzcWlqcyHTx4EI0bN4ZSqSxbQ1bVgGGHgepNyycYVVlSlRJdTGuIjiHckPpD8HHTj0XHICLSWqUuSuLi4jBp0iR4enrCxMQEzs7OaNu2LdatW4fMzMxyDdehQwdMnjy5XNusCtzc3BAbG4uGDRuWqZ3s7Gx8+umn+Oyzz9T3zZs3DxKJBBKJBAYGBnB3d8fHH3+M9PSqe62BadOm4dixY6JjVIqgoCAYGhq+1lV8CzC3B4bsB7z0q6il0gt6+kh0BGEkkODjph9jWvPyvyo3EVFVUqqi5O7du/D398fhw4fxxRdf4MqVKzh79ixmzJiB/fv34+jRoxWVk14gk8ng4uICA4OyXWbmv//9L6ysrNC2bVuN+xs0aIDY2FjExMRgyZIl+OGHHzB16tQyHUubWVhYwN7eXnSMSjN06NASXYW3RIzMgPe2A415nQUqWuMHoXAxdRQdo9IZSY3wVbuvuMoWEVEJlKooGTt2LAwMDBASEoJ+/frBx8cHHh4eePvtt/Hnn3+iV69e6n1TUlLw0UcfwdHREVZWVujUqRPCwsLU258PmdmyZQvc3d1hbW2N9957D2lpaQDy3zidPHkSK1euVH9yHxMTAwA4efIkWrRoAWNjY7i6umLWrFnIy8tTt52Tk4OJEyfCyckJJiYmeOONN3Dx4sViz83d3R0LFizAgAEDYG5ujurVq2PNmjUa+5T1nAAgLS0NgwYNgrm5OVxdXfH1118X6BGSSCT4/fffNY5tY2ODTZs2ASg4fOvEiROQSCQ4duwYmjVrBjMzM7Rp0wYRERHFnvOOHTs0vmfPGRgYwMXFBTVq1ED//v0xaNAg7Nu3DyqVCp6enli2bJnG/qGhoZBIJLhz5w4A4NatW3jjjTdgYmKC+vXr4+jRowXO6dq1a+jUqRNMTU1hb2+PkSNHavTGnDhxAi1atIC5uTlsbGzQtm1b3Lt3T739jz/+QPPmzWFiYgIHBwf06fPv1ZBzcnIwbdo0VK9eHebm5mjZsiVOnDhR5PPw8vCtVx37Rc+/Fzt27ECbNm1gYmKChg0b4uTJk+p9FAoFhg8fjtq1a8PU1BTe3t5YuXKlRjtDhw5F7969MX/+fPXra/To0ZDL5ep93N3d8c0332g8rnHjxpg3b5769ooVK9CoUSOYm5vDzc0NY8eOLdDL1atXL4SEhCAqKqrI56RUZAZA77XAG1PKpz2qciRQIdDYVXSMSmVtbI31XdcjqHaQ6ChERDqhxEVJYmIiDh8+jHHjxsHc3LzQfSQSifr/7777LuLj4/HXX3/h0qVLaNKkCQICApCUlKTeJyoqCr///jv279+P/fv34+TJk1i8eDEAYOXKlWjdujVGjBiB2NhYxMbGws3NDY8ePUL37t3RvHlzhIWFYd26ddiwYQMWLlyobnfGjBnYs2cPNm/ejMuXL8PT0xOBgYEaxy7M0qVL4efnhytXrmDWrFmYNGkSjhw5Um7nBABTpkxBcHAw9u3bhyNHjuDUqVO4fLl8rpQ9Z84cLF++HCEhITAwMMCwYcV/Onf69OkSXXHT1NQUcrkcEokEw4YNw8aNGzW2b9y4Ee3atYOnpycUCgV69+4NMzMznD9/Hj/88APmzJmjsX9GRgYCAwNha2uLixcvYvfu3Th69CjGjx8PAMjLy0Pv3r3Rvn17XL16FWfPnsXIkSPVr68///wTffr0Qffu3XHlyhUcO3YMLVq0ULc/fvx4nD17Fjt27MDVq1fx7rvvIigoCJGRka8811cduyjTp0/H1KlTceXKFbRu3Rq9evVCYmIiAECpVKJGjRrYvXs3bt68iblz5+L//u//sGvXLo02jh07hvDwcJw4cQLbt2/Hr7/+ivnz578y84ukUilWrVqFGzduYPPmzTh+/DhmzJihsU/NmjXh7OyMU6dOlartV+r8GdBtKSDhVDUqKCi+8MK+KqphUQO/dPsFTZybiI5CRKQzSjz+586dO1CpVPD21rx4moODA7KzswEA48aNw5IlS3D69GlcuHAB8fHxMDY2BgAsW7YMv//+O/773/9i5MiRAPLfrG3atAmWlpYAgMGDB+PYsWNYtGgRrK2tYWRkBDMzM7i4uKiPt3btWri5uWH16tWQSCSoV68eHj9+jJkzZ2Lu3LnIysrCunXrsGnTJnTr1g0AsH79ehw5cgQbNmzA9OnTizzHtm3bYtasWQCAunXrIjg4GF9//TW6dOlSLueUlpaGzZs3Y9u2bQgICACQ/4a+WrVqJf02FGvRokVo3749AGDWrFno0aMHsrOzYWJiUmDflJQUpKamvvLYly5dwrZt29CpUycA+Z/oz507FxcuXECLFi2Qm5uLbdu2qXtPjhw5gqioKJw4cUL9fVu0aBG6dOmibnPbtm3Izs7Gzz//rC5wV69ejV69emHJkiUwNDREamoqevbsiTp18pee9fHx0TjP9957T+MNu5+fHwDg/v372LhxI+7fv68+t2nTpuHgwYPYuHEjvvjii2LP99mzZ8Ueuyjjx49H3759AQDr1q3DwYMHsWHDBsyYMQOGhoYaWWvXro2zZ89i165d6Nevn/p+IyMj/PTTTzAzM0ODBg3w+eefY/r06ViwYAGk0pK90X+xx83d3R0LFy7E6NGjsXbtWo39qlWrVmTvT5m0HJl/PZNfRwGKnPJvn3RWw0fX4NagBR5kxomOUqF8HXyxqtMq2Jvqz5BQIqLyUOaPNC9cuIDQ0FA0aNAAOTn5b0LCwsKQnp4Oe3t7WFhYqL+io6M1hoy4u7ur37wDgKurK+Lji1/TPjw8HK1bt9b45Lpt27ZIT0/Hw4cPERUVhdzcXI15EoaGhmjRogXCw8OLbbt169YFbj9/THmc0927d5Gbm6vxqb61tXWBQu91+fr6ahwXQJHPZ1ZWFgAUWrBcu3YNFhYWMDU1RYsWLdC6dWusXr0aQP6b2R49euCnn34CkD+MKicnB++++y4AICIiAm5ubhqF5IvnC+R/D/38/DR63Nq2bQulUomIiAjY2dlh6NChCAwMRK9evbBy5UrExsaq9w0NDVUXdYVlVygUqFu3rsb36eTJkyUarvSqYxflxdeOgYEBmjVrpvF6W7NmDZo2bQpHR0dYWFjghx9+wP379zXa8PPzg5mZmUab6enpePDgwSuP/9zRo0cREBCA6tWrw9LSEoMHD0ZiYmKBRShMTU3LfWEKtQZ9gPf3AKZcBpY0BRpV7Xklndw6YUPgBhYkRESvocQ9JZ6enpBIJAXmKXh4eADIf5PzXHp6OlxdXQsdx//iUqyGhoYa2yQSSdmXKq0glXlOEokEKpVK477c3NxXPu7FYz8v2oo6tr29PSQSCZKTkwts8/b2xr59+2BgYIBq1arByMhIY/tHH32EwYMH4+uvv8bGjRvRv39/jTfT5WHjxo2YOHEiDh48iJ07d+KTTz7BkSNH0KpVK43X2svS09Mhk8lw6dIlyGQyjW0WFhZlPvbr2LFjB6ZNm4bly5ejdevWsLS0xNKlS3H+/PlStSOVSot9XcTExKBnz54YM2YMFi1aBDs7O5w+fRrDhw+HXC7X+B4lJSXB0bEC3yDWfhMYdRLYORiIDa2445BOCYq9ix+L/vHVae/7vI/pzadDyuGLRESvpcS/Pe3t7dGlSxesXr0aGRkZxe7bpEkTxMXFwcDAAJ6enhpfDg4OJQ5nZGQEhUKhcZ+Pjw/Onj2r8eYsODgYlpaWqFGjBurUqQMjIyMEBwert+fm5uLixYuoX79+scc7d+5cgdvPh+6Uxzl5eHjA0NBQY9J9amoqbt++rbGfo6OjxqfzkZGR5f6ptpGREerXr4+bN28Wus3T0xPu7u4FChIA6N69O8zNzdXDlF6cu+Lt7Y0HDx7gyZMn6vteXmTAx8cHYWFhGq+j4OBgSKVSjV4jf39/zJ49G2fOnEHDhg2xbds2APk9QkUt4evv7w+FQoH4+PgC36cXe29epahjF+XF105eXh4uXbqkfu0EBwejTZs2GDt2LPz9/eHp6Vlor01YWJi6B+t5mxYWFnBzcwNQ8HXx7NkzREdHq29funQJSqUSy5cvR6tWrVC3bl08fvy4wHGys7MRFRUFf3//Ej4br8mmJjD8MNDkg4o9DukM77hw1DavLjpGuTKSGmFOyzmY2WImCxIiojIo1W/QtWvXIi8vD82aNcPOnTsRHh6OiIgI/PLLL7h165b6k+nOnTujdevW6N27Nw4fPoyYmBicOXMGc+bMQUhISImP5+7ujvPnzyMmJgYJCQlQKpUYO3YsHjx4gAkTJuDWrVvYu3cvPvvsM0yZMgVSqRTm5uYYM2YMpk+fjoMHD+LmzZsYMWIEMjMzMXz48GKPFxwcjK+++gq3b9/GmjVrsHv3bkyaNKnczsnS0hJDhgzB9OnT8ffff+PGjRsYPnw4pFKpxnC0Tp06YfXq1bhy5QpCQkIwevToAj0w5SEwMBCnT58u9eNkMhmGDh2K2bNnw8vLS2PoUpcuXVCnTh0MGTIEV69eRXBwMD755BMA//beDBo0CCYmJhgyZAiuX7+Ov//+GxMmTMDgwYPh7OyM6OhozJ49G2fPnsW9e/dw+PBhREZGqt/kf/bZZ9i+fTs+++wzhIeH49q1a1iyZAmA/LlAgwYNwgcffIBff/0V0dHRuHDhAr788kv8+eefrzy3Vx27KGvWrMFvv/2GW7duYdy4cUhOTlYXa15eXggJCcGhQ4dw+/ZtfPrpp4WuBieXyzF8+HDcvHkTBw4cwGeffYbx48er55N06tQJW7ZswalTp3Dt2jUMGTJEozfI09MTubm5+Pbbb3H37l1s2bIF3333XYHjnDt3DsbGxgWGK1YIA2PgrW+Bt1YDBgWHCpL+CTKoOsP6alrWxJbuW/BevfdERyEi0nmlKkrq1KmDK1euoHPnzpg9ezb8/PzQrFkzfPvtt5g2bRoWLFgAIP/N54EDB9CuXTt8+OGHqFu3Lt577z3cu3cPzs7OJT7etGnTIJPJUL9+fTg6OuL+/fuoXr06Dhw4gAsXLsDPzw+jR4/G8OHD1W98AWDx4sXo27cvBg8ejCZNmuDOnTs4dOgQbG1tiz3e1KlTERISAn9/fyxcuBArVqxAYGBguZ7TihUr0Lp1a/Ts2ROdO3dG27Zt4ePjozG3Y/ny5XBzc8Obb76JgQMHYtq0aeU+PAoAhg8fjgMHDiA1NfW1HiuXy/Hhhx9q3C+TyfD7778jPT0dzZs3x0cffaRefev5OZqZmeHQoUNISkpC8+bN8c477yAgIEA9b8XMzAy3bt1C3759UbduXYwcORLjxo3DqFGjAORfVHP37t3Yt28fGjdujE6dOuHChQvqDBs3bsQHH3yAqVOnwtvbG71798bFixdRs2bNV57Xq45dlMWLF2Px4sXw8/PD6dOnsW/fPnUP2qhRo/Cf//wH/fv3R8uWLZGYmIixY8cWaCMgIABeXl5o164d+vfvj7feektjud/Zs2ejffv26NmzJ3r06IHevXurJ+MD+XNSVqxYgSVLlqBhw4bYunUrvvzyywLH2b59OwYNGlQhr6kiNRkMDDuU33tCei3o8e1X76QDurl3w65eu1DfvvgeeCIiKhmJ6uVB6nrK3d0dkydPrvQryGdkZKB69epYvnz5K3tyKsK7776LJk2aYPbs2aV63KlTpxAQEIAHDx68sigLDg7GG2+8gTt37mi8ia4KYmJiULt2bVy5ckXjWielNXToUKSkpBS4Pk15S0hIgLe3N0JCQlC7du0KPVahMpOAX0cCd468el+qsvo2egO30++/ekctZCIzwcwWM/FO3XdERyEiqlLKdklwKrUrV67g1q1baNGiBVJTU/H5558DAN5++20heZYuXYo//vijxPvn5OTg6dOnmDdvHt59991CC5LffvsNFhYW8PLywp07dzBp0iS0bdu2yhUkuigmJgZr164VU5AAgJkdMHAX8L+vgJNLAJV2LmxBFStIagVd7C+pbV0by9ovQ13buqKjEBFVOZyVJ8CyZcvg5+eHzp07IyMjA6dOnSrVAgDlyd3dHRMmTCjx/tu3b0etWrWQkpKCr776qtB90tLSMG7cONSrVw9Dhw5F8+bNsXfv3vKKTGXQrFkz9O/fX2wIqRToMAsY8gdg6y42CwkR9LDgAhva7q06b2FHjx0sSIiIKgiHbxGROPIM4Mhc4OIGAPxVpE/e82uPG8+iX72jYKYGppjTcg7e9hTTm01EpC/YU0JE4hiZAz2WA0P2cRK8nglSVeJCC6+pmXMz7Oq5iwUJEVElYE8JEWmHnHTg8CfApY2ik1AliLV1Q6CNFCot7CGzNrbG1KZT0duzt8Zy7UREVHFYlBCRdok6DuybCKQ+EJ2EKthgv44IfVbwQqIida/dHTOaz4C9qb3oKEREeoXDt4hIu9TpBIw5AzQZAoCfUldlQUpj0RHUaljUwHedv8OSdktYkBARCcCeEiLSXg9DgIOzgIcXRSehCvDUygWdHUygFLg0tIHEAIMbDMZYv7EwMTB59QOIiKhCsCghIu2mUgHXdgNH5wHPHolOQ+VsWOMAXEyNFHLsRg6N8Fnrz+Bt5y3k+ERE9C9ePJGItJtEAvj2A+r1BIJX5n/lZYlOReUkKE+Gyu4HczJ1wujGo9HXqy+kEo5iJiLSBuwpISLdkvoQOPIZcP2/opNQOUgyd0CAsxXyVHkVfiwbYxsMbzgc79V7j0O1iIi0DIsSItJNDy4Af80EHl8WnYTKaJR/F5xJiaiw9s0MzDC4/mAMbTAUFkYWFXYcIiJ6fSxKiEh3qVRAxAHgf8tYnOiw3+p3xtys2+XerpHUCP28+2GE7wjYmdiVe/tERFR+WJQQUdVw51h+cXL/jOgkVEqppjboWM0eucrccmlPJpHhrTpvYYzfGLhauJZLm0REVLFYlBBR1RITDJxaln8RRtIZ4/0DcTIlvExtGEgM0KVWF4xpPAa1rWuXUzIiIqoMXH2LiKoW97b5X48u5fecRPwFgJ+9aLvA7FycfM3H2hrb4p2676C/d384mzuXay4iIqoc7CkhoqrtyQ0geBVw83cgL1t0GipChrEl2ru5IEeRU+LHeNt6Y5DPIHT36A5jmfZcHZ6IiEqPRQkR6YesZCBsB3BpE/D0lug0VIiPm3TD0eQbxe4jk8jQ0a0jBvkMQjOXZpWUjIiIKhqLEiLSP/fP5RcnN37nhRi1yEHv9pgujy50m5WRFfrW7YsB3gM4eZ2IqApiUUJE+isrGQjb+U/vSdkmWVPZZRmZoX0tN2T9UyjKJDK0qtYKPWr3QOdanWFqYCo4IRERVRQWJUREAHD/PHBtF3DrTyAtVnQavTWjSXc8kknR3aM7gtyDYG9qLzoSERFVAhYlREQvUqmAhyHArT+A8D+ApLuiE+mHav5A/beR26APDG3dRachIqJKxqKEiKg4T24A4fvzC5Qn10SnqTqkBkD1ZoBPT8DnLcC2luhEREQkEIsSIqKSSo7JL07uHM0f7sVJ8qXj6AN4dAA82gO12gImVqITERGRlmBRQkT0OvLkwKMQIPoUEHMKeHiR10F5mVWNf4uQ2u0BS17YkIiICseihIioPOTJgdjQ/OWGH5zP/8p4KjpV5TEwAZx8AJdG+fNDarcH7OuITkVERDqCRQkRUUVJuQ/E38pfbvj5v09vA7kZopOVjaltfvHh4vvPVyPAoS4gMxCdjIiIdBSLEiKiyqRSASn3gKcRQHx4/tXln0bkL0OcHg+oFKIT5jNzAKxraH7Z1ckvQGzcRKcjIqIqhkUJEZG2UCqBzEQgPQ5IfwKkPcn/9/lX2hMgJw1QyAFFDqDIBfL++VeRk3+/SqnZpoEpYGQGGJkDRhb5/xqa/ft/I3PAwvmF4sMNsK4OGPJChUREVHlYlBARVSVKRX6holLmFx9SqehEREREr8SihIiIiIiIhOJHaEREREREJBSLEiIiIiIiEopFCRERERERCcWihIiIiIiIhGJRQkREREREQrEoISIiIiIioViUEBERERGRUCxKiIiIiIhIKBYlREREREQkFIsSIiIiIiISikUJEREREREJxaKEiIiIiIiEYlFCRERERERCsSghIiIiIiKhWJQQEREREZFQLEqIiIiIiEgoFiVERERERCQUixIiIiIiIhKKRQkREREREQnFooSIiIiIiIRiUUJEREREREKxKCEiIiIiIqFYlBARERERkVAsSoiIiIiISCgWJUREREREJBSLEiIiIiIiEopFCRERERERCcWihIiIiIiIhGJRQkREREREQrEoISIiIiIioViUEBERERGRUCxKiIiIiIhIKBYlREREREQkFIsSIiIiIiISikUJEREREREJxaKEiIiIiIiEYlFCRERERERCsSghIiIiIiKhWJQQEREREZFQLEqIiIiIiEgoFiVERERERCQUixIiIiIiIhKKRQkREREREQnFooSIiIiIiIRiUUJEREREREL9P6MtWHxUCA+9AAAAAElFTkSuQmCC",
-            "text/plain": [
-              "<Figure size 640x480 with 1 Axes>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        }
-      ],
-      "source": [
-        "import matplotlib.pyplot as plt\n",
-        "\n",
-        "# plotting a histogram\n",
-        "species_counts = df[\"species\"].value_counts()\n",
-        "plt.pie(species_counts, labels=species_counts.index, autopct='%1.1f%%')\n",
-        "plt.show()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Pandas interoperability\n",
-        "\n",
-        "BigQuery DataFrames can be converted from and to Pandas DataFrame with `to_pandas` and `read_pandas` respectively.\n",
-        "This could be handy to take advantage of the capabilities of the two systems.\n",
-        "\n",
-        "> Note: `to_pandas` converts the BigQuery DataFrame to Pandas DataFrame by bringing all the data in memory, which would be an issue\n",
-        "for large data, as your machine may not have enough memory to accommodate that."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 7,
-      "metadata": {},
-      "outputs": [
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "We have a dataframe of <class 'bigframes.dataframe.DataFrame'>\n",
-            "\n"
-          ]
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job ff4c22ff-2735-46db-b52b-a33cf8fef27e is DONE. 28.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:ff4c22ff-2735-46db-b52b-a33cf8fef27e&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "We have a dataframe of <class 'pandas.core.frame.DataFrame'>\n",
-            "\n"
-          ]
-        },
-        {
-          "data": {
-            "text/html": [
-              "Load job 49eb4aa0-7166-484e-90b1-63a675eafd00 is DONE. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:49eb4aa0-7166-484e-90b1-63a675eafd00&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "We have a dataframe of <class 'bigframes.dataframe.DataFrame'>\n",
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "def print_type(df):\n",
-        "    print(f\"\\nWe have a dataframe of {type(df)}\\n\")\n",
-        "\n",
-        "# The original bigframes dataframe\n",
-        "cur_df = df\n",
-        "print_type(cur_df)\n",
-        "\n",
-        "# Convert to pandas dataframe\n",
-        "cur_df = cur_df.to_pandas()\n",
-        "print_type(cur_df)\n",
-        "\n",
-        "# Convert back to bigframes dataframe\n",
-        "cur_df = bpd.read_pandas(cur_df)\n",
-        "print_type(cur_df)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Machine Learning with BigQuery DataFrames"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Clean and prepare data\n",
-        "\n",
-        "We're are going to start with supervised learning, where a Linear Regression model will learn to predict the body mass (output variable `y`) using input features such as flipper length, sex, species, and more (features `X`)."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 10,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "Query job c8682a2f-c1df-437f-95c3-836a317752d5 is DONE. 28.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:c8682a2f-c1df-437f-95c3-836a317752d5&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job e4198287-043e-45cf-b615-990b00abc521 is DONE. 28.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:e4198287-043e-45cf-b615-990b00abc521&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "    X shape: (334, 6)\n",
-            "    y shape: (334, 1)\n",
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "# Drop any rows that has missing (NA) values\n",
-        "df = df.dropna()\n",
-        "\n",
-        "# Isolate input features and output variable into DataFrames\n",
-        "X = df[['island', 'culmen_length_mm', 'culmen_depth_mm', 'flipper_length_mm', 'sex', 'species']]\n",
-        "y = df[['body_mass_g']]\n",
-        "\n",
-        "# Print the shapes of features and label\n",
-        "print(f\"\"\"\n",
-        "    X shape: {X.shape}\n",
-        "    y shape: {y.shape}\n",
-        "\"\"\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Part of preparing data for a machine learning task is splitting it into subsets for training and testing to ensure that the solution is not overfitting. By default, BQML will automatically manage splitting the data for you. However, BQML also supports manually splitting out your training data.\n",
-        "\n",
-        "Performing a manual data split can be done with `bigframes.ml.model_selection.train_test_split` like so:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 11,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "Query job c45c1c1c-7a9a-4598-929c-ef18455a5d58 is DONE. 28.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:c45c1c1c-7a9a-4598-929c-ef18455a5d58&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job a6ccb958-f34e-48c1-9ec6-961e1e07ae25 is DONE. 28.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:a6ccb958-f34e-48c1-9ec6-961e1e07ae25&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job 3f357436-61ea-4d75-9a3c-a7042d20330e is DONE. 28.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:3f357436-61ea-4d75-9a3c-a7042d20330e&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job 040b5cc6-9ded-43ea-9176-89a7eaf741ce is DONE. 28.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:040b5cc6-9ded-43ea-9176-89a7eaf741ce&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job 99f1db63-2cb7-40de-9dea-bc5624c540d0 is DONE. 28.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:99f1db63-2cb7-40de-9dea-bc5624c540d0&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "\n",
-            "    X_train shape: (267, 6)\n",
-            "    X_test shape: (67, 6)\n",
-            "    y_train shape: (267, 1)\n",
-            "    y_test shape: (67, 1)\n",
-            "\n"
-          ]
-        }
-      ],
-      "source": [
-        "from bigframes.ml.model_selection import train_test_split\n",
-        "\n",
-        "# This will split X and y into test and training sets, with 20% of the rows in the test set,\n",
-        "# and the rest in the training set\n",
-        "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)\n",
-        "\n",
-        "# Show the shape of the data after the split\n",
-        "print(f\"\"\"\n",
-        "    X_train shape: {X_train.shape}\n",
-        "    X_test shape: {X_test.shape}\n",
-        "    y_train shape: {y_train.shape}\n",
-        "    y_test shape: {y_test.shape}\n",
-        "\"\"\")"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Define pipeline\n",
-        "\n",
-        "This step is subjective to the problem. Although a model can be directly trained on the original data, it is often useful to apply some preprocessing to the original data.\n",
-        "In this example we want to apply a [`ColumnTransformer`](https://cloud.google.com/python/docs/reference/bigframes/latest/bigframes.ml.compose.ColumnTransformer) in which we apply [`OneHotEncoder`](https://cloud.google.com/python/docs/reference/bigframes/latest/bigframes.ml.preprocessing.OneHotEncoder) to the category features and [`StandardScaler`](https://cloud.google.com/python/docs/reference/bigframes/latest/bigframes.ml.preprocessing.StandardScaler) to the numeric features."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 8,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/plain": [
-              "Pipeline(steps=[('preproc',\n",
-              "                 ColumnTransformer(transformers=[('onehot', OneHotEncoder(),\n",
-              "                                                  ['island', 'species', 'sex']),\n",
-              "                                                 ('scaler', StandardScaler(),\n",
-              "                                                  ['culmen_depth_mm',\n",
-              "                                                   'culmen_length_mm',\n",
-              "                                                   'flipper_length_mm'])])),\n",
-              "                ('linreg', LinearRegression(fit_intercept=False))])"
-            ]
-          },
-          "execution_count": 8,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "from bigframes.ml.linear_model import LinearRegression\n",
-        "from bigframes.ml.pipeline import Pipeline\n",
-        "from bigframes.ml.compose import ColumnTransformer\n",
-        "from bigframes.ml.preprocessing import StandardScaler, OneHotEncoder\n",
-        "\n",
-        "preprocessing = ColumnTransformer([\n",
-        "    (\"onehot\", OneHotEncoder(), [\"island\", \"species\", \"sex\"]),\n",
-        "    (\"scaler\", StandardScaler(), [\"culmen_depth_mm\", \"culmen_length_mm\", \"flipper_length_mm\"]),\n",
-        "])\n",
-        "\n",
-        "model = LinearRegression(fit_intercept=False)\n",
-        "\n",
-        "pipeline = Pipeline([\n",
-        "    ('preproc', preprocessing),\n",
-        "    ('linreg', model)\n",
-        "])\n",
-        "\n",
-        "# View the pipeline\n",
-        "pipeline"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Train and Predict\n",
-        "\n",
-        "Supervised learning is when we train a model on input-output pairs, and then ask it to predict the output for new inputs. An example of such a predictor is `bigframes.ml.linear_models.LinearRegression`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 12,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "Query job 1ccf6bcb-f38d-4680-a5df-89aaa03d6ea5 is DONE. 28.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:1ccf6bcb-f38d-4680-a5df-89aaa03d6ea5&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job cefb04e4-6fd2-477b-a579-be3b2ca745ba is DONE. 22.6 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:cefb04e4-6fd2-477b-a579-be3b2ca745ba&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job bebcf4df-d8d1-45c4-9efc-86c7645cd40d is DONE. 30.0 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:bebcf4df-d8d1-45c4-9efc-86c7645cd40d&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job 25d66657-3a7b-4e79-bca2-5a8116ba5c94 is DONE. 6.2 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:25d66657-3a7b-4e79-bca2-5a8116ba5c94&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>predicted_body_mass_g</th>\n",
-              "      <th>island</th>\n",
-              "      <th>culmen_length_mm</th>\n",
-              "      <th>culmen_depth_mm</th>\n",
-              "      <th>flipper_length_mm</th>\n",
-              "      <th>sex</th>\n",
-              "      <th>species</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>286</th>\n",
-              "      <td>3230.741308</td>\n",
-              "      <td>Biscoe</td>\n",
-              "      <td>37.9</td>\n",
-              "      <td>18.6</td>\n",
-              "      <td>172.0</td>\n",
-              "      <td>FEMALE</td>\n",
-              "      <td>Adelie Penguin (Pygoscelis adeliae)</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>41</th>\n",
-              "      <td>3186.002207</td>\n",
-              "      <td>Torgersen</td>\n",
-              "      <td>40.2</td>\n",
-              "      <td>17.0</td>\n",
-              "      <td>176.0</td>\n",
-              "      <td>FEMALE</td>\n",
-              "      <td>Adelie Penguin (Pygoscelis adeliae)</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>72</th>\n",
-              "      <td>3324.549608</td>\n",
-              "      <td>Dream</td>\n",
-              "      <td>36.5</td>\n",
-              "      <td>18.0</td>\n",
-              "      <td>182.0</td>\n",
-              "      <td>FEMALE</td>\n",
-              "      <td>Adelie Penguin (Pygoscelis adeliae)</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>36</th>\n",
-              "      <td>3426.252381</td>\n",
-              "      <td>Dream</td>\n",
-              "      <td>36.0</td>\n",
-              "      <td>18.5</td>\n",
-              "      <td>186.0</td>\n",
-              "      <td>FEMALE</td>\n",
-              "      <td>Adelie Penguin (Pygoscelis adeliae)</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>247</th>\n",
-              "      <td>3413.687704</td>\n",
-              "      <td>Biscoe</td>\n",
-              "      <td>39.0</td>\n",
-              "      <td>17.5</td>\n",
-              "      <td>186.0</td>\n",
-              "      <td>FEMALE</td>\n",
-              "      <td>Adelie Penguin (Pygoscelis adeliae)</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "</div>"
-            ],
-            "text/plain": [
-              "     predicted_body_mass_g     island  culmen_length_mm  culmen_depth_mm  \\\n",
-              "286            3230.741308     Biscoe              37.9             18.6   \n",
-              "41             3186.002207  Torgersen              40.2             17.0   \n",
-              "72             3324.549608      Dream              36.5             18.0   \n",
-              "36             3426.252381      Dream              36.0             18.5   \n",
-              "247            3413.687704     Biscoe              39.0             17.5   \n",
-              "\n",
-              "     flipper_length_mm     sex                              species  \n",
-              "286              172.0  FEMALE  Adelie Penguin (Pygoscelis adeliae)  \n",
-              "41               176.0  FEMALE  Adelie Penguin (Pygoscelis adeliae)  \n",
-              "72               182.0  FEMALE  Adelie Penguin (Pygoscelis adeliae)  \n",
-              "36               186.0  FEMALE  Adelie Penguin (Pygoscelis adeliae)  \n",
-              "247              186.0  FEMALE  Adelie Penguin (Pygoscelis adeliae)  "
-            ]
-          },
-          "execution_count": 12,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "# Learn from the training data how to predict output y\n",
-        "pipeline.fit(X_train, y_train)\n",
-        "\n",
-        "# Predict y for the test data\n",
-        "y_pred = pipeline.predict(X_test)\n",
-        "\n",
-        "# View predictions preview\n",
-        "y_pred.peek()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Evaluate results\n",
-        "\n",
-        "Some models include a convenient `.score(X, y)` method for evaulation with a preset accuracy metric:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 13,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "Query job 33f30db0-43ab-47f4-ae17-bf8c7e5e8bdc is DONE. 30.0 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:33f30db0-43ab-47f4-ae17-bf8c7e5e8bdc&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job 0a49d654-7883-409b-bc8f-3b16eeee873b is DONE. 48 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:0a49d654-7883-409b-bc8f-3b16eeee873b&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>mean_absolute_error</th>\n",
-              "      <th>mean_squared_error</th>\n",
-              "      <th>mean_squared_log_error</th>\n",
-              "      <th>median_absolute_error</th>\n",
-              "      <th>r2_score</th>\n",
-              "      <th>explained_variance</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>233.280852</td>\n",
-              "      <td>79664.958768</td>\n",
-              "      <td>0.004725</td>\n",
-              "      <td>200.960554</td>\n",
-              "      <td>0.889414</td>\n",
-              "      <td>0.897374</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "<p>1 rows × 6 columns</p>\n",
-              "</div>[1 rows x 6 columns in total]"
-            ],
-            "text/plain": [
-              "   mean_absolute_error  mean_squared_error  mean_squared_log_error  \\\n",
-              "0           233.280852        79664.958768                0.004725   \n",
-              "\n",
-              "   median_absolute_error  r2_score  explained_variance  \n",
-              "0             200.960554  0.889414            0.897374  \n",
-              "\n",
-              "[1 rows x 6 columns]"
-            ]
-          },
-          "execution_count": 13,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "pipeline.score(X_test, y_test)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "For a more general approach, the library `bigframes.ml.metrics` is provided:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 14,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "Query job d42f72e4-c1dc-4859-8d2f-99e09006ed64 is DONE. 28.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:d42f72e4-c1dc-4859-8d2f-99e09006ed64&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job 5b8dc932-3d79-47ab-b43a-8cd987091883 is DONE. 28.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:5b8dc932-3d79-47ab-b43a-8cd987091883&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job b93b8f2f-533d-46b7-b320-0349cee22635 is DONE. 30.0 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:b93b8f2f-533d-46b7-b320-0349cee22635&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/plain": [
-              "0.8894138438612413"
-            ]
-          },
-          "execution_count": 14,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "from bigframes.ml.metrics import r2_score\n",
-        "\n",
-        "r2_score(y_test, y_pred[\"predicted_body_mass_g\"])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "## Generative AI with BigQuery DataFrames\n",
-        "\n",
-        "BigQuery DataFrames integration with the Large Language Models (LLM) supported by BigQuery ML. Check out the [`bigframes.ml.llm`](https://cloud.google.com/python/docs/reference/bigframes/latest/bigframes.ml.llm) module for all the available models."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Create prompts\n",
-        "\n",
-        "A \"prompt\" text column can be initialized either directly or via the pandas APIs. For simplicity let's use a direct initialization here."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 44,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "Query job 180784d4-bff2-4165-9958-07f77b711980 is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:180784d4-bff2-4165-9958-07f77b711980&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>prompt</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>What is BigQuery?</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>What is BQML?</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2</th>\n",
-              "      <td>What is BigQuery DataFrames?</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "<p>3 rows × 1 columns</p>\n",
-              "</div>[3 rows x 1 columns in total]"
-            ],
-            "text/plain": [
-              "                         prompt\n",
-              "0             What is BigQuery?\n",
-              "1                 What is BQML?\n",
-              "2  What is BigQuery DataFrames?\n",
-              "\n",
-              "[3 rows x 1 columns]"
-            ]
-          },
-          "execution_count": 44,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "df = bpd.DataFrame(\n",
-        "        {\n",
-        "            \"prompt\": [\"What is BigQuery?\", \"What is BQML?\", \"What is BigQuery DataFrames?\"],\n",
-        "        })\n",
-        "df"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "### Generate responses\n",
-        "\n",
-        "Here we will use the [`GeminiTextGenerator`](https://cloud.google.com/python/docs/reference/bigframes/latest/bigframes.ml.llm.GeminiTextGenerator) LLM to answer the questions. Read the API documentation for all the model versions supported via the `model_name` param."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 45,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "Query job aefe66a0-70da-44e4-89be-05a152b046f8 is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:aefe66a0-70da-44e4-89be-05a152b046f8&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job 8b3b543d-e4a2-4534-b55a-6a499e958108 is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:8b3b543d-e4a2-4534-b55a-6a499e958108&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "/usr/local/google/home/shobs/code/bigframes/bigframes/core/__init__.py:109: PreviewWarning: Interpreting JSON column(s) as StringDtype. This behavior may change in future versions.\n",
-            "  warnings.warn(\n"
-          ]
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job cef454ea-1d31-4de4-a724-eed712e36d2c is DONE. 6 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:cef454ea-1d31-4de4-a724-eed712e36d2c&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "Query job 1eb4c2a5-9626-40fb-a346-1e6c137c5239 is DONE. 10.7 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:1eb4c2a5-9626-40fb-a346-1e6c137c5239&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "data": {
-            "text/html": [
-              "<div>\n",
-              "<style scoped>\n",
-              "    .dataframe tbody tr th:only-of-type {\n",
-              "        vertical-align: middle;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe tbody tr th {\n",
-              "        vertical-align: top;\n",
-              "    }\n",
-              "\n",
-              "    .dataframe thead th {\n",
-              "        text-align: right;\n",
-              "    }\n",
-              "</style>\n",
-              "<table border=\"1\" class=\"dataframe\">\n",
-              "  <thead>\n",
-              "    <tr style=\"text-align: right;\">\n",
-              "      <th></th>\n",
-              "      <th>ml_generate_text_llm_result</th>\n",
-              "      <th>ml_generate_text_rai_result</th>\n",
-              "      <th>ml_generate_text_status</th>\n",
-              "      <th>prompt</th>\n",
-              "    </tr>\n",
-              "  </thead>\n",
-              "  <tbody>\n",
-              "    <tr>\n",
-              "      <th>0</th>\n",
-              "      <td>BigQuery is a serverless, highly scalable, and...</td>\n",
-              "      <td>[{\"category\":1,\"probability\":1,\"probability_sc...</td>\n",
-              "      <td></td>\n",
-              "      <td>What is BigQuery?</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>1</th>\n",
-              "      <td>## BQML: Bringing Quantum Machine Learning to ...</td>\n",
-              "      <td>[{\"category\":1,\"probability\":1,\"probability_sc...</td>\n",
-              "      <td></td>\n",
-              "      <td>What is BQML?</td>\n",
-              "    </tr>\n",
-              "    <tr>\n",
-              "      <th>2</th>\n",
-              "      <td>## BigQuery DataFrames\n",
-              "\n",
-              "BigQuery DataFrames is...</td>\n",
-              "      <td>[{\"category\":1,\"probability\":1,\"probability_sc...</td>\n",
-              "      <td></td>\n",
-              "      <td>What is BigQuery DataFrames?</td>\n",
-              "    </tr>\n",
-              "  </tbody>\n",
-              "</table>\n",
-              "<p>3 rows × 4 columns</p>\n",
-              "</div>[3 rows x 4 columns in total]"
-            ],
-            "text/plain": [
-              "                         ml_generate_text_llm_result  \\\n",
-              "0  BigQuery is a serverless, highly scalable, and...   \n",
-              "1  ## BQML: Bringing Quantum Machine Learning to ...   \n",
-              "2  ## BigQuery DataFrames\n",
-              "\n",
-              "BigQuery DataFrames is...   \n",
-              "\n",
-              "                         ml_generate_text_rai_result ml_generate_text_status  \\\n",
-              "0  [{\"category\":1,\"probability\":1,\"probability_sc...                           \n",
-              "1  [{\"category\":1,\"probability\":1,\"probability_sc...                           \n",
-              "2  [{\"category\":1,\"probability\":1,\"probability_sc...                           \n",
-              "\n",
-              "                         prompt  \n",
-              "0             What is BigQuery?  \n",
-              "1                 What is BQML?  \n",
-              "2  What is BigQuery DataFrames?  \n",
-              "\n",
-              "[3 rows x 4 columns]"
-            ]
-          },
-          "execution_count": 45,
-          "metadata": {},
-          "output_type": "execute_result"
-        }
-      ],
-      "source": [
-        "from bigframes.ml.llm import GeminiTextGenerator\n",
-        "\n",
-        "model = GeminiTextGenerator()\n",
-        "\n",
-        "pred = model.predict(df)\n",
-        "pred"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "Let's print the full text response for the question \"What is BigQuery DataFrames?\"."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 46,
-      "metadata": {},
-      "outputs": [
-        {
-          "data": {
-            "text/html": [
-              "Query job d5fed4ed-26c2-45a6-b842-3af8c901985c is DONE. 10.7 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:d5fed4ed-26c2-45a6-b842-3af8c901985c&page=queryresults\">Open Job</a>"
-            ],
-            "text/plain": [
-              "<IPython.core.display.HTML object>"
-            ]
-          },
-          "metadata": {},
-          "output_type": "display_data"
-        },
-        {
-          "name": "stdout",
-          "output_type": "stream",
-          "text": [
-            "## BigQuery DataFrames\n",
-            "\n",
-            "BigQuery DataFrames is an open-source project offered by Google that provides the capabilities of using pandas-style APIs directly in BigQuery's serverless environment for performing SQL and DDL queries. This essentially means you have the flexibility to write pandas code within BigQuery for data exploration, transformation,  visualization and building machine learning models. It acts as an intermediary bridge that facilitates SQL queries to the BigQuery engine for running your analysis with speed and scalability on large datasets without requiring manual configuration. It can further extend its functionalities through third-party libraries like scikit-learn, matplotlib, seaborn etc., enhancing its versatility within the realm of data manipulation.\n",
-            "\n",
-            "Here's are some key benefits associated with BigQuery DataFrames:\n",
-            "\n",
-            "\n",
-            "### Streamlined Experience:\n",
-            "\n",
-            "BigQuery DataFrames simplifies your development workflow by eliminating the back-and-forth communication between pandas and BigQuery environments for data operations. It allows working seamlessly within BigQuery to leverage powerful SQL features while using familiar pandas functions on data stored within. This enables a smoother process from ingesting, analyzing, and visualizing your data efficiently.\n",
-            "\n",
-            "### Serverless Infrastructure:\n",
-            "\n",
-            "One of the greatest advantages of BigQuery DataFrames is that it runs on serverless infrastructure, eliminating the need to maintain complex environments for development. This translates to less complexity, easy management, and a focus on efficient analysis rather than infrastructure upkeep.\n",
-            "\n",
-            "### Scalable Capabilities:\n",
-            "\n",
-            "As mentioned, BigQuery excels in dealing with immense data sets with efficient storage and processing power due to its architecture built for handling petabyte-scale datasets in Google Cloud Storage. DataFrames inherits this strength, empowering the analysis of vast information while ensuring speed and reliability throughout.\n",
-            "\n",
-            "### Open-source Ecosystem:\n",
-            "\n",
-            "While Google spearheads its initial creation, DataFrames benefits immensely from its open-source structure. This fosters community-wide involvement in its advancement; developers are continually making contributions that bolster functionalities, introduce improvements with regular updates and fixes.\n",
-            "\n",
-            "Here are a few scenarios where using BigQuery DataFrames might prove particularly valuable:\n",
-            "\n",
-            "-   Performing exploratory analysis on a diverse range of dataset directly on serverless infrastructure with scalability, saving valuable operational cost and time.\n",
-            "\n",
-            "-   Implementing data preprocessing steps using Python and DataFrames within Google Cloud Platform without having to transfer and analyze it elsewhere, streamlining workflow within the same framework.\n",
-            "\n",
-            "-   When building and training ML models directly from datasets without exporting the data outside, maintaining security within and improving efficiency.\n",
-            "\n",
-            "\n",
-            "However, be aware that DataFrames is an ever-evolving project and some aspects such as DML functionalities remain under active development to reach feature completion as compared to standard SQL commands which have matured functionality already in place within DataFrames.\n",
-            "\n",
-            "\n",
-            "Would you like me to delve deeper into specific features of DataFrames, its current limitations or perhaps provide examples of its applications or user cases?\n"
-          ]
-        }
-      ],
-      "source": [
-        "print(pred.loc[2][\"ml_generate_text_llm_result\"])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "TpV-iwP9qw9c"
-      },
-      "source": [
-        "## Cleaning up\n",
-        "\n",
-        "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
-        "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
-        "\n",
-        "To remove any temporary cloud artifacts (inclusing BQ tables) created in the current BigQuery DataFrames session, simply call `close_session`."
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": 15,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Delete the temporary cloud artifacts created during the bigframes session \n",
-        "bpd.close_session()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {
-        "id": "wCsmt0IwFkDy"
-      },
-      "source": [
-        "## Summary and next steps\n",
-        "\n",
-        "1. You created BigQuery DataFrames objects, and inspected and manipulated data with pandas APIs at BigQuery scale and speed.\n",
-        "\n",
-        "1. You also created ML model from a DataFrame and used them to run predictions on another DataFrame.\n",
-        "\n",
-        "1. You got access to Google's state-of-the-art Gemini LLM through simple pythonic API.\n",
-        "\n",
-        "Learn more about BigQuery DataFrames in the documentation [BigQuery DataFrames](https://cloud.google.com/bigquery/docs/bigquery-dataframes-introduction) and its [API reference](https://cloud.google.com/python/docs/reference/bigframes/latest).\n",
-        "\n",
-        "Also, find more sample notebooks in the [GitHub repo](https://github.com/googleapis/python-bigquery-dataframes/tree/main/notebooks), including the [pypi.ipynb](https://github.com/googleapis/python-bigquery-dataframes/blob/main/notebooks/dataframes/pypi.ipynb) that processes 400+ TB data at the cost and efficiency close to direct SQL by taking advantage of the [partial ordering](https://cloud.google.com/python/docs/reference/bigframes/latest/bigframes._config.bigquery_options.BigQueryOptions#bigframes__config_bigquery_options_BigQueryOptions_ordering_mode) mode."
-      ]
-    }
-  ],
-  "metadata": {
-    "colab": {
-      "provenance": [],
-      "toc_visible": true
-    },
-    "kernelspec": {
-      "display_name": "Python 3",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.10.12"
-    }
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "ur8xi4C7S06n"
+   },
+   "outputs": [],
+   "source": [
+    "# Copyright 2023 Google LLC\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     https://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 0
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "JAPoU8Sm5E6e"
+   },
+   "source": [
+    "# Get started with BigQuery DataFrames\n",
+    "\n",
+    "<table align=\"left\">\n",
+    "\n",
+    "  <td>\n",
+    "    <a href=\"https://colab.research.google.com/github/googleapis/python-bigquery-dataframes/blob/main/notebooks/getting_started/bq_dataframes_template.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/colab-logo-32px.png\" alt=\"Colab logo\"> Run in Colab\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://github.com/googleapis/python-bigquery-dataframes/blob/main/notebooks/getting_started/bq_dataframes_template.ipynb\">\n",
+    "      <img src=\"https://cloud.google.com/ml-engine/images/github-logo-32px.png\" alt=\"GitHub logo\">\n",
+    "      View on GitHub\n",
+    "    </a>\n",
+    "  </td>\n",
+    "  <td>\n",
+    "    <a href=\"https://console.cloud.google.com/vertex-ai/workbench/deploy-notebook?download_url=https://raw.githubusercontent.com/googleapis/python-bigquery-dataframes/blob/main/notebooks/getting_started/bq_dataframes_template.ipynb\">\n",
+    "      <img src=\"https://lh3.googleusercontent.com/UiNooY4LUgW_oTvpsNhPpQzsstV5W8F7rYgxgGBD85cWJoLmrOzhVs_ksK_vgx40SHs7jCqkTkCk=e14-rj-sc0xffffff-h130-w32\" alt=\"Vertex AI logo\">\n",
+    "      Open in Vertex AI Workbench\n",
+    "    </a>\n",
+    "  </td>                                                                                               \n",
+    "</table>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "24743cf4a1e1"
+   },
+   "source": [
+    "**_NOTE_**: This notebook has been tested in the following environment:\n",
+    "\n",
+    "* Python version = 3.10"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "tvgnzT1CKxrO"
+   },
+   "source": [
+    "## Overview\n",
+    "\n",
+    "BigQuery DataFrames (also known as BigFrames) provides a Pythonic DataFrame and machine learning (ML) API powered by the BigQuery engine.\n",
+    "\n",
+    "* `bigframes.pandas` provides a pandas-like API for analytics.\n",
+    "* `bigframes.ml` provides a scikit-learn-like API for ML.\n",
+    "* `bigframes.ml.llm` provides API for large language models including Gemini.\n",
+    "\n",
+    "You can learn more about [BigQuery DataFrames](https://cloud.google.com/bigquery/docs/bigquery-dataframes-introduction) and its [API reference](https://cloud.google.com/python/docs/reference/bigframes/latest).\n",
+    "\n",
+    "For any issues or feedback please reach out to bigframes-feedback@google.com."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "BF1j6f9HApxa"
+   },
+   "source": [
+    "## Before you begin\n",
+    "\n",
+    "Complete the tasks in this section to set up your environment."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "Yq7zKYWelRQP"
+   },
+   "source": [
+    "### Install the python package\n",
+    "\n",
+    "You need the [bigframes](https://pypi.org/project/bigframes/) python package to be installed. If you don't have that, uncomment and run the following cell and *restart the kernel*."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#%pip install  --upgrade"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "WReHDGG5g0XY"
+   },
+   "source": [
+    "### Set your project id and location\n",
+    "\n",
+    "Following are some quick references:\n",
+    "\n",
+    "* Google Cloud Project: https://cloud.google.com/resource-manager/docs/creating-managing-projects.\n",
+    "* BigQuery Location: https://cloud.google.com/bigquery/docs/locations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "oM1iC_MfAts1"
+   },
+   "outputs": [],
+   "source": [
+    "PROJECT_ID = \"\"  # @param {type: \"string\"}\n",
+    "LOCATION = \"US\"  # @param {type: \"string\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "960505627ddf"
+   },
+   "source": [
+    "### Import library"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "PyQmSRbKA8r-"
+   },
+   "outputs": [],
+   "source": [
+    "import bigframes.pandas as bpd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "init_aip:mbsdk,all"
+   },
+   "source": [
+    "\n",
+    "### Set BigQuery DataFrames options"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "NPPMuw2PXGeo"
+   },
+   "outputs": [],
+   "source": [
+    "# Note: The project option is not required in all environments.\n",
+    "# On BigQuery Studio, the project ID is automatically detected.\n",
+    "bpd.options.bigquery.project = PROJECT_ID\n",
+    "\n",
+    "# Note: The location option is not required.\n",
+    "# It defaults to the location of the first table or query\n",
+    "# passed to read_gbq(). For APIs where a location can't be\n",
+    "# auto-detected, the location defaults to the \"US\" location.\n",
+    "bpd.options.bigquery.location = LOCATION\n",
+    "\n",
+    "# Note: BigQuery DataFrames objects are by default fully ordered like Pandas.\n",
+    "# If ordering is not important for you, you can uncomment the following\n",
+    "# expression to run BigQuery DataFrames in partial ordering mode.\n",
+    "#bpd.options.bigquery.ordering_mode = \"partial\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "pDfrKwMKE_dK"
+   },
+   "source": [
+    "If you want to reset the project and/or location of the created DataFrame or Series objects, reset the session by executing `bpd.close_session()`. After that, you can redo the above steps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Query using the BigQuery magics\n",
+    "\n",
+    "Running this code will query a table in BigQuery create a DataFrame named `_bq_df`.\n",
+    "Learn more in the [Visualizing BigQuery data guide in notebooks](https://cloud.google.com/bigquery/docs/visualize-jupyter).\n",
+    "\n",
+    "This example uses a\n",
+    "[penguin public dataset](https://console.cloud.google.com/bigquery?p=bigquery-public-data&d=ml_datasets&t=penguins&page=table&_ga=2.251359750.1031997792.1692116300-1119797950.1692116300).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%bqsql\n",
+    "SELECT * FROM `bigquery-public-data.ml_datasets.penguins`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "9EMAqR37AfLS"
+   },
+   "source": [
+    "## Create a BigQuery DataFrames DataFrame\n",
+    "\n",
+    "You can create a BigQuery DataFrames DataFrame by reading data from any of the\n",
+    "following locations:\n",
+    "\n",
+    "* A local data file\n",
+    "* Data stored in a BigQuery table\n",
+    "* A data file stored in Cloud Storage\n",
+    "* An in-memory pandas DataFrame\n",
+    "\n",
+    "Note that the DataFrame does not copy the data to the local memory, instead\n",
+    "keeps the underlying data in a BigQuery table during read and analysis. That's\n",
+    "how it can handle really large size of data (at BigQuery Scale) independent of\n",
+    "the local memory.\n",
+    "\n",
+    "For simplicity, speed and cost efficiency, this tutorial uses the\n",
+    "[`penguins`](https://pantheon.corp.google.com/bigquery?ws=!1m5!1m4!4m3!1sbigquery-public-data!2sml_datasets!3spenguins)\n",
+    "table from BigQuery public data, which contains 27 KB data about a set of\n",
+    "penguins - species, island of residence, culmen length and depth, flipper length\n",
+    "and sex. There is a version of this data in the Cloud Storage\n",
+    "[cloud samples data](https://pantheon.corp.google.com/storage/browser/_details/cloud-samples-data/vertex-ai/bigframe/penguins.csv)\n",
+    "as well."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "Vyex9BQI-BNa"
+   },
+   "outputs": [],
+   "source": [
+    "# This is how you read a BigQuery table\n",
+    "df = bpd.read_gbq(\"bigquery-public-data.ml_datasets.penguins\")\n",
+    "\n",
+    "# This is how you would read a csv from the Cloud Storage\n",
+    "#df = bpd.read_csv(\"gs://cloud-samples-data/vertex-ai/bigframe/penguins.csv\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use `peek` to preview a few rows (selected arbitrarily) from the dataframes:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.peek()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "gE6CEALjDZZV"
+   },
+   "source": [
+    "We just created a DataFrame, `df`, refering to the entirety of the source table data, without downloading it to the local machine."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "rwPLjqW2Ajzh"
+   },
+   "source": [
+    "## Inspect and manipulate data in BigQuery DataFrames"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "bExmYlL_ELtV"
+   },
+   "source": [
+    "### Using pandas API\n",
+    "\n",
+    "You can use pandas API on the BigQuery DataFrames DataFrame as you normally would in Pandas, but computation happens in the BigQuery query engine instead of your local environment."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "EJIZJaNXFQzh"
+   },
+   "source": [
+    "Let's compute the mean of the `body_mass_g` series:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "YKwCW7Nsavap"
+   },
+   "outputs": [],
+   "source": [
+    "average_body_mass = df[\"body_mass_g\"].mean()\n",
+    "print(f\"average_body_mass: {average_body_mass}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "DSs1cnca-MOU"
+   },
+   "source": [
+    "Calculate the mean `body_mass_g` by `species` using the `groupby` operation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "id": "4PyKMR61-Mjy"
+   },
+   "outputs": [],
+   "source": [
+    "df[[\"species\", \"body_mass_g\"]].groupby(by=df[\"species\"]).mean(numeric_only=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "6sf9kZ2C9Ixe"
+   },
+   "source": [
+    "You can confirm that the calculations were run in BigQuery by clicking \"Open job\" from the previous cells' output. This takes you to the BigQuery console to view the SQL statement and job details."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Visualize data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### First party visualizations\n",
+    "\n",
+    "BigQuery DataFrames provides a number of visualizations via the `plot` method and [accessor](https://cloud.google.com/python/docs/reference/bigframes/latest/bigframes.operations.plotting.PlotAccessor) on the DataFrame and Series objects."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.plot(title=\"Numeric features\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "means = df.groupby(\"species\").mean(numeric_only=True)\n",
+    "means.plot.bar()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Integration with open source visualizations\n",
+    "\n",
+    "BigQuery Dataframes is also compatible with several open source visualization packages, such as `matplotlib`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "# plotting a histogram\n",
+    "species_counts = df[\"species\"].value_counts()\n",
+    "plt.pie(species_counts, labels=species_counts.index, autopct='%1.1f%%')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Pandas interoperability\n",
+    "\n",
+    "BigQuery DataFrames can be converted from and to Pandas DataFrame with `to_pandas` and `read_pandas` respectively.\n",
+    "This could be handy to take advantage of the capabilities of the two systems.\n",
+    "\n",
+    "> Note: `to_pandas` converts the BigQuery DataFrame to Pandas DataFrame by bringing all the data in memory, which would be an issue\n",
+    "for large data, as your machine may not have enough memory to accommodate that."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def print_type(df):\n",
+    "    print(f\"\\nWe have a dataframe of {type(df)}\\n\")\n",
+    "\n",
+    "# The original bigframes dataframe\n",
+    "cur_df = df\n",
+    "print_type(cur_df)\n",
+    "\n",
+    "# Convert to pandas dataframe\n",
+    "cur_df = cur_df.to_pandas()\n",
+    "print_type(cur_df)\n",
+    "\n",
+    "# Convert back to bigframes dataframe\n",
+    "cur_df = bpd.read_pandas(cur_df)\n",
+    "print_type(cur_df)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Machine Learning with BigQuery DataFrames"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Clean and prepare data\n",
+    "\n",
+    "We're are going to start with supervised learning, where a Linear Regression model will learn to predict the body mass (output variable `y`) using input features such as flipper length, sex, species, and more (features `X`)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Drop any rows that has missing (NA) values\n",
+    "df = df.dropna()\n",
+    "\n",
+    "# Isolate input features and output variable into DataFrames\n",
+    "X = df[['island', 'culmen_length_mm', 'culmen_depth_mm', 'flipper_length_mm', 'sex', 'species']]\n",
+    "y = df[['body_mass_g']]\n",
+    "\n",
+    "# Print the shapes of features and label\n",
+    "print(f\"\"\"\n",
+    "    X shape: {X.shape}\n",
+    "    y shape: {y.shape}\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Part of preparing data for a machine learning task is splitting it into subsets for training and testing to ensure that the solution is not overfitting. By default, BQML will automatically manage splitting the data for you. However, BQML also supports manually splitting out your training data.\n",
+    "\n",
+    "Performing a manual data split can be done with `bigframes.ml.model_selection.train_test_split` like so:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bigframes.ml.model_selection import train_test_split\n",
+    "\n",
+    "# This will split X and y into test and training sets, with 20% of the rows in the test set,\n",
+    "# and the rest in the training set\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2)\n",
+    "\n",
+    "# Show the shape of the data after the split\n",
+    "print(f\"\"\"\n",
+    "    X_train shape: {X_train.shape}\n",
+    "    X_test shape: {X_test.shape}\n",
+    "    y_train shape: {y_train.shape}\n",
+    "    y_test shape: {y_test.shape}\n",
+    "\"\"\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define pipeline\n",
+    "\n",
+    "This step is subjective to the problem. Although a model can be directly trained on the original data, it is often useful to apply some preprocessing to the original data.\n",
+    "In this example we want to apply a [`ColumnTransformer`](https://cloud.google.com/python/docs/reference/bigframes/latest/bigframes.ml.compose.ColumnTransformer) in which we apply [`OneHotEncoder`](https://cloud.google.com/python/docs/reference/bigframes/latest/bigframes.ml.preprocessing.OneHotEncoder) to the category features and [`StandardScaler`](https://cloud.google.com/python/docs/reference/bigframes/latest/bigframes.ml.preprocessing.StandardScaler) to the numeric features."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bigframes.ml.linear_model import LinearRegression\n",
+    "from bigframes.ml.pipeline import Pipeline\n",
+    "from bigframes.ml.compose import ColumnTransformer\n",
+    "from bigframes.ml.preprocessing import StandardScaler, OneHotEncoder\n",
+    "\n",
+    "preprocessing = ColumnTransformer([\n",
+    "    (\"onehot\", OneHotEncoder(), [\"island\", \"species\", \"sex\"]),\n",
+    "    (\"scaler\", StandardScaler(), [\"culmen_depth_mm\", \"culmen_length_mm\", \"flipper_length_mm\"]),\n",
+    "])\n",
+    "\n",
+    "model = LinearRegression(fit_intercept=False)\n",
+    "\n",
+    "pipeline = Pipeline([\n",
+    "    ('preproc', preprocessing),\n",
+    "    ('linreg', model)\n",
+    "])\n",
+    "\n",
+    "# View the pipeline\n",
+    "pipeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Train and Predict\n",
+    "\n",
+    "Supervised learning is when we train a model on input-output pairs, and then ask it to predict the output for new inputs. An example of such a predictor is `bigframes.ml.linear_models.LinearRegression`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Learn from the training data how to predict output y\n",
+    "pipeline.fit(X_train, y_train)\n",
+    "\n",
+    "# Predict y for the test data\n",
+    "y_pred = pipeline.predict(X_test)\n",
+    "\n",
+    "# View predictions preview\n",
+    "y_pred.peek()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Evaluate results\n",
+    "\n",
+    "Some models include a convenient `.score(X, y)` method for evaulation with a preset accuracy metric:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pipeline.score(X_test, y_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For a more general approach, the library `bigframes.ml.metrics` is provided:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bigframes.ml.metrics import r2_score\n",
+    "\n",
+    "r2_score(y_test, y_pred[\"predicted_body_mass_g\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generative AI with BigQuery DataFrames\n",
+    "\n",
+    "BigQuery DataFrames integration with the Large Language Models (LLM) supported by BigQuery ML. Check out the [`bigframes.ml.llm`](https://cloud.google.com/python/docs/reference/bigframes/latest/bigframes.ml.llm) module for all the available models."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create prompts\n",
+    "\n",
+    "A \"prompt\" text column can be initialized either directly or via the pandas APIs. For simplicity let's use a direct initialization here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = bpd.DataFrame(\n",
+    "        {\n",
+    "            \"prompt\": [\"What is BigQuery?\", \"What is BQML?\", \"What is BigQuery DataFrames?\"],\n",
+    "        })\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Generate responses\n",
+    "\n",
+    "Here we will use the [`GeminiTextGenerator`](https://cloud.google.com/python/docs/reference/bigframes/latest/bigframes.ml.llm.GeminiTextGenerator) LLM to answer the questions. Read the API documentation for all the model versions supported via the `model_name` param."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bigframes.ml.llm import GeminiTextGenerator\n",
+    "\n",
+    "model = GeminiTextGenerator()\n",
+    "\n",
+    "pred = model.predict(df)\n",
+    "pred"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's print the full text response for the question \"What is BigQuery DataFrames?\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(pred.loc[2][\"ml_generate_text_llm_result\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "TpV-iwP9qw9c"
+   },
+   "source": [
+    "## Cleaning up\n",
+    "\n",
+    "To clean up all Google Cloud resources used in this project, you can [delete the Google Cloud\n",
+    "project](https://cloud.google.com/resource-manager/docs/creating-managing-projects#shutting_down_projects) you used for the tutorial.\n",
+    "\n",
+    "To remove any temporary cloud artifacts (inclusing BQ tables) created in the current BigQuery DataFrames session, simply call `close_session`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete the temporary cloud artifacts created during the bigframes session \n",
+    "bpd.close_session()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "id": "wCsmt0IwFkDy"
+   },
+   "source": [
+    "## Summary and next steps\n",
+    "\n",
+    "1. You created BigQuery DataFrames objects, and inspected and manipulated data with pandas APIs at BigQuery scale and speed.\n",
+    "\n",
+    "1. You also created ML model from a DataFrame and used them to run predictions on another DataFrame.\n",
+    "\n",
+    "1. You got access to Google's state-of-the-art Gemini LLM through simple pythonic API.\n",
+    "\n",
+    "Learn more about BigQuery DataFrames in the documentation [BigQuery DataFrames](https://cloud.google.com/bigquery/docs/bigquery-dataframes-introduction) and its [API reference](https://cloud.google.com/python/docs/reference/bigframes/latest).\n",
+    "\n",
+    "Also, find more sample notebooks in the [GitHub repo](https://github.com/googleapis/python-bigquery-dataframes/tree/main/notebooks), including the [pypi.ipynb](https://github.com/googleapis/python-bigquery-dataframes/blob/main/notebooks/dataframes/pypi.ipynb) that processes 400+ TB data at the cost and efficiency close to direct SQL by taking advantage of the [partial ordering](https://cloud.google.com/python/docs/reference/bigframes/latest/bigframes._config.bigquery_options.BigQueryOptions#bigframes__config_bigquery_options_BigQueryOptions_ordering_mode) mode."
+   ]
+  }
+ ],
+ "metadata": {
+  "colab": {
+   "provenance": [],
+   "toc_visible": true
+  },
+  "kernelspec": {
+   "display_name": "venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ description = (
 release_status = "Development Status :: 5 - Production/Stable"
 dependencies = [
     # please keep these in sync with the minimum versions in testing/constraints-3.9.txt
+    "bigquery-magics >= 0.5.0",
     "cloudpickle >= 2.0.0",
     "fsspec >=2023.3.0",
     "gcsfs >=2023.3.0",

--- a/testing/constraints-3.11.txt
+++ b/testing/constraints-3.11.txt
@@ -1,0 +1,2 @@
+# IMPORTANT: When Python 3.10 support is dropped, update these to
+# match the minimums in setup.py.

--- a/testing/constraints-3.12.txt
+++ b/testing/constraints-3.12.txt
@@ -1,0 +1,2 @@
+# IMPORTANT: When Python 3.11 support is dropped, update these to
+# match the minimums in setup.py.

--- a/testing/constraints-3.13.txt
+++ b/testing/constraints-3.13.txt
@@ -1,0 +1,2 @@
+# IMPORTANT: When Python 3.12 support is dropped, update these to
+# match the minimums in setup.py.

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -1,4 +1,5 @@
 # please keep these in sync with the minimum versions in setup.py
+bigquery-magics==0.5.0
 cloudpickle==2.0.0
 fsspec==2023.3.0
 gcsfs==2023.3.0


### PR DESCRIPTION
BREAKING-CHANGE: notebooks that mix the %%bigquery / %%bqsql magics and the bigframes module will use bigframes for DataFrame output by default
Release-As: 1.30.0

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes internal issue 384564457 🦕
