### PR TITLE
chore: update semantic operator notebook

### DIFF
--- a/notebooks/experimental/semantic_operators.ipynb
+++ b/notebooks/experimental/semantic_operators.ipynb
@@ -25,24 +25,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# BigFrames Semantic Operator Demo"
+    "# BigQuery DataFrames Semantic Operator Demo"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We implemented the semantics operators based on the idea in the \"Lotus\" paper: https://arxiv.org/pdf/2407.11418.\n",
+    "The BigQuery DataFrames team implements semantics operators as described in the \"Lotus\" paper: https://arxiv.org/pdf/2407.11418.\n",
     "\n",
-    "This notebook gives you a hands-on preview of semantic operator APIs powered by LLM. The demonstration is devided into two sections: \n",
+    "This notebook gives you a hands-on preview of semantic operator APIs powered by LLM. You can open this notebook on Google Colab [here](https://colab.research.google.com/github/googleapis/python-bigquery-dataframes/blob/main/notebooks/experimental/semantic_operators.ipynb). \n",
     "\n",
-    "The first section introduces the API syntax with some simple examples. We aim to get you familiar with how BigFrames semantic operators work. \n",
-    "\n",
-    "The second section talks about applying semantic operators on real-world large datasets. The examples are designed to benchmark the performance of the operators, and to (maybe) spark some ideas for your next application scenarios.\n",
-    "\n",
-    "You can open this notebook on Google Colab [here](https://colab.research.google.com/github/googleapis/python-bigquery-dataframes/blob/main/notebooks/experimental/semantic_operators.ipynb).\n",
-    "\n",
-    "Without further ado, let's get started."
+    "The notebook has two sections. The first section introduces the API syntax with examples, with the aim to get you familiar with how semantic operators work. The second section applies semantic operators on a large real-world dataset. You will also find some performance statistics there."
    ]
   },
   {
@@ -56,7 +50,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "First, let's import BigFrames packages."
+    "First, import the BigQuery DataFrames modules."
    ]
   },
   {
@@ -91,7 +85,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Turn on the semantic operator experiment. You will see a warning sign saying that these operators are still under experiments. This is a necessary step. Otherwise you will see `NotImplementedError` when calling these operators."
+    "Turn on the semantic operator experiment. You will see a warning sign saying that these operators are still under experiments. If you don't turn on the experiment before using the operators, you will get `NotImplemenetedError`s."
    ]
   },
   {
@@ -132,7 +126,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's also create some LLM instances for these operators. They will be passed in as paramters in each method call."
+    "Create LLM instances. They will be passed in as parameters for each semantic operator."
    ]
   },
   {
@@ -150,8 +144,8 @@
     }
    ],
    "source": [
-    "import bigframes.ml.llm as llm\n",
-    "gemini_model = llm.GeminiTextGenerator(model_name=llm._GEMINI_1P5_FLASH_001_ENDPOINT)\n",
+    "from bigframes.ml import llm\n",
+    "gemini_model = llm.GeminiTextGenerator(model_name=\"gemini-1.5-flash-001\")\n",
     "text_embedding_model = llm.TextEmbeddingGenerator(model_name=\"text-embedding-005\")"
    ]
   },
@@ -166,7 +160,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this section we will go through the semantic operator APIs with small examples."
+    "You will learn about each semantic operator by trying some examples."
    ]
   },
   {
@@ -180,7 +174,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Semantic filtering allows you to filter your dataframe based on the instruction (i.e. prompt) you provided. Let's first create a small dataframe:"
+    "Semantic filtering allows you to filter your dataframe based on the instruction (i.e. prompt) you provided. \n",
+    "\n",
+    "First, create a dataframe:"
    ]
   },
   {
@@ -257,12 +253,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, let's filter this dataframe by keeping only the rows where the value in `city` column is the capital of the value in `country` column. The column references could be \"escaped\" by using a pair of braces in your instruction. In this example, our instruction should be like this:\n",
+    "Now, filter this dataframe by keeping only the rows where the value in `city` column is the capital of the value in `country` column. The column references could be \"escaped\" by using a pair of braces in your instruction. In this example, your instruction should be like this:\n",
     "```\n",
     "The {city} is the capital of the {country}.\n",
     "```\n",
     "\n",
-    "Note that this is not a Python f-string, so you shouldn't prefix your instruction with an `f`. Let's give it a try:"
+    "Note that this is not a Python f-string, so you shouldn't prefix your instruction with an `f`."
    ]
   },
   {
@@ -348,7 +344,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Semantic mapping allows to you to combine values from multiple columns into a single output based your instruction. To demonstrate this, let's create an example dataframe:"
+    "Semantic mapping allows to you to combine values from multiple columns into a single output based your instruction. \n",
+    "\n",
+    "Here is an example:"
    ]
   },
   {
@@ -428,7 +426,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now, let's ask LLM what kind of food can be made from the two ingredients in each row. The column reference syntax in your instruction stays the same. In addition, you need to specify the column name by setting the `output_column` parameter to hold the mapping results."
+    "Now, you ask LLM what kind of food can be made from the two ingredients in each row. The column reference syntax in your instruction stays the same. In addition, you need to specify the column name by setting the `output_column` parameter to hold the mapping results."
    ]
   },
   {
@@ -519,13 +517,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The mechanism behind semantic mapping is very similar with semantic filtering. The one major difference: instead of asking LLM to reply true or false to each row, the operator lets LLM reply free-form strings and attach them as a new column to the dataframe."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "## Semantic Joining"
    ]
   },
@@ -533,7 +524,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Semantic joining can join two dataframes based on the instruction you provided. First, let's prepare two dataframes."
+    "Semantic joining can join two dataframes based on the instruction you provided. \n",
+    "\n",
+    "First, you prepare two dataframes:"
    ]
   },
   {
@@ -550,7 +543,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We want to join the `cities` with `continents` to form a new dataframe such that, in each row the city from the `cities` data frame is in the continent from the `continents` dataframe. We could re-use the aforementioned column reference syntax:"
+    "You want to join the `cities` with `continents` to form a new dataframe such that, in each row the city from the `cities` data frame is in the continent from the `continents` dataframe. You could re-use the aforementioned column reference syntax:"
    ]
   },
   {
@@ -640,7 +633,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "!! **Important:** Semantic join can trigger probihitively expensitve operations! This operation first cross joins two dataframes, then invokes semantic filter on each row. That means if you have two dataframes of sizes `M` and `N`, the total amount of queries sent to the LLM is on the scale of `M * N`. Therefore, we have added a parameter `max_rows`, a threshold that guards against unexpected expensive calls. With this parameter, the operator first calculates the size of your cross-joined data, and compares it with the threshold. If the size exceeds your threshold, the fuction will abort early with a `ValueError`. You can manually set the value of `max_rows` to raise or lower the threshold."
+    "!! **Important:** Semantic join can trigger probihitively expensitve operations! This operation first cross joins two dataframes, then invokes semantic filter on each row. That means if you have two dataframes of sizes `M` and `N`, the total amount of queries sent to the LLM is on the scale of `M * N`. Therefore, our team has added a parameter `max_rows`, a threshold that guards against unexpected expensive calls. With this parameter, the operator first calculates the size of your cross-joined data, and compares it with the threshold. If the size exceeds your threshold, the fuction will abort early with a `ValueError`. You can manually set the value of `max_rows` to raise or lower the threshold."
    ]
   },
   {
@@ -654,9 +647,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We use a self-join example to demonstrate a special case: what happens when the joining columns exist in both data frames? It turns out that you need to provide extra information in your column references: by attaching \"left.\" and \"right.\" prefixes to your column names. \n",
+    "This self-join example is for demonstrating a special case: what happens when the joining columns exist in both data frames? It turns out that you need to provide extra information in your column references: by attaching \"left.\" and \"right.\" prefixes to your column names. \n",
     "\n",
-    "Let's create an example data frame:"
+    "Create an example data frame:"
    ]
   },
   {
@@ -672,7 +665,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We want to compare the weights of these animals, and output all the pairs where the animal on the left is heavier than the animal on the right. In this case, we use `left.animal` and `right.animal` to differentiate the data sources:"
+    "You want to compare the weights of these animals, and output all the pairs where the animal on the left is heavier than the animal on the right. In this case, you use `left.animal` and `right.animal` to differentiate the data sources:"
    ]
   },
   {
@@ -781,7 +774,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Semantic aggregation merges all the values in a column into one. At this moment you can only aggregate a single column in each oeprator call. Let's create an example:"
+    "Semantic aggregation merges all the values in a column into one. At this moment you can only aggregate a single column in each oeprator call.\n",
+    "\n",
+    "Here is an example:"
    ]
   },
   {
@@ -884,7 +879,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's ask LLM to find the oldest movie:"
+    "You ask LLM to find the oldest movie:"
    ]
   },
   {
@@ -922,7 +917,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Instead of going through each row one by one, this operator batches multiple rows in a single request towards LLM. It then aggregates all the batched results with the same technique, until there is only one value left. You could set the batch size with `max_agg_rows` parameter, which defaults to 10."
+    "Instead of going through each row one by one, this operator first batches rows to get many  aggregation results. It then repeatly batches those results for aggregation, until there is only one value left. You could set the batch size with `max_agg_rows` parameter, which defaults to 10."
    ]
   },
   {
@@ -952,7 +947,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We want to find the top two most popular pets:"
+    "You want to find the top two most popular pets:"
    ]
   },
   {
@@ -1027,7 +1022,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Under the hood, the semantic top K operator performs pair-wise comparisons with LLM. It also adopts the quick select algorithm, which means the top K results are returns in the order of their indices instead of their ranks."
+    "Under the hood, the semantic top K operator performs pair-wise comparisons with LLM. The top K results are returned in the order of their indices instead of their ranks."
    ]
   },
   {
@@ -1041,7 +1036,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Semantic search searches the most similar values to your qury within a single column. Here is an example:"
+    "Semantic search searches the most similar values to your query within a single column. Here is an example:"
    ]
   },
   {
@@ -1124,7 +1119,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We want to get the top 2 creatures that are most similar to \"monkey\":"
+    "You want to get the top 2 creatures that are most similar to \"monkey\":"
    ]
   },
   {
@@ -1206,7 +1201,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Notice that we are using a text embedding model this time. This model generates embedding vectors for both your query as well as the values in the search space. The operator then uses BigQuery's built-in VECTOR_SEARCH function to find the nearest neighbors of your query.\n",
+    "Notice that you are using a text embedding model this time. This model generates embedding vectors for both your query as well as the values in the search space. The operator then uses BigQuery's built-in VECTOR_SEARCH function to find the nearest neighbors of your query.\n",
     "\n",
     "In addition, `score_column` is an optional parameter for storing the distances between the results and your query. If not set, the score column won't be attached to the result."
    ]
