### PR TITLE
feat: (df|s).hist(), (df|s).line(), (df|s).area(), (df|s).bar(), df.scatter()

### DIFF
--- a/bigframes/dataframe.py
+++ b/bigframes/dataframe.py
@@ -4313,6 +4313,56 @@ class DataFrame(vendored_pandas_frame.DataFrame):
     def plot(self):
         return plotting.PlotAccessor(self)
 
+    def hist(
+        self, by: typing.Optional[typing.Sequence[str]] = None, bins: int = 10, **kwargs
+    ):
+        return self.plot.hist(by=by, bins=bins, **kwargs)
+
+    hist.__doc__ = inspect.getdoc(plotting.PlotAccessor.hist)
+
+    def line(
+        self,
+        x: typing.Optional[typing.Hashable] = None,
+        y: typing.Optional[typing.Hashable] = None,
+        **kwargs,
+    ):
+        return self.plot.line(x=x, y=y, **kwargs)
+
+    line.__doc__ = inspect.getdoc(plotting.PlotAccessor.line)
+
+    def area(
+        self,
+        x: typing.Optional[typing.Hashable] = None,
+        y: typing.Optional[typing.Hashable] = None,
+        stacked: bool = True,
+        **kwargs,
+    ):
+        return self.plot.area(x=x, y=y, stacked=stacked, **kwargs)
+
+    area.__doc__ = inspect.getdoc(plotting.PlotAccessor.area)
+
+    def bar(
+        self,
+        x: typing.Optional[typing.Hashable] = None,
+        y: typing.Optional[typing.Hashable] = None,
+        **kwargs,
+    ):
+        return self.plot.bar(x=x, y=y, **kwargs)
+
+    bar.__doc__ = inspect.getdoc(plotting.PlotAccessor.bar)
+
+    def scatter(
+        self,
+        x: typing.Optional[typing.Hashable] = None,
+        y: typing.Optional[typing.Hashable] = None,
+        s: typing.Union[typing.Hashable, typing.Sequence[typing.Hashable]] = None,
+        c: typing.Union[typing.Hashable, typing.Sequence[typing.Hashable]] = None,
+        **kwargs,
+    ):
+        return self.plot.scatter(x=x, y=y, s=s, c=c, **kwargs)
+
+    scatter.__doc__ = inspect.getdoc(plotting.PlotAccessor.scatter)
+
     def __matmul__(self, other) -> DataFrame:
         return self.dot(other)
 

