### PR TITLE
deps: remove sqlglot upper bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,14 +57,11 @@ dependencies = [
     "requests >=2.27.1",
     "scikit-learn >=1.2.2",
     "sqlalchemy >=1.4,<3.0dev",
-    # Keep sqlglot versions in sync with ibis-framework. This avoids problems
-    # where the incorrect version of sqlglot is installed, such as
-    # https://github.com/googleapis/python-bigquery-dataframes/issues/315
-    "sqlglot >=23.6.3,<25.2",
-    "tabulate >= 0.9",
+    "sqlglot >=23.6.3",
+    "tabulate >=0.9",
     "ipywidgets >=7.7.1",
-    "humanize >= 4.6.0",
-    "matplotlib >= 3.7.1",
+    "humanize >=4.6.0",
+    "matplotlib >=3.7.1",
     # For vendored ibis-framework.
     "atpublic>=2.3,<6",
     "parsy>=2,<3",


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)

Fixes #942  🦕

Additionally this allows use of bigframes with SQLMesh. If this is merged, I will build first class support into SQLMesh which opens up BigFrames usage to the audience of folks building transformations for their org with that tool. 

The upper bound is removed in this PR. This helps libraries include bigframes as a package. SQLMesh team are also the stewards of SQLGlot and hence they ride the bleeding edge. An upper bound would eventually introduce dependency hell (unresolvable). I checked the API surface area of what is being used in sqlglot. It seems quite minor outside what `ibis/expr/sql.py` touches. 