@@ -1222,7 +1217,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When you have multiple queries to search in the same value space, you could use similarity join to simplify your call. For example:"
+    "When you want to perform multiple similarity queries in the same value space, you could use similarity join to simplify your call. For example:"
    ]
   },
   {
@@ -1239,7 +1234,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this example, we want to pick the most related animal from `df2` for each value in `df1`, and this is how it's done:"
+    "In this example, you want to pick the most related animal from `df2` for each value in `df1`."
    ]
   },
   {
@@ -1336,14 +1331,14 @@
     }
    ],
    "source": [
-    "df1.semantics.sim_join(df2, left_on='animal', right_on='animal', top_k=1, model= text_embedding_model, score_column='distance')"
+    "df1.semantics.sim_join(df2, left_on='animal', right_on='animal', top_k=1, model=text_embedding_model, score_column='distance')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "!! **Important** Like semantic join, this operator can also be very expensive. To guard against unexpected processing of large dataset, use the `max_rows` parameter to provide a threshold. "
+    "!! **Important** Like semantic join, this operator can also be very expensive. To guard against unexpected processing of large dataset, use the `max_rows` parameter to specify a threshold. "
    ]
   },
   {
@@ -1373,7 +1368,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We want to cluster these products into 3 groups, and this is how:"
+    "You want to cluster these products into 3 groups:"
    ]
   },
   {
@@ -1420,17 +1415,17 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>Smartphone</td>\n",
-       "      <td>1</td>\n",
+       "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>Laptop</td>\n",
-       "      <td>1</td>\n",
+       "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>Coffee Maker</td>\n",
-       "      <td>3</td>\n",
+       "      <td>2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -1449,9 +1444,9 @@
       ],
       "text/plain": [
        "        Product  Cluster ID\n",
-       "0    Smartphone           1\n",
-       "1        Laptop           1\n",
-       "2  Coffee Maker           3\n",
+       "0    Smartphone           2\n",
+       "1        Laptop           2\n",
+       "2  Coffee Maker           2\n",
        "3       T-shirt           2\n",
        "4         Jeans           2\n",
        "\n",
@@ -1471,7 +1466,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This operator uses the the embedding model to generate vectors for each value, and then uses KMeans algorithm to group them."
+    "This operator uses the the embedding model to generate vectors for each value, and then the KMeans algorithm for clustering."
    ]
   },
   {
@@ -1485,7 +1480,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this section we will use BigQuery's public data of hacker news to perform some heavy work. First, let's load 3K rows from the table:"
+    "In this section, you will use BigQuery's public data of hacker news to perform some heavy work. We recommend you to check the code without executing them in order to save your time and money. The execution results are attached after each cell for your reference.\n",
+    "\n",
+    "First, load 3K rows from the table:"
    ]
   },
   {
@@ -1853,7 +1850,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then, let's keep only the rows that have text content:"
+    "Then, keep only the rows that have text content:"
    ]
   },
   {
@@ -1864,7 +1861,7 @@
     {
      "data": {
       "text/plain": [
-       "2554"
+       "2555"
       ]
      },
      "execution_count": 26,
@@ -1881,7 +1878,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's calculate the average text length in all the rows:"
+    "You can get an idea of the input token length by calculating the average string length."
    ]
   },
   {
@@ -1892,7 +1889,7 @@
     {
      "data": {
       "text/plain": [
-       "390.6558339859039"
+       "390.61878669276047"
       ]
      },
      "execution_count": 27,
@@ -1908,7 +1905,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now it's LLM's turn. Let's keep the rows in which the text is talking about iPhone. This will take several minutes to finish."
+    "Now it's LLM's turn. You want to keep only the rows whose texts are talking about iPhone. This will take several minutes to finish."
    ]
   },
   {
@@ -1982,7 +1979,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1513</th>\n",
+       "      <th>1512</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>Why would this take a week? i(phone)OS was ori...</td>\n",
        "      <td>TheOtherHobbes</td>\n",
@@ -1991,7 +1988,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1560</th>\n",
+       "      <th>1559</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&amp;gt;or because Apple drama brings many clicks?...</td>\n",
        "      <td>weberer</td>\n",
@@ -2009,15 +2006,15 @@
        "9     <NA>  It doesn’t work on Safari, and WebKit based br...      archiewood   \n",
        "419   <NA>  Well last time I got angry down votes for sayi...       drieddust   \n",
        "812   <NA>  New iPhone should be announced on September. L...         meerita   \n",
-       "1513  <NA>  Why would this take a week? i(phone)OS was ori...  TheOtherHobbes   \n",
-       "1560  <NA>  &gt;or because Apple drama brings many clicks?...         weberer   \n",
+       "1512  <NA>  Why would this take a week? i(phone)OS was ori...  TheOtherHobbes   \n",
+       "1559  <NA>  &gt;or because Apple drama brings many clicks?...         weberer   \n",
        "\n",
        "      score                  timestamp     type  \n",
        "9      <NA>  2023-04-21 16:45:13+00:00  comment  \n",
        "419    <NA>  2021-01-11 19:27:27+00:00  comment  \n",
        "812    <NA>  2019-07-30 20:54:42+00:00  comment  \n",
-       "1513   <NA>  2021-06-08 09:25:24+00:00  comment  \n",
-       "1560   <NA>  2022-09-05 13:16:02+00:00  comment  \n",
+       "1512   <NA>  2021-06-08 09:25:24+00:00  comment  \n",
+       "1559   <NA>  2022-09-05 13:16:02+00:00  comment  \n",
        "\n",
        "[5 rows x 6 columns]"
       ]
@@ -2036,7 +2033,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The performance of the semantic operators depends on the length of your input as well as your quota. Here are my benchmarks for running the previous operation over data of different sizes.\n",
+    "The performance of the semantic operators depends on the length of your input as well as your quota. Here are our benchmarks for running the previous operation over data of different sizes.\n",
     "\n",
     "* 800 Rows -> 1m 21.3s\n",
     "* 2550 Rows -> 5m 9s\n",
@@ -2049,7 +2046,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now let's use LLM to summarize the sentiments towards iPhone:"
+    "Now, use LLM to summarize the sentiments towards iPhone:"
    ]
   },
   {
@@ -2127,7 +2124,7 @@
        "      <td>Excited anticipation.</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1513</th>\n",
+       "      <th>1512</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>Why would this take a week? i(phone)OS was ori...</td>\n",
        "      <td>TheOtherHobbes</td>\n",
@@ -2137,7 +2134,7 @@
        "      <td>Frustrated, critical, obvious.</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1560</th>\n",
+       "      <th>1559</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&amp;gt;or because Apple drama brings many clicks?...</td>\n",
        "      <td>weberer</td>\n",
@@ -2156,15 +2153,15 @@
        "9     <NA>  It doesn’t work on Safari, and WebKit based br...      archiewood   \n",
        "419   <NA>  Well last time I got angry down votes for sayi...       drieddust   \n",
        "812   <NA>  New iPhone should be announced on September. L...         meerita   \n",
-       "1513  <NA>  Why would this take a week? i(phone)OS was ori...  TheOtherHobbes   \n",
-       "1560  <NA>  &gt;or because Apple drama brings many clicks?...         weberer   \n",
+       "1512  <NA>  Why would this take a week? i(phone)OS was ori...  TheOtherHobbes   \n",
+       "1559  <NA>  &gt;or because Apple drama brings many clicks?...         weberer   \n",
        "\n",
        "      score                  timestamp     type  \\\n",
        "9      <NA>  2023-04-21 16:45:13+00:00  comment   \n",
        "419    <NA>  2021-01-11 19:27:27+00:00  comment   \n",
        "812    <NA>  2019-07-30 20:54:42+00:00  comment   \n",
-       "1513   <NA>  2021-06-08 09:25:24+00:00  comment   \n",
-       "1560   <NA>  2022-09-05 13:16:02+00:00  comment   \n",
+       "1512   <NA>  2021-06-08 09:25:24+00:00  comment   \n",
+       "1559   <NA>  2022-09-05 13:16:02+00:00  comment   \n",
        "\n",
        "                             sentiment  \n",
        "9           Frustrated, but hopeful. \n",
@@ -2173,9 +2170,9 @@
        "  \n",
        "812            Excited anticipation. \n",
        "  \n",
-       "1513  Frustrated, critical, obvious. \n",
+       "1512  Frustrated, critical, obvious. \n",
        "  \n",
-       "1560     Negative, clickbait, Apple. \n",
+       "1559     Negative, clickbait, Apple. \n",
        "  \n",
        "\n",
        "[5 rows x 7 columns]"
@@ -2194,7 +2191,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here is another example: we  count the number of rows whose authors have animals in their names."
+    "Here is another example: count the number of rows whose authors have animals in their names."
    ]
   },
   {
@@ -2206,7 +2203,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/venv/lib/python3.11/site-packages/IPython/core/interactiveshell.py:3577: UserWarning: Reading cached table from 2024-12-27 01:00:10.095976+00:00 to avoid incompatibilies with previous reads of this table. To read the latest version, set `use_cache=False` or close the current session with Session.close() or bigframes.pandas.close_session().\n",
+      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/venv/lib/python3.11/site-packages/IPython/core/interactiveshell.py:3577: UserWarning: Reading cached table from 2024-12-27 21:39:10.129973+00:00 to avoid incompatibilies with previous reads of this table. To read the latest version, set `use_cache=False` or close the current session with Session.close() or bigframes.pandas.close_session().\n",
       "  exec(code_obj, self.user_global_ns, self.user_ns)\n"
      ]
     },
