### PR TITLE
chore: fix experimental blob repr without content_type

### DIFF
--- a/bigframes/dataframe.py
+++ b/bigframes/dataframe.py
@@ -768,11 +768,11 @@ class DataFrame(vendored_pandas_frame.DataFrame):
 
                 def obj_ref_rt_to_html(obj_ref_rt) -> str:
                     obj_ref_rt_json = json.loads(obj_ref_rt)
+                    gcs_metadata = obj_ref_rt_json["objectref"]["details"][
+                        "gcs_metadata"
+                    ]
                     content_type = typing.cast(
-                        str,
-                        obj_ref_rt_json["objectref"]["details"]["gcs_metadata"][
-                            "content_type"
-                        ],
+                        str, gcs_metadata.get("content_type", "")
                     )
                     if content_type.startswith("image"):
                         url = obj_ref_rt_json["access_urls"]["read_url"]


### PR DESCRIPTION
verified in test env screen/abHW62XjLfHuvBD, the README file doesn't have a content_type

b/391953196