--- a/bigframes/series.py
+++ b/bigframes/series.py
@@ -1984,15 +1984,47 @@ class Series(bigframes.operations.base.SeriesMethods, vendored_pandas_series.Ser
 
         return NotImplemented
 
-    # Keep this at the bottom of the Series class to avoid
-    # confusing type checker by overriding str
-    @property
-    def str(self) -> strings.StringMethods:
-        return strings.StringMethods(self._block)
-
     @property
     def plot(self):
         return plotting.PlotAccessor(self)
+
+    def hist(
+        self, by: typing.Optional[typing.Sequence[str]] = None, bins: int = 10, **kwargs
+    ):
+        return self.plot.hist(by=by, bins=bins, **kwargs)
+
+    hist.__doc__ = inspect.getdoc(plotting.PlotAccessor.hist)
+
+    def line(
+        self,
+        x: typing.Optional[typing.Hashable] = None,
+        y: typing.Optional[typing.Hashable] = None,
+        **kwargs,
+    ):
+        return self.plot.line(x=x, y=y, **kwargs)
+
+    line.__doc__ = inspect.getdoc(plotting.PlotAccessor.line)
+
+    def area(
+        self,
+        x: typing.Optional[typing.Hashable] = None,
+        y: typing.Optional[typing.Hashable] = None,
+        stacked: bool = True,
+        **kwargs,
+    ):
+        return self.plot.area(x=x, y=y, stacked=stacked, **kwargs)
+
+    area.__doc__ = inspect.getdoc(plotting.PlotAccessor.area)
+
+    def bar(
+        self,
+        x: typing.Optional[typing.Hashable] = None,
+        y: typing.Optional[typing.Hashable] = None,
+        **kwargs,
+    ):
+        return self.plot.bar(x=x, y=y, **kwargs)
+
+    bar.__doc__ = inspect.getdoc(plotting.PlotAccessor.bar)
 
     def _slice(
         self,
@@ -2021,6 +2053,12 @@ class Series(bigframes.operations.base.SeriesMethods, vendored_pandas_series.Ser
     def _cached(self, *, force: bool = True, session_aware: bool = True) -> Series:
         self._block.cached(force=force, session_aware=session_aware)
         return self
+
+    # Keep this at the bottom of the Series class to avoid
+    # confusing type checker by overriding str
+    @property
+    def str(self) -> strings.StringMethods:
+        return strings.StringMethods(self._block)
 
 
 def _is_list_like(obj: typing.Any) -> typing_extensions.TypeGuard[typing.Sequence]:

--- a/tests/system/small/operations/test_plotting.py
+++ b/tests/system/small/operations/test_plotting.py
@@ -34,10 +34,20 @@ def _check_legend_labels(ax, labels):
         assert label == e
 
 
-def test_series_hist_bins(scalars_dfs):
+@pytest.mark.parametrize(
+    ("alias"),
+    [
+        pytest.param(True),
+        pytest.param(False),
+    ],
+)
+def test_series_hist_bins(scalars_dfs, alias):
     scalars_df, scalars_pandas_df = scalars_dfs
     bins = 5
-    ax = scalars_df["int64_col"].plot.hist(bins=bins)
+    if alias:
+        ax = scalars_df["int64_col"].hist(bins=bins)
+    else:
+        ax = scalars_df["int64_col"].plot.hist(bins=bins)
     pd_ax = scalars_pandas_df["int64_col"].plot.hist(bins=bins)
 
     # Compares axis values and height between bigframes and pandas histograms.
@@ -49,11 +59,21 @@ def test_series_hist_bins(scalars_dfs):
         assert ax.patches[i]._height == pd_ax.patches[i]._height
 
 
-def test_dataframes_hist_bins(scalars_dfs):
+@pytest.mark.parametrize(
+    ("alias"),
+    [
+        pytest.param(True),
+        pytest.param(False),
+    ],
+)
+def test_dataframes_hist_bins(scalars_dfs, alias):
     scalars_df, scalars_pandas_df = scalars_dfs
     bins = 7
     columns = ["int64_col", "int64_too", "float64_col"]
-    ax = scalars_df[columns].plot.hist(bins=bins)
+    if alias:
+        ax = scalars_df[columns].hist(bins=bins)
+    else:
+        ax = scalars_df[columns].plot.hist(bins=bins)
     pd_ax = scalars_pandas_df[columns].plot.hist(bins=bins)
 
     # Compares axis values and height between bigframes and pandas histograms.
@@ -171,10 +191,25 @@ def test_hist_kwargs_ticks_props(scalars_dfs):
         tm.assert_almost_equal(ylabels[i].get_rotation(), pd_ylables[i].get_rotation())
 
 
-def test_line(scalars_dfs):
+@pytest.mark.parametrize(
+    ("col_names", "alias"),
+    [
+        pytest.param(
+            ["int64_col", "float64_col", "int64_too", "bool_col"], True, id="df_alias"
+        ),
+        pytest.param(
+            ["int64_col", "float64_col", "int64_too", "bool_col"], False, id="df"
+        ),
+        pytest.param(["int64_col"], True, id="series_alias"),
+        pytest.param(["int64_col"], False, id="series"),
+    ],
+)
+def test_line(scalars_dfs, col_names, alias):
     scalars_df, scalars_pandas_df = scalars_dfs
-    col_names = ["int64_col", "float64_col", "int64_too", "bool_col"]
-    ax = scalars_df[col_names].plot.line()
+    if alias:
+        ax = scalars_df[col_names].line()
+    else:
+        ax = scalars_df[col_names].plot.line()
     pd_ax = scalars_pandas_df[col_names].plot.line()
     tm.assert_almost_equal(ax.get_xticks(), pd_ax.get_xticks())
     tm.assert_almost_equal(ax.get_yticks(), pd_ax.get_yticks())
@@ -183,10 +218,21 @@ def test_line(scalars_dfs):
         tm.assert_almost_equal(line.get_data()[1], pd_line.get_data()[1])
 
 
-def test_area(scalars_dfs):
+@pytest.mark.parametrize(
+    ("col_names", "alias"),
+    [
+        pytest.param(["int64_col", "float64_col", "int64_too"], True, id="df_alias"),
+        pytest.param(["int64_col", "float64_col", "int64_too"], False, id="df"),
+        pytest.param(["int64_col"], True, id="series_alias"),
+        pytest.param(["int64_col"], False, id="series"),
+    ],
+)
+def test_area(scalars_dfs, col_names, alias):
     scalars_df, scalars_pandas_df = scalars_dfs
-    col_names = ["int64_col", "float64_col", "int64_too"]
-    ax = scalars_df[col_names].plot.area(stacked=False)
+    if alias:
+        ax = scalars_df[col_names].area(stacked=False)
+    else:
+        ax = scalars_df[col_names].plot.area(stacked=False)
     pd_ax = scalars_pandas_df[col_names].plot.area(stacked=False)
     tm.assert_almost_equal(ax.get_xticks(), pd_ax.get_xticks())
     tm.assert_almost_equal(ax.get_yticks(), pd_ax.get_yticks())
@@ -195,10 +241,21 @@ def test_area(scalars_dfs):
         tm.assert_almost_equal(line.get_data()[1], pd_line.get_data()[1])
 
 
-def test_bar(scalars_dfs):
+@pytest.mark.parametrize(
+    ("col_names", "alias"),
+    [
+        pytest.param(["int64_col", "float64_col", "int64_too"], True, id="df_alias"),
+        pytest.param(["int64_col", "float64_col", "int64_too"], False, id="df"),
+        pytest.param(["int64_col"], True, id="series_alias"),
+        pytest.param(["int64_col"], False, id="series"),
+    ],
+)
+def test_bar(scalars_dfs, col_names, alias):
     scalars_df, scalars_pandas_df = scalars_dfs
-    col_names = ["int64_col", "float64_col", "int64_too"]
-    ax = scalars_df[col_names].plot.bar()
+    if alias:
+        ax = scalars_df[col_names].bar()
+    else:
+        ax = scalars_df[col_names].plot.bar()
     pd_ax = scalars_pandas_df[col_names].plot.bar()
     tm.assert_almost_equal(ax.get_xticks(), pd_ax.get_xticks())
     tm.assert_almost_equal(ax.get_yticks(), pd_ax.get_yticks())
@@ -207,10 +264,23 @@ def test_bar(scalars_dfs):
         tm.assert_almost_equal(line.get_data()[1], pd_line.get_data()[1])
 
 
-def test_scatter(scalars_dfs):
+@pytest.mark.parametrize(
+    ("col_names", "alias"),
+    [
+        pytest.param(
+            ["int64_col", "float64_col", "int64_too", "bool_col"], True, id="df_alias"
+        ),
+        pytest.param(
+            ["int64_col", "float64_col", "int64_too", "bool_col"], False, id="df"
+        ),
+    ],
+)
+def test_scatter(scalars_dfs, col_names, alias):
     scalars_df, scalars_pandas_df = scalars_dfs
-    col_names = ["int64_col", "float64_col", "int64_too", "bool_col"]
-    ax = scalars_df[col_names].plot.scatter(x="int64_col", y="float64_col")
+    if alias:
+        ax = scalars_df[col_names].scatter(x="int64_col", y="float64_col")
+    else:
+        ax = scalars_df[col_names].plot.scatter(x="int64_col", y="float64_col")
     pd_ax = scalars_pandas_df[col_names].plot.scatter(x="int64_col", y="float64_col")
     tm.assert_almost_equal(ax.get_xticks(), pd_ax.get_xticks())
     tm.assert_almost_equal(ax.get_yticks(), pd_ax.get_yticks())


### PR DESCRIPTION
This change is creating `df.hist()` API, which is an alias for `df.plot.hist()`. Similarly, we also create `hist()`, `line()`, `area()`, `bar()` for both DataFrame and Series, and `scatter()` for DataFrame.

- [X] Fixes internal issue 353988356 
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes internal issue 353988356 🦕