@@ -2938,7 +2935,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here are my performance numbers:\n",
+    "Here are our performance numbers:\n",
     "* 3000 rows -> 6m 9.2s\n",
     "* 10000 rows -> 26m 42.4s"
    ]

--- a/notebooks/experimental/semantic_operators.ipynb
+++ b/notebooks/experimental/semantic_operators.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +61,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,18 +73,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Make sure the BigFrames version is at least `1.22.0`"
+    "Make sure the BigFrames version is at least `1.23.0`"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
     "from packaging.version import Version\n",
     "\n",
-    "assert Version(bigframes.__version__) >= Version(\"1.22.0\")"
+    "assert Version(bigframes.__version__) >= Version(\"1.23.0\")"
    ]
   },
   {
@@ -96,14 +96,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/_config/experiment_options.py:33: UserWarning: Semantic operators are still under experiments, and are subject to change in the future.\n",
+      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/_config/experiment_options.py:34: UserWarning: Semantic operators are still under experiments, and are subject to change in the future.\n",
       "  warnings.warn(\n"
      ]
     }
@@ -121,11 +121,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
-    "# bpd.options.display.progress_bar = None"
+    "bpd.options.display.progress_bar = None"
    ]
   },
   {
@@ -137,40 +137,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/pandas/__init__.py:559: DefaultLocationWarning: No explicit location is set, so using location US for the session.\n",
+      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/pandas/__init__.py:258: DefaultLocationWarning: No explicit location is set, so using location US for the session.\n",
       "  return global_session.get_global_session()\n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job aadc79c5-5402-4922-a694-adb3848e3193 is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:aadc79c5-5402-4922-a694-adb3848e3193&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 16757654-a541-47ed-ac48-84b4b549f3bd is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:16757654-a541-47ed-ac48-84b4b549f3bd&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [
@@ -209,21 +185,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "Query job 2640c2d3-ceb0-4f8a-8bb2-a3ec5b3c8eb8 is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:2640c2d3-ceb0-4f8a-8bb2-a3ec5b3c8eb8&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "data": {
       "text/html": [
@@ -279,7 +243,7 @@
        "[3 rows x 2 columns]"
       ]
      },
