### PR TITLE
chore: Revert "remove 10t benchmark temporarily"

### DIFF
--- a/tests/benchmark/tpch/config.jsonl
+++ b/tests/benchmark/tpch/config.jsonl
@@ -6,3 +6,5 @@
 {"benchmark_suffix": "100g_unordered", "project_id": "bigframes-dev-perf", "dataset_id": "tpch_0100g", "ordered": false}
 {"benchmark_suffix": "1t_ordered", "project_id": "bigframes-dev-perf", "dataset_id": "tpch_0001t", "ordered": true}
 {"benchmark_suffix": "1t_unordered", "project_id": "bigframes-dev-perf", "dataset_id": "tpch_0001t", "ordered": false}
+{"benchmark_suffix": "10t_ordered", "project_id": "bigframes-dev-perf", "dataset_id": "tpch_0010t", "ordered": true}
+{"benchmark_suffix": "10t_unordered", "project_id": "bigframes-dev-perf", "dataset_id": "tpch_0010t", "ordered": false}


### PR DESCRIPTION
Reverts googleapis/python-bigquery-dataframes#1341