### PR TITLE
fix: avoid global mutation in `BigQueryOptions.client_endpoints_override`

### DIFF
--- a/bigframes/_config/bigquery_options.py
+++ b/bigframes/_config/bigquery_options.py
@@ -91,7 +91,7 @@ class BigQueryOptions:
         skip_bq_connection_check: bool = False,
         *,
         ordering_mode: Literal["strict", "partial"] = "strict",
-        client_endpoints_override: dict = {},
+        client_endpoints_override: Optional[dict] = None,
     ):
         self._credentials = credentials
         self._project = project
@@ -104,6 +104,10 @@ class BigQueryOptions:
         self._session_started = False
         # Determines the ordering strictness for the session.
         self._ordering_mode = _validate_ordering_mode(ordering_mode)
+
+        if client_endpoints_override is None:
+            client_endpoints_override = {}
+        
         self._client_endpoints_override = client_endpoints_override
 
     @property

--- a/bigframes/_config/bigquery_options.py
+++ b/bigframes/_config/bigquery_options.py
@@ -107,7 +107,7 @@ class BigQueryOptions:
 
         if client_endpoints_override is None:
             client_endpoints_override = {}
-        
+
         self._client_endpoints_override = client_endpoints_override
 
     @property


### PR DESCRIPTION
This fixes a common "gotcha" in Python. Before this fix, mutations to this dictionary will affect all instances of the BigQueryOptions class, not just the current instance.

See: https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes internal issue 389087778 🦕