-     "execution_count": 6,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -303,64 +267,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "Query job 0aeff7d2-c2f3-45f1-8f8f-5be572392822 is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:0aeff7d2-c2f3-45f1-8f8f-5be572392822&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:112: PreviewWarning: Interpreting JSON column(s) as StringDtype. This behavior may change in future versions.\n",
+      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:109: PreviewWarning: Interpreting JSON column(s) as StringDtype and pyarrow.large_string. This behavior may change in future versions.\n",
       "  warnings.warn(\n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 0f3bfbe3-30c5-4bf9-8cf2-a3ea694f878d is DONE. 6 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:0f3bfbe3-30c5-4bf9-8cf2-a3ea694f878d&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job dfef2ffb-7196-4c94-bcae-d050021ebb5f is DONE. 50 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:dfef2ffb-7196-4c94-bcae-d050021ebb5f&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job f6397298-dfe2-4e9d-ab91-e790c04ccddc is DONE. 33 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:f6397298-dfe2-4e9d-ab91-e790c04ccddc&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
      "data": {
@@ -405,7 +321,7 @@
        "[1 rows x 2 columns]"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -437,21 +353,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "Query job 2d6b0f90-20b3-419e-8d38-68be9e7ee1ae is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:2d6b0f90-20b3-419e-8d38-68be9e7ee1ae&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "data": {
       "text/html": [
@@ -507,7 +411,7 @@
        "[3 rows x 2 columns]"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -529,64 +433,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "Query job a90d785f-29d7-4818-b595-9326657cc865 is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:a90d785f-29d7-4818-b595-9326657cc865&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:112: PreviewWarning: Interpreting JSON column(s) as StringDtype. This behavior may change in future versions.\n",
+      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:109: PreviewWarning: Interpreting JSON column(s) as StringDtype and pyarrow.large_string. This behavior may change in future versions.\n",
       "  warnings.warn(\n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job de201200-4135-487b-8582-12d5137ddc24 is DONE. 6 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:de201200-4135-487b-8582-12d5137ddc24&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job ec36bc3a-773b-4443-be63-72e4c1063168 is DONE. 52 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:ec36bc3a-773b-4443-be63-72e4c1063168&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job ec204378-936a-4dc9-8e4a-5d4b17caad78 is DONE. 133 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:ec204378-936a-4dc9-8e4a-5d4b17caad78&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
      "data": {
@@ -650,7 +506,7 @@
        "[3 rows x 3 columns]"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -682,7 +538,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -699,64 +555,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "Query job d1195b35-ca65-474c-9847-8e315447a941 is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:d1195b35-ca65-474c-9847-8e315447a941&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:112: PreviewWarning: Interpreting JSON column(s) as StringDtype. This behavior may change in future versions.\n",
+      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:109: PreviewWarning: Interpreting JSON column(s) as StringDtype and pyarrow.large_string. This behavior may change in future versions.\n",
       "  warnings.warn(\n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 721d1ef5-810e-4d0f-bb4a-250dc12bbe82 is DONE. 30 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:721d1ef5-810e-4d0f-bb4a-250dc12bbe82&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 54502b90-fea2-4545-8542-a6be6f6837ac is DONE. 251 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:54502b90-fea2-4545-8542-a6be6f6837ac&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 00326a4e-2371-4572-a842-e14ba99ac02c is DONE. 144 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:00326a4e-2371-4572-a842-e14ba99ac02c&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
      "data": {
@@ -819,7 +627,7 @@
        "[4 rows x 2 columns]"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -853,7 +661,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -869,64 +677,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "Query job 2a87f5a4-927d-472f-808d-bc86e008dbaf is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:2a87f5a4-927d-472f-808d-bc86e008dbaf&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:112: PreviewWarning: Interpreting JSON column(s) as StringDtype. This behavior may change in future versions.\n",
+      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:109: PreviewWarning: Interpreting JSON column(s) as StringDtype and pyarrow.large_string. This behavior may change in future versions.\n",
       "  warnings.warn(\n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 591da923-319f-43f9-bf24-20e34abf899f is DONE. 32 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:591da923-319f-43f9-bf24-20e34abf899f&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 1422bfcf-23a9-4484-96d7-16d5b56dfe26 is DONE. 266 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:1422bfcf-23a9-4484-96d7-16d5b56dfe26&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job a659dcaf-9bd4-4776-bb82-c0d3408b41a2 is DONE. 180 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:a659dcaf-9bd4-4776-bb82-c0d3408b41a2&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
      "data": {
@@ -1001,7 +761,7 @@
        "[6 rows x 2 columns]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1026,21 +786,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "Query job 6606270b-b734-494c-a602-544db495b4c1 is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:6606270b-b734-494c-a602-544db495b4c1&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "data": {
       "text/html": [
@@ -1063,64 +811,56 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
        "      <th>Movies</th>\n",
-       "      <th>Year</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>Titanic</td>\n",
-       "      <td>1997</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>The Wolf of Wall Street</td>\n",
-       "      <td>2013</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>Killers of the Flower Moon</td>\n",
-       "      <td>2023</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>The Revenant</td>\n",
-       "      <td>2015</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>Inception</td>\n",
-       "      <td>2010</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
        "      <td>Shuttle Island</td>\n",
-       "      <td>2010</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
        "      <td>The Great Gatsby</td>\n",
-       "      <td>2013</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>7 rows × 2 columns</p>\n",
-       "</div>[7 rows x 2 columns in total]"
+       "<p>7 rows × 1 columns</p>\n",
+       "</div>[7 rows x 1 columns in total]"
       ],
       "text/plain": [
-       "                       Movies  Year\n",
-       "0                     Titanic  1997\n",
-       "1     The Wolf of Wall Street  2013\n",
-       "2  Killers of the Flower Moon  2023\n",
-       "3                The Revenant  2015\n",
-       "4                   Inception  2010\n",
-       "5              Shuttle Island  2010\n",
-       "6            The Great Gatsby  2013\n",
+       "                       Movies\n",
+       "0                     Titanic\n",
+       "1     The Wolf of Wall Street\n",
+       "2  Killers of the Flower Moon\n",
+       "3                The Revenant\n",
+       "4                   Inception\n",
+       "5              Shuttle Island\n",
+       "6            The Great Gatsby\n",
        "\n",
-       "[7 rows x 2 columns]"
+       "[7 rows x 1 columns]"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1136,7 +876,6 @@
     "        \"Shuttle Island\",\n",
     "        \"The Great Gatsby\",\n",
     "    ],\n",
-    "    \"Year\": [1997, 2013, 2023, 2015, 2010, 2010, 2013],\n",
     "})\n",
     "df"
    ]
@@ -1145,97 +884,37 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's ask LLM to find the actor/actress that starred in all movies:"
+    "Let's ask LLM to find the oldest movie:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "Query job 6918cec6-9ac3-49d5-82b3-61eeedbd54dc is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:6918cec6-9ac3-49d5-82b3-61eeedbd54dc&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:112: PreviewWarning: Interpreting JSON column(s) as StringDtype. This behavior may change in future versions.\n",
+      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:109: PreviewWarning: Interpreting JSON column(s) as StringDtype and pyarrow.large_string. This behavior may change in future versions.\n",
       "  warnings.warn(\n"
      ]
     },
     {
      "data": {
-      "text/html": [
-       "Query job d95e8f6d-bbe2-4149-86a5-f5e69ad07c9e is DONE. 2 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:d95e8f6d-bbe2-4149-86a5-f5e69ad07c9e&page=queryresults\">Open Job</a>"
-      ],
       "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job a6d7545d-91bc-4336-beed-a67295bdfa13 is DONE. 16 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:a6d7545d-91bc-4336-beed-a67295bdfa13&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job aafc86f8-2bc3-44da-821e-891ca4c75d46 is DONE. 37 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:aafc86f8-2bc3-44da-821e-891ca4c75d46&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 8ca9c614-268c-4592-aaf0-a5df0143e1e7 is DONE. 37 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:8ca9c614-268c-4592-aaf0-a5df0143e1e7&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "0    Leonardo DiCaprio \n",
+       "0    Titanic \n",
        "\n",
        "Name: Movies, dtype: string"
       ]
      },
-     "execution_count": 15,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "agg_df = df.semantics.agg(\"Find the actors/actresses who starred in all {Movies}. Reply with their names only.\", model=gemini_model)\n",
+    "agg_df = df.semantics.agg(\"Find the oldest movie from {Movies}. Reply with only the movie title\", model=gemini_model)\n",
     "agg_df"
    ]
   },
@@ -1262,7 +941,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1278,112 +957,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "Query job 6cb9ade5-c3fd-468c-b590-c59d8c51c68c is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:6cb9ade5-c3fd-468c-b590-c59d8c51c68c&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job a56383c1-3bd0-4af1-b0d6-1de829f4e371 is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:a56383c1-3bd0-4af1-b0d6-1de829f4e371&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 2f58a6fe-4a80-481b-b590-9d657f965d91 is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:2f58a6fe-4a80-481b-b590-9d657f965d91&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 281c1181-fcdf-407b-9a5d-03c975f05687 is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:281c1181-fcdf-407b-9a5d-03c975f05687&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:112: PreviewWarning: Interpreting JSON column(s) as StringDtype. This behavior may change in future versions.\n",
+      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:109: PreviewWarning: Interpreting JSON column(s) as StringDtype and pyarrow.large_string. This behavior may change in future versions.\n",
       "  warnings.warn(\n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 593b3b9c-e2b3-4eb9-a233-56454e2a8419 is DONE. 6 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:593b3b9c-e2b3-4eb9-a233-56454e2a8419&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 5fe0c094-740d-47ec-a4c5-9b4cdd4c66af is DONE. 66 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:5fe0c094-740d-47ec-a4c5-9b4cdd4c66af&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job bab92744-1ec8-42fc-aa8f-ced99ae2fc66 is DONE. 66 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:bab92744-1ec8-42fc-aa8f-ced99ae2fc66&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 5a27f6f8-7e7b-45bf-8d17-580ef5c73432 is DONE. 52 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:5a27f6f8-7e7b-45bf-8d17-580ef5c73432&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
      "data": {
@@ -1411,12 +994,12 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>Orange Cat</td>\n",
+       "      <th>0</th>\n",
+       "      <td>Corgi</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>Parrot</td>\n",
+       "      <th>1</th>\n",
+       "      <td>Orange Cat</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1425,13 +1008,13 @@
       ],
       "text/plain": [
        "      Animals\n",
+       "0       Corgi\n",
        "1  Orange Cat\n",
-       "2      Parrot\n",
        "\n",
        "[2 rows x 1 columns]"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1463,21 +1046,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "Query job f9e814b1-a3e4-47f4-b966-0177f879c2a9 is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:f9e814b1-a3e4-47f4-b966-0177f879c2a9&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "data": {
       "text/html": [
@@ -1539,7 +1110,7 @@
        "[5 rows x 1 columns]"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 19,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1558,120 +1129,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "Query job 8ae9b68c-43e7-449d-8709-b2b6108981b9 is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:8ae9b68c-43e7-449d-8709-b2b6108981b9&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:112: PreviewWarning: Interpreting JSON column(s) as StringDtype. This behavior may change in future versions.\n",
+      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:109: PreviewWarning: Interpreting JSON column(s) as StringDtype and pyarrow.large_string. This behavior may change in future versions.\n",
+      "  warnings.warn(\n",
+      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:109: PreviewWarning: Interpreting JSON column(s) as StringDtype and pyarrow.large_string. This behavior may change in future versions.\n",
+      "  warnings.warn(\n",
+      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:109: PreviewWarning: Interpreting JSON column(s) as StringDtype and pyarrow.large_string. This behavior may change in future versions.\n",
       "  warnings.warn(\n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job ff50ee3b-e005-4608-9e3f-37e48f924152 is DONE. 10 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:ff50ee3b-e005-4608-9e3f-37e48f924152&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job bbc89422-ee33-4afb-8c66-b08c0b6754b9 is DONE. 30.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:bbc89422-ee33-4afb-8c66-b08c0b6754b9&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job dfea7010-9fb5-4459-b789-b26dc98cb94d is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:dfea7010-9fb5-4459-b789-b26dc98cb94d&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:112: PreviewWarning: Interpreting JSON column(s) as StringDtype. This behavior may change in future versions.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 66c3b84e-7eb6-408a-a244-20713ad18f1b is DONE. 2 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:66c3b84e-7eb6-408a-a244-20713ad18f1b&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 62f2a822-4b7f-4072-8957-e7539c7a6646 is RUNNING. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:62f2a822-4b7f-4072-8957-e7539c7a6646&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 286ee4e0-ee7f-4ba7-b057-de17818d0ea1 is DONE. 37.2 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:286ee4e0-ee7f-4ba7-b057-de17818d0ea1&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 9d56d05c-ad52-47ea-b911-0abf67b6489f is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:9d56d05c-ad52-47ea-b911-0abf67b6489f&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
      "data": {
@@ -1702,12 +1173,12 @@
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>baboons</td>\n",
-       "      <td>0.773411</td>\n",
+       "      <td>0.708434</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>chimpanzee</td>\n",
-       "      <td>0.781101</td>\n",
+       "      <td>0.635844</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1716,13 +1187,13 @@
       ],
       "text/plain": [
        "    creatures  similarity score\n",
-       "2     baboons          0.773411\n",
-       "4  chimpanzee          0.781101\n",
+       "2     baboons          0.708434\n",
+       "4  chimpanzee          0.635844\n",
        "\n",
        "[2 rows x 2 columns]"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 20,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1756,7 +1227,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1773,120 +1244,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "Query job 292332da-b5ec-45c2-aa34-322afbce8102 is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:292332da-b5ec-45c2-aa34-322afbce8102&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:112: PreviewWarning: Interpreting JSON column(s) as StringDtype. This behavior may change in future versions.\n",
+      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:109: PreviewWarning: Interpreting JSON column(s) as StringDtype and pyarrow.large_string. This behavior may change in future versions.\n",
+      "  warnings.warn(\n",
+      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:109: PreviewWarning: Interpreting JSON column(s) as StringDtype and pyarrow.large_string. This behavior may change in future versions.\n",
       "  warnings.warn(\n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 95e9743a-2965-4d66-888c-49d5359253d0 is DONE. 10 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:95e9743a-2965-4d66-888c-49d5359253d0&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 9bdaa6c6-0bdc-41c2-bf4d-aecd677a4991 is DONE. 30.8 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:9bdaa6c6-0bdc-41c2-bf4d-aecd677a4991&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job b148669b-1071-4128-8f7d-4c4c37b23d43 is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:b148669b-1071-4128-8f7d-4c4c37b23d43&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:112: PreviewWarning: Interpreting JSON column(s) as StringDtype. This behavior may change in future versions.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 0c09280c-69ad-4692-9559-c48a656d9cf2 is DONE. 10 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:0c09280c-69ad-4692-9559-c48a656d9cf2&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 9e31d888-d333-4bbd-9410-0444115e022b is RUNNING. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:9e31d888-d333-4bbd-9410-0444115e022b&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job bb8988ec-a2b7-4f5b-95c0-f8b89f53f4cc is DONE. 61.5 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:bb8988ec-a2b7-4f5b-95c0-f8b89f53f4cc&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 6657a931-d0c5-4c8f-a12e-71719394740b is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:6657a931-d0c5-4c8f-a12e-71719394740b&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
      "data": {
@@ -1919,31 +1288,31 @@
        "      <th>0</th>\n",
        "      <td>monkey</td>\n",
        "      <td>baboon</td>\n",
-       "      <td>0.747665</td>\n",
+       "      <td>0.620521</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>spider</td>\n",
        "      <td>scorpion</td>\n",
-       "      <td>0.890909</td>\n",
+       "      <td>0.728024</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>salmon</td>\n",
        "      <td>tuna</td>\n",
-       "      <td>0.925461</td>\n",
+       "      <td>0.782141</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>giraffe</td>\n",
        "      <td>elephant</td>\n",
-       "      <td>0.887858</td>\n",
+       "      <td>0.7135</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>sparrow</td>\n",
        "      <td>owl</td>\n",
-       "      <td>0.932959</td>\n",
+       "      <td>0.810864</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1952,16 +1321,16 @@
       ],
       "text/plain": [
        "    animal  animal_1  distance\n",
-       "0   monkey    baboon  0.747665\n",
-       "1   spider  scorpion  0.890909\n",
-       "2   salmon      tuna  0.925461\n",
-       "3  giraffe  elephant  0.887858\n",
-       "4  sparrow       owl  0.932959\n",
+       "0   monkey    baboon  0.620521\n",
+       "1   spider  scorpion  0.728024\n",
+       "2   salmon      tuna  0.782141\n",
+       "3  giraffe  elephant    0.7135\n",
+       "4  sparrow       owl  0.810864\n",
        "\n",
        "[5 rows x 3 columns]"
       ]
      },
-     "execution_count": 21,
+     "execution_count": 22,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1993,7 +1362,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2009,100 +1378,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "metadata": {},
    "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "Query job 1b1d59bd-3bfe-4887-a595-f281d745cf2a is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:1b1d59bd-3bfe-4887-a595-f281d745cf2a&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:112: PreviewWarning: Interpreting JSON column(s) as StringDtype. This behavior may change in future versions.\n",
+      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:109: PreviewWarning: Interpreting JSON column(s) as StringDtype and pyarrow.large_string. This behavior may change in future versions.\n",
+      "  warnings.warn(\n",
+      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:109: PreviewWarning: Interpreting JSON column(s) as StringDtype and pyarrow.large_string. This behavior may change in future versions.\n",
       "  warnings.warn(\n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 1f01891d-4177-450d-a647-85eb7461a1ec is DONE. 10 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:1f01891d-4177-450d-a647-85eb7461a1ec&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job eee27d1d-e3c9-4efd-a0ae-bfb982e51cb1 is DONE. 30.8 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:eee27d1d-e3c9-4efd-a0ae-bfb982e51cb1&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job b98ed0ab-903f-4e4a-b450-d800cef3cabf is DONE. 30.7 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:b98ed0ab-903f-4e4a-b450-d800cef3cabf&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job ec7f3a21-cf30-4f5b-88e8-c7721da60066 is DONE. 138.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:ec7f3a21-cf30-4f5b-88e8-c7721da60066&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 0766e72b-cb0f-48e2-8475-91d55e95ff42 is DONE. 80 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:0766e72b-cb0f-48e2-8475-91d55e95ff42&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 9c6275c9-f368-47bf-a9ce-7e4b64f97b2c is DONE. 170 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:9c6275c9-f368-47bf-a9ce-7e4b64f97b2c&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
      "data": {
@@ -2133,17 +1420,17 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>Smartphone</td>\n",
-       "      <td>3</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>Laptop</td>\n",
-       "      <td>3</td>\n",
+       "      <td>1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>Coffee Maker</td>\n",
-       "      <td>1</td>\n",
+       "      <td>3</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -2162,16 +1449,16 @@
       ],
       "text/plain": [
        "        Product  Cluster ID\n",
-       "0    Smartphone           3\n",
-       "1        Laptop           3\n",
-       "2  Coffee Maker           1\n",
+       "0    Smartphone           1\n",
+       "1        Laptop           1\n",
+       "2  Coffee Maker           3\n",
        "3       T-shirt           2\n",
        "4         Jeans           2\n",
        "\n",
        "[5 rows x 2 columns]"
       ]
      },
-     "execution_count": 23,
+     "execution_count": 24,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2203,33 +1490,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "metadata": {},
    "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "Query job 6622d251-728a-428f-8eb9-55c450460fe4 is DONE. 16.7 GB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:6622d251-728a-428f-8eb9-55c450460fe4&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 409b18ea-bf23-44ac-84eb-deb33feeaa89 is DONE. 1.2 MB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:409b18ea-bf23-44ac-84eb-deb33feeaa89&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "data": {
       "text/html": [
@@ -2576,7 +1839,7 @@
        "[3000 rows x 6 columns]"
       ]
      },
-     "execution_count": 24,
+     "execution_count": 25,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2595,28 +1858,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "Query job d98d2f69-ece3-4e58-b608-8114e59d275b is DONE. 1.0 MB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:d98d2f69-ece3-4e58-b608-8114e59d275b&page=queryresults\">Open Job</a>"
-      ],
       "text/plain": [
-       "<IPython.core.display.HTML object>"
+       "2554"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "2558"
-      ]
-     },
-     "execution_count": 25,
+     "execution_count": 26,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2635,28 +1886,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "Query job 0211925e-0599-454d-a1d5-e145e6db79c4 is DONE. 1.0 MB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:0211925e-0599-454d-a1d5-e145e6db79c4&page=queryresults\">Open Job</a>"
-      ],
       "text/plain": [
-       "<IPython.core.display.HTML object>"
+       "390.6558339859039"
       ]
      },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/plain": [
-       "390.7251759186865"
-      ]
-     },
-     "execution_count": 26,
+     "execution_count": 27,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2674,72 +1913,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "Query job d06977e3-3c83-4360-a920-4815dd1fbb0d is DONE. 1.0 MB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:d06977e3-3c83-4360-a920-4815dd1fbb0d&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:112: PreviewWarning: Interpreting JSON column(s) as StringDtype. This behavior may change in future versions.\n",
+      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:109: PreviewWarning: Interpreting JSON column(s) as StringDtype and pyarrow.large_string. This behavior may change in future versions.\n",
       "  warnings.warn(\n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job af69426d-ebea-4338-a742-cef524ecca72 is DONE. 5.7 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:af69426d-ebea-4338-a742-cef524ecca72&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/ml/llm.py:976: RuntimeWarning: Some predictions failed. Check column ml_generate_text_status for detailed status. You may want to filter the failed rows and retry.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job ccd12132-da6c-45ed-9bd3-a199d4c47118 is DONE. 1.2 MB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:ccd12132-da6c-45ed-9bd3-a199d4c47118&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 824d2d55-cc04-4794-9f18-9eb67c639b19 is DONE. 1.8 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:824d2d55-cc04-4794-9f18-9eb67c639b19&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
      "data": {
@@ -2772,16 +1955,16 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>16</th>\n",
+       "      <th>9</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>you have to auth again when you use apple pay.</td>\n",
-       "      <td>empath75</td>\n",
+       "      <td>It doesn’t work on Safari, and WebKit based br...</td>\n",
+       "      <td>archiewood</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>2017-09-12 18:58:20+00:00</td>\n",
+       "      <td>2023-04-21 16:45:13+00:00</td>\n",
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>413</th>\n",
+       "      <th>419</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>Well last time I got angry down votes for sayi...</td>\n",
        "      <td>drieddust</td>\n",
@@ -2790,7 +1973,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>797</th>\n",
+       "      <th>812</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>New iPhone should be announced on September. L...</td>\n",
        "      <td>meerita</td>\n",
@@ -2799,7 +1982,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1484</th>\n",
+       "      <th>1513</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>Why would this take a week? i(phone)OS was ori...</td>\n",
        "      <td>TheOtherHobbes</td>\n",
@@ -2808,7 +1991,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1529</th>\n",
+       "      <th>1560</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&amp;gt;or because Apple drama brings many clicks?...</td>\n",
        "      <td>weberer</td>\n",
@@ -2816,41 +1999,30 @@
        "      <td>2022-09-05 13:16:02+00:00</td>\n",
        "      <td>comment</td>\n",
        "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1561</th>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>Location: Sydney, AU&lt;p&gt;Remote: Yes&lt;p&gt;Willing t...</td>\n",
-       "      <td>drEv0</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>2016-05-03 23:55:26+00:00</td>\n",
-       "      <td>comment</td>\n",
-       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>6 rows × 6 columns</p>\n",
-       "</div>[6 rows x 6 columns in total]"
+       "<p>5 rows × 6 columns</p>\n",
+       "</div>[5 rows x 6 columns in total]"
       ],
       "text/plain": [
        "     title                                               text              by  \\\n",
-       "16    <NA>     you have to auth again when you use apple pay.        empath75   \n",
-       "413   <NA>  Well last time I got angry down votes for sayi...       drieddust   \n",
-       "797   <NA>  New iPhone should be announced on September. L...         meerita   \n",
-       "1484  <NA>  Why would this take a week? i(phone)OS was ori...  TheOtherHobbes   \n",
-       "1529  <NA>  &gt;or because Apple drama brings many clicks?...         weberer   \n",
-       "1561  <NA>  Location: Sydney, AU<p>Remote: Yes<p>Willing t...           drEv0   \n",
+       "9     <NA>  It doesn’t work on Safari, and WebKit based br...      archiewood   \n",
+       "419   <NA>  Well last time I got angry down votes for sayi...       drieddust   \n",
+       "812   <NA>  New iPhone should be announced on September. L...         meerita   \n",
+       "1513  <NA>  Why would this take a week? i(phone)OS was ori...  TheOtherHobbes   \n",
+       "1560  <NA>  &gt;or because Apple drama brings many clicks?...         weberer   \n",
        "\n",
        "      score                  timestamp     type  \n",
-       "16     <NA>  2017-09-12 18:58:20+00:00  comment  \n",
-       "413    <NA>  2021-01-11 19:27:27+00:00  comment  \n",
-       "797    <NA>  2019-07-30 20:54:42+00:00  comment  \n",
-       "1484   <NA>  2021-06-08 09:25:24+00:00  comment  \n",
-       "1529   <NA>  2022-09-05 13:16:02+00:00  comment  \n",
-       "1561   <NA>  2016-05-03 23:55:26+00:00  comment  \n",
+       "9      <NA>  2023-04-21 16:45:13+00:00  comment  \n",
+       "419    <NA>  2021-01-11 19:27:27+00:00  comment  \n",
+       "812    <NA>  2019-07-30 20:54:42+00:00  comment  \n",
+       "1513   <NA>  2021-06-08 09:25:24+00:00  comment  \n",
+       "1560   <NA>  2022-09-05 13:16:02+00:00  comment  \n",
        "\n",
-       "[6 rows x 6 columns]"
+       "[5 rows x 6 columns]"
       ]
      },
-     "execution_count": 27,
+     "execution_count": 28,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2882,64 +2054,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "metadata": {},
    "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "Query job 6d7d7de8-0ec8-4966-a8d1-1dc09e61af6a is DONE. 1.6 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:6d7d7de8-0ec8-4966-a8d1-1dc09e61af6a&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:112: PreviewWarning: Interpreting JSON column(s) as StringDtype. This behavior may change in future versions.\n",
+      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:109: PreviewWarning: Interpreting JSON column(s) as StringDtype and pyarrow.large_string. This behavior may change in future versions.\n",
       "  warnings.warn(\n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 5aa9d5a4-aa2f-4320-91ab-3cf7479ab883 is DONE. 12 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:5aa9d5a4-aa2f-4320-91ab-3cf7479ab883&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job d64f52ab-6575-43a5-870d-418decc99e49 is DONE. 2.0 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:d64f52ab-6575-43a5-870d-418decc99e49&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 9e11e90f-1ae1-4fee-b5bf-932436e4ea92 is DONE. 2.0 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:9e11e90f-1ae1-4fee-b5bf-932436e4ea92&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
      "data": {
@@ -2973,27 +2097,27 @@
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
-       "      <th>16</th>\n",
+       "      <th>9</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>you have to auth again when you use apple pay.</td>\n",
-       "      <td>empath75</td>\n",
+       "      <td>It doesn’t work on Safari, and WebKit based br...</td>\n",
+       "      <td>archiewood</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>2017-09-12 18:58:20+00:00</td>\n",
+       "      <td>2023-04-21 16:45:13+00:00</td>\n",
        "      <td>comment</td>\n",
-       "      <td>Frustrated, Negative, Annoyed</td>\n",
+       "      <td>Frustrated, but hopeful.</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>413</th>\n",
+       "      <th>419</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>Well last time I got angry down votes for sayi...</td>\n",
        "      <td>drieddust</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>2021-01-11 19:27:27+00:00</td>\n",
        "      <td>comment</td>\n",
-       "      <td>Frustrated, feeling cheated.</td>\n",
+       "      <td>Frustrated and angry.</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>797</th>\n",
+       "      <th>812</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>New iPhone should be announced on September. L...</td>\n",
        "      <td>meerita</td>\n",
@@ -3003,7 +2127,7 @@
        "      <td>Excited anticipation.</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1484</th>\n",
+       "      <th>1513</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>Why would this take a week? i(phone)OS was ori...</td>\n",
        "      <td>TheOtherHobbes</td>\n",
@@ -3013,65 +2137,51 @@
        "      <td>Frustrated, critical, obvious.</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>1529</th>\n",
+       "      <th>1560</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&amp;gt;or because Apple drama brings many clicks?...</td>\n",
        "      <td>weberer</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>2022-09-05 13:16:02+00:00</td>\n",
        "      <td>comment</td>\n",
-       "      <td>Negative, clickbait, controversy.</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1561</th>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>Location: Sydney, AU&lt;p&gt;Remote: Yes&lt;p&gt;Willing t...</td>\n",
-       "      <td>drEv0</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>2016-05-03 23:55:26+00:00</td>\n",
-       "      <td>comment</td>\n",
-       "      <td>Seeking employment in Australia.</td>\n",
+       "      <td>Negative, clickbait, Apple.</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
-       "<p>6 rows × 7 columns</p>\n",
-       "</div>[6 rows x 7 columns in total]"
+       "<p>5 rows × 7 columns</p>\n",
+       "</div>[5 rows x 7 columns in total]"
       ],
       "text/plain": [
        "     title                                               text              by  \\\n",
-       "16    <NA>     you have to auth again when you use apple pay.        empath75   \n",
-       "413   <NA>  Well last time I got angry down votes for sayi...       drieddust   \n",
-       "797   <NA>  New iPhone should be announced on September. L...         meerita   \n",
-       "1484  <NA>  Why would this take a week? i(phone)OS was ori...  TheOtherHobbes   \n",
-       "1529  <NA>  &gt;or because Apple drama brings many clicks?...         weberer   \n",
-       "1561  <NA>  Location: Sydney, AU<p>Remote: Yes<p>Willing t...           drEv0   \n",
+       "9     <NA>  It doesn’t work on Safari, and WebKit based br...      archiewood   \n",
+       "419   <NA>  Well last time I got angry down votes for sayi...       drieddust   \n",
+       "812   <NA>  New iPhone should be announced on September. L...         meerita   \n",
+       "1513  <NA>  Why would this take a week? i(phone)OS was ori...  TheOtherHobbes   \n",
+       "1560  <NA>  &gt;or because Apple drama brings many clicks?...         weberer   \n",
        "\n",
        "      score                  timestamp     type  \\\n",
-       "16     <NA>  2017-09-12 18:58:20+00:00  comment   \n",
-       "413    <NA>  2021-01-11 19:27:27+00:00  comment   \n",
-       "797    <NA>  2019-07-30 20:54:42+00:00  comment   \n",
-       "1484   <NA>  2021-06-08 09:25:24+00:00  comment   \n",
-       "1529   <NA>  2022-09-05 13:16:02+00:00  comment   \n",
-       "1561   <NA>  2016-05-03 23:55:26+00:00  comment   \n",
+       "9      <NA>  2023-04-21 16:45:13+00:00  comment   \n",
+       "419    <NA>  2021-01-11 19:27:27+00:00  comment   \n",
+       "812    <NA>  2019-07-30 20:54:42+00:00  comment   \n",
+       "1513   <NA>  2021-06-08 09:25:24+00:00  comment   \n",
+       "1560   <NA>  2022-09-05 13:16:02+00:00  comment   \n",
        "\n",
-       "                                sentiment  \n",
-       "16        Frustrated, Negative, Annoyed \n",
+       "                             sentiment  \n",
+       "9           Frustrated, but hopeful. \n",
        "  \n",
-       "413        Frustrated, feeling cheated. \n",
+       "419            Frustrated and angry. \n",
        "  \n",
-       "797               Excited anticipation. \n",
+       "812            Excited anticipation. \n",
        "  \n",
-       "1484     Frustrated, critical, obvious. \n",
+       "1513  Frustrated, critical, obvious. \n",
        "  \n",
-       "1529  Negative, clickbait, controversy. \n",
-       "  \n",
-       "1561   Seeking employment in Australia. \n",
+       "1560     Negative, clickbait, Apple. \n",
        "  \n",
        "\n",
-       "[6 rows x 7 columns]"
+       "[5 rows x 7 columns]"
       ]
      },
-     "execution_count": 28,
+     "execution_count": 29,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3089,28 +2199,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 30,
    "metadata": {},
    "outputs": [
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/venv/lib/python3.11/site-packages/IPython/core/interactiveshell.py:3577: UserWarning: Reading cached table from 2024-10-10 20:04:54.370456+00:00 to avoid incompatibilies with previous reads of this table. To read the latest version, set `use_cache=False` or close the current session with Session.close() or bigframes.pandas.close_session().\n",
+      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/venv/lib/python3.11/site-packages/IPython/core/interactiveshell.py:3577: UserWarning: Reading cached table from 2024-12-27 01:00:10.095976+00:00 to avoid incompatibilies with previous reads of this table. To read the latest version, set `use_cache=False` or close the current session with Session.close() or bigframes.pandas.close_session().\n",
       "  exec(code_obj, self.user_global_ns, self.user_ns)\n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job ec9a3769-cc0a-4f45-9565-c1af98ae98e5 is DONE. 0 Bytes processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:ec9a3769-cc0a-4f45-9565-c1af98ae98e5&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
      "data": {
@@ -3458,7 +2556,7 @@
        "[3000 rows x 6 columns]"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 30,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -3470,72 +2568,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "Query job bff6ac16-2641-495a-a624-11883435e06c is DONE. 54.2 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:bff6ac16-2641-495a-a624-11883435e06c&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:112: PreviewWarning: Interpreting JSON column(s) as StringDtype. This behavior may change in future versions.\n",
+      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/core/__init__.py:109: PreviewWarning: Interpreting JSON column(s) as StringDtype and pyarrow.large_string. This behavior may change in future versions.\n",
       "  warnings.warn(\n"
      ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job aa390314-5b6e-4c7e-9502-8497dc27429a is DONE. 5.9 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:aa390314-5b6e-4c7e-9502-8497dc27429a&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/google/home/sycai/src/python-bigquery-dataframes/bigframes/ml/llm.py:976: RuntimeWarning: Some predictions failed. Check column ml_generate_text_status for detailed status. You may want to filter the failed rows and retry.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job 3591e287-5c45-4ec2-a11b-afe95fd956e3 is DONE. 1.2 MB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:3591e287-5c45-4ec2-a11b-afe95fd956e3&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "Query job b0801c71-d44a-498a-ab3a-6302de52729f is DONE. 45.7 kB processed. <a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:b0801c71-d44a-498a-ab3a-6302de52729f&page=queryresults\">Open Job</a>"
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     },
     {
      "data": {
@@ -3577,7 +2619,7 @@
        "      <td>story</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>96</th>\n",
+       "      <th>98</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>i resisted switching to chrome for months beca...</td>\n",
        "      <td>catshirt</td>\n",
@@ -3586,16 +2628,16 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>106</th>\n",
+       "      <th>137</th>\n",
+       "      <td>FDA reverses marketing ban on Juul e-cigarettes</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>I was about to say the same thing myself. For ...</td>\n",
-       "      <td>geophile</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>2011-12-08 21:13:08+00:00</td>\n",
-       "      <td>comment</td>\n",
+       "      <td>anigbrowl</td>\n",
+       "      <td>2</td>\n",
+       "      <td>2024-06-06 16:42:40+00:00</td>\n",
+       "      <td>story</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>184</th>\n",
+       "      <th>188</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>I think it&amp;#x27;s more than hazing. It may be ...</td>\n",
        "      <td>bayesianhorse</td>\n",
@@ -3604,7 +2646,16 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>223</th>\n",
+       "      <th>208</th>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>I like the idea of moving that arrow the way h...</td>\n",
+       "      <td>rattray</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>2015-06-08 02:15:30+00:00</td>\n",
+       "      <td>comment</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>227</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>I don&amp;#x27;t understand why a beginner would s...</td>\n",
        "      <td>wolco</td>\n",
@@ -3613,7 +2664,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>284</th>\n",
+       "      <th>289</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>I leaerned more with one minute of this than a...</td>\n",
        "      <td>agumonkey</td>\n",
@@ -3622,7 +2673,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>297</th>\n",
+       "      <th>302</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>I've suggested a &lt;i&gt;rationale&lt;/i&gt; for the tabo...</td>\n",
        "      <td>mechanical_fish</td>\n",
@@ -3631,7 +2682,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>306</th>\n",
+       "      <th>311</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>Do you have any reference for this?&lt;p&gt;I&amp;#x27;m...</td>\n",
        "      <td>banashark</td>\n",
@@ -3640,7 +2691,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>316</th>\n",
+       "      <th>321</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>Default search scope is an option in the Finde...</td>\n",
        "      <td>kitsunesoba</td>\n",
@@ -3649,7 +2700,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>386</th>\n",
+       "      <th>390</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>Orthogonality and biology aren&amp;#x27;t friends.</td>\n",
        "      <td>agumonkey</td>\n",
@@ -3658,7 +2709,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>391</th>\n",
+       "      <th>395</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>I chose some random physics book that was good...</td>\n",
        "      <td>prawn</td>\n",
@@ -3667,7 +2718,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>417</th>\n",
+       "      <th>423</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>Seeing this get huge on Twitter. It&amp;#x27;s the...</td>\n",
        "      <td>shenanigoat</td>\n",
@@ -3676,7 +2727,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>421</th>\n",
+       "      <th>427</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>Looking through the comments there are a numbe...</td>\n",
        "      <td>moomin</td>\n",
@@ -3685,7 +2736,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>422</th>\n",
+       "      <th>428</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>Legacy media is a tough business. GBTC is payi...</td>\n",
        "      <td>arcticbull</td>\n",
@@ -3694,7 +2745,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>429</th>\n",
+       "      <th>435</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>Same thing if you sell unsafe food, yet we hav...</td>\n",
        "      <td>jabradoodle</td>\n",
@@ -3703,7 +2754,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>431</th>\n",
+       "      <th>437</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>There was briefly a thing called HSCSD (&amp;quot;...</td>\n",
        "      <td>LeoPanthera</td>\n",
@@ -3712,7 +2763,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>439</th>\n",
+       "      <th>445</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&amp;gt; This article is a bit comical to read and...</td>\n",
        "      <td>lapcat</td>\n",
@@ -3721,7 +2772,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>446</th>\n",
+       "      <th>452</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>Large positions are most likely sold off in sm...</td>\n",
        "      <td>meowkit</td>\n",
@@ -3730,7 +2781,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>500</th>\n",
+       "      <th>506</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>A US-based VPN (or really any VPN) is only goi...</td>\n",
        "      <td>RandomBacon</td>\n",
@@ -3739,7 +2790,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>533</th>\n",
+       "      <th>542</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>&lt;a href=\"https:&amp;#x2F;&amp;#x2F;codeberg.org&amp;#x2F;A...</td>\n",
        "      <td>ElectronBadger</td>\n",
@@ -3748,16 +2799,16 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>589</th>\n",
+       "      <th>564</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>&amp;gt; To me, a point of view is to do with your...</td>\n",
-       "      <td>dragonwriter</td>\n",
+       "      <td>It’s much harder for people without hands to w...</td>\n",
+       "      <td>Aeolun</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>2019-02-13 23:05:50+00:00</td>\n",
+       "      <td>2024-05-03 11:58:13+00:00</td>\n",
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>601</th>\n",
+       "      <th>611</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>So by using ADMIN_SL0T instead was it just set...</td>\n",
        "      <td>minitoar</td>\n",
@@ -3766,25 +2817,7 @@
        "      <td>comment</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>616</th>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>I completely agree that this sets a bad preced...</td>\n",
-       "      <td>save_ferris</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>2019-05-08 14:55:22+00:00</td>\n",
-       "      <td>comment</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>634</th>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>How are guitar playing skills useful if you do...</td>\n",
-       "      <td>Yajirobe</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>2019-06-14 10:18:19+00:00</td>\n",
-       "      <td>comment</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>647</th>\n",
+       "      <th>658</th>\n",
        "      <td>&lt;NA&gt;</td>\n",
        "      <td>Outstanding!</td>\n",
        "      <td>cafard</td>\n",
@@ -3792,98 +2825,107 @@
        "      <td>2022-06-09 09:51:54+00:00</td>\n",
        "      <td>comment</td>\n",
        "    </tr>\n",
+       "    <tr>\n",
+       "      <th>671</th>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>On the other hand, something can be said for &amp;...</td>\n",
+       "      <td>babby</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>2013-08-12 00:31:02+00:00</td>\n",
+       "      <td>comment</td>\n",
+       "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "<p>25 rows × 6 columns</p>\n",
-       "</div>[121 rows x 6 columns in total]"
+       "</div>[123 rows x 6 columns in total]"
       ],
       "text/plain": [
-       "                            title  \\\n",
-       "24   Working Best at Coffee Shops   \n",
-       "96                           <NA>   \n",
-       "106                          <NA>   \n",
-       "184                          <NA>   \n",
-       "223                          <NA>   \n",
-       "284                          <NA>   \n",
-       "297                          <NA>   \n",
-       "306                          <NA>   \n",
-       "316                          <NA>   \n",
-       "386                          <NA>   \n",
-       "391                          <NA>   \n",
-       "417                          <NA>   \n",
-       "421                          <NA>   \n",
-       "422                          <NA>   \n",
-       "429                          <NA>   \n",
-       "431                          <NA>   \n",
-       "439                          <NA>   \n",
-       "446                          <NA>   \n",
-       "500                          <NA>   \n",
-       "533                          <NA>   \n",
-       "589                          <NA>   \n",
-       "601                          <NA>   \n",
-       "616                          <NA>   \n",
-       "634                          <NA>   \n",
-       "647                          <NA>   \n",
+       "                                               title  \\\n",
+       "24                      Working Best at Coffee Shops   \n",
+       "98                                              <NA>   \n",
+       "137  FDA reverses marketing ban on Juul e-cigarettes   \n",
+       "188                                             <NA>   \n",
+       "208                                             <NA>   \n",
+       "227                                             <NA>   \n",
+       "289                                             <NA>   \n",
+       "302                                             <NA>   \n",
+       "311                                             <NA>   \n",
+       "321                                             <NA>   \n",
+       "390                                             <NA>   \n",
+       "395                                             <NA>   \n",
+       "423                                             <NA>   \n",
+       "427                                             <NA>   \n",
+       "428                                             <NA>   \n",
+       "435                                             <NA>   \n",
+       "437                                             <NA>   \n",
+       "445                                             <NA>   \n",
+       "452                                             <NA>   \n",
+       "506                                             <NA>   \n",
+       "542                                             <NA>   \n",
+       "564                                             <NA>   \n",
+       "611                                             <NA>   \n",
+       "658                                             <NA>   \n",
+       "671                                             <NA>   \n",
        "\n",
        "                                                  text               by  \\\n",
        "24                                                <NA>   GiraffeNecktie   \n",
-       "96   i resisted switching to chrome for months beca...         catshirt   \n",
-       "106  I was about to say the same thing myself. For ...         geophile   \n",
-       "184  I think it&#x27;s more than hazing. It may be ...    bayesianhorse   \n",
-       "223  I don&#x27;t understand why a beginner would s...            wolco   \n",
-       "284  I leaerned more with one minute of this than a...        agumonkey   \n",
-       "297  I've suggested a <i>rationale</i> for the tabo...  mechanical_fish   \n",
-       "306  Do you have any reference for this?<p>I&#x27;m...        banashark   \n",
-       "316  Default search scope is an option in the Finde...      kitsunesoba   \n",
-       "386     Orthogonality and biology aren&#x27;t friends.        agumonkey   \n",
-       "391  I chose some random physics book that was good...            prawn   \n",
-       "417  Seeing this get huge on Twitter. It&#x27;s the...      shenanigoat   \n",
-       "421  Looking through the comments there are a numbe...           moomin   \n",
-       "422  Legacy media is a tough business. GBTC is payi...       arcticbull   \n",
-       "429  Same thing if you sell unsafe food, yet we hav...      jabradoodle   \n",
-       "431  There was briefly a thing called HSCSD (&quot;...      LeoPanthera   \n",
-       "439  &gt; This article is a bit comical to read and...           lapcat   \n",
-       "446  Large positions are most likely sold off in sm...          meowkit   \n",
-       "500  A US-based VPN (or really any VPN) is only goi...      RandomBacon   \n",
-       "533  <a href=\"https:&#x2F;&#x2F;codeberg.org&#x2F;A...   ElectronBadger   \n",
-       "589  &gt; To me, a point of view is to do with your...     dragonwriter   \n",
-       "601  So by using ADMIN_SL0T instead was it just set...         minitoar   \n",
-       "616  I completely agree that this sets a bad preced...      save_ferris   \n",
-       "634  How are guitar playing skills useful if you do...         Yajirobe   \n",
-       "647                                       Outstanding!           cafard   \n",
+       "98   i resisted switching to chrome for months beca...         catshirt   \n",
+       "137                                               <NA>        anigbrowl   \n",
+       "188  I think it&#x27;s more than hazing. It may be ...    bayesianhorse   \n",
+       "208  I like the idea of moving that arrow the way h...          rattray   \n",
+       "227  I don&#x27;t understand why a beginner would s...            wolco   \n",
+       "289  I leaerned more with one minute of this than a...        agumonkey   \n",
+       "302  I've suggested a <i>rationale</i> for the tabo...  mechanical_fish   \n",
+       "311  Do you have any reference for this?<p>I&#x27;m...        banashark   \n",
+       "321  Default search scope is an option in the Finde...      kitsunesoba   \n",
+       "390     Orthogonality and biology aren&#x27;t friends.        agumonkey   \n",
+       "395  I chose some random physics book that was good...            prawn   \n",
+       "423  Seeing this get huge on Twitter. It&#x27;s the...      shenanigoat   \n",
+       "427  Looking through the comments there are a numbe...           moomin   \n",
+       "428  Legacy media is a tough business. GBTC is payi...       arcticbull   \n",
+       "435  Same thing if you sell unsafe food, yet we hav...      jabradoodle   \n",
+       "437  There was briefly a thing called HSCSD (&quot;...      LeoPanthera   \n",
+       "445  &gt; This article is a bit comical to read and...           lapcat   \n",
+       "452  Large positions are most likely sold off in sm...          meowkit   \n",
+       "506  A US-based VPN (or really any VPN) is only goi...      RandomBacon   \n",
+       "542  <a href=\"https:&#x2F;&#x2F;codeberg.org&#x2F;A...   ElectronBadger   \n",
+       "564  It’s much harder for people without hands to w...           Aeolun   \n",
+       "611  So by using ADMIN_SL0T instead was it just set...         minitoar   \n",
+       "658                                       Outstanding!           cafard   \n",
+       "671  On the other hand, something can be said for &...            babby   \n",
        "\n",
        "     score                  timestamp     type  \n",
        "24     249  2011-04-19 14:25:17+00:00    story  \n",
-       "96    <NA>  2011-04-06 08:02:24+00:00  comment  \n",
-       "106   <NA>  2011-12-08 21:13:08+00:00  comment  \n",
-       "184   <NA>  2015-06-18 16:42:53+00:00  comment  \n",
-       "223   <NA>  2019-02-03 14:35:43+00:00  comment  \n",
-       "284   <NA>  2016-07-16 06:19:39+00:00  comment  \n",
-       "297   <NA>  2008-12-17 04:42:02+00:00  comment  \n",
-       "306   <NA>  2023-11-13 19:57:00+00:00  comment  \n",
-       "316   <NA>  2017-08-13 17:15:19+00:00  comment  \n",
-       "386   <NA>  2016-04-24 16:33:41+00:00  comment  \n",
-       "391   <NA>  2011-03-27 22:29:51+00:00  comment  \n",
-       "417   <NA>  2016-01-09 03:04:22+00:00  comment  \n",
-       "421   <NA>  2024-10-01 14:37:04+00:00  comment  \n",
-       "422   <NA>  2021-04-16 16:30:33+00:00  comment  \n",
-       "429   <NA>  2023-08-03 20:47:52+00:00  comment  \n",
-       "431   <NA>  2019-02-11 19:49:29+00:00  comment  \n",
-       "439   <NA>  2023-01-02 16:00:49+00:00  comment  \n",
-       "446   <NA>  2021-01-27 23:22:48+00:00  comment  \n",
-       "500   <NA>  2019-04-05 00:58:58+00:00  comment  \n",
-       "533   <NA>  2023-12-13 08:13:15+00:00  comment  \n",
-       "589   <NA>  2019-02-13 23:05:50+00:00  comment  \n",
-       "601   <NA>  2021-03-05 16:07:56+00:00  comment  \n",
-       "616   <NA>  2019-05-08 14:55:22+00:00  comment  \n",
-       "634   <NA>  2019-06-14 10:18:19+00:00  comment  \n",
-       "647   <NA>  2022-06-09 09:51:54+00:00  comment  \n",
+       "98    <NA>  2011-04-06 08:02:24+00:00  comment  \n",
+       "137      2  2024-06-06 16:42:40+00:00    story  \n",
+       "188   <NA>  2015-06-18 16:42:53+00:00  comment  \n",
+       "208   <NA>  2015-06-08 02:15:30+00:00  comment  \n",
+       "227   <NA>  2019-02-03 14:35:43+00:00  comment  \n",
+       "289   <NA>  2016-07-16 06:19:39+00:00  comment  \n",
+       "302   <NA>  2008-12-17 04:42:02+00:00  comment  \n",
+       "311   <NA>  2023-11-13 19:57:00+00:00  comment  \n",
+       "321   <NA>  2017-08-13 17:15:19+00:00  comment  \n",
+       "390   <NA>  2016-04-24 16:33:41+00:00  comment  \n",
+       "395   <NA>  2011-03-27 22:29:51+00:00  comment  \n",
+       "423   <NA>  2016-01-09 03:04:22+00:00  comment  \n",
+       "427   <NA>  2024-10-01 14:37:04+00:00  comment  \n",
+       "428   <NA>  2021-04-16 16:30:33+00:00  comment  \n",
+       "435   <NA>  2023-08-03 20:47:52+00:00  comment  \n",
+       "437   <NA>  2019-02-11 19:49:29+00:00  comment  \n",
+       "445   <NA>  2023-01-02 16:00:49+00:00  comment  \n",
+       "452   <NA>  2021-01-27 23:22:48+00:00  comment  \n",
+       "506   <NA>  2019-04-05 00:58:58+00:00  comment  \n",
+       "542   <NA>  2023-12-13 08:13:15+00:00  comment  \n",
+       "564   <NA>  2024-05-03 11:58:13+00:00  comment  \n",
+       "611   <NA>  2021-03-05 16:07:56+00:00  comment  \n",
+       "658   <NA>  2022-06-09 09:51:54+00:00  comment  \n",
+       "671   <NA>  2013-08-12 00:31:02+00:00  comment  \n",
        "...\n",
        "\n",
-       "[121 rows x 6 columns]"
+       "[123 rows x 6 columns]"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
* Updated the version requirement to be at least 1.23.
* Hide progress bar.
* Updated the semantic aggregation with the correct example.
