### PR TITLE
chore: add experimental blob.pdf_chunking function

### DIFF
--- a/bigframes/blob/_functions.py
+++ b/bigframes/blob/_functions.py
@@ -186,21 +186,21 @@ def pdf_chunk_func(src_obj_ref_rt: str, chunk_size: int, overlap_size: int) -> s
 
     all_text_chunks = []
     curr_chunk = ""
-    chunk_start_idx = 0
     for page in reader.pages:
         page_text = page.extract_text()
         if page_text:
-            for char in page_text:
-                curr_chunk += char
-                if len(curr_chunk) >= chunk_size:
-                    all_text_chunks.append(curr_chunk)
-                    chunk_start_idx += chunk_size - overlap_size
-                    curr_chunk = page_text[
-                        chunk_start_idx : chunk_start_idx + overlap_size
-                    ]
-                    chunk_start_idx = 0
-                    if len(curr_chunk) > chunk_size:
-                        curr_chunk = curr_chunk[:chunk_size]
+            curr_chunk += page_text
+
+            while len(curr_chunk) >= chunk_size:
+                split_idx = curr_chunk.rfind(" ", 0, chunk_size)
+                if split_idx == -1:
+                    split_idx = chunk_size
+
+                actual_chunk = curr_chunk[:split_idx]
+                all_text_chunks.append(actual_chunk)
+                overlap = curr_chunk[split_idx + 1 : split_idx + 1 + overlap_size]
+                curr_chunk = overlap + curr_chunk[split_idx + 1 + overlap_size :]
+
     if curr_chunk:
         all_text_chunks.append(curr_chunk)
 

--- a/bigframes/blob/_functions.py
+++ b/bigframes/blob/_functions.py
@@ -130,7 +130,7 @@ def image_blur_func(
 image_blur_def = FunctionDef(image_blur_func, ["opencv-python", "numpy", "requests"])
 
 
-def pdf_chunking_func(src_obj_ref_rt: str, dst_obj_ref_rt: str) -> str:
+def pdf_chunking_func(src_obj_ref_rt: str) -> str:
     import io
     import json
 
@@ -138,13 +138,7 @@ def pdf_chunking_func(src_obj_ref_rt: str, dst_obj_ref_rt: str) -> str:
     import requests
 
     src_obj_ref_rt_json = json.loads(src_obj_ref_rt)
-    dst_obj_ref_rt_json = json.loads(dst_obj_ref_rt)
-
     src_url = src_obj_ref_rt_json["access_urls"]["read_url"]
-    dst_url = dst_obj_ref_rt_json["access_urls"]["write_url"]
-
-    print(f"Source URL: {src_url}")  # Debug print
-    print(f"Destination URL: {dst_url}")  # Debug print
 
     response = requests.get(src_url, stream=True)
     response.raise_for_status()
@@ -160,16 +154,7 @@ def pdf_chunking_func(src_obj_ref_rt: str, dst_obj_ref_rt: str) -> str:
 
     all_text_json_string = json.dumps(all_text)
 
-    # Upload the JSON string to the destination URL
-    requests.put(
-        url=dst_url,
-        data=all_text_json_string.encode("utf-8"),
-        headers={
-            "Content-Type": "application/json",
-        },
-    )
-
-    return dst_obj_ref_rt
+    return all_text_json_string
 
 
 pdf_chunking_def = FunctionDef(pdf_chunking_func, ["pypdf", "requests"])

--- a/bigframes/blob/_functions.py
+++ b/bigframes/blob/_functions.py
@@ -142,9 +142,10 @@ def pdf_chunking_func(src_obj_ref_rt: str) -> str:
 
     response = requests.get(src_url, stream=True)
     response.raise_for_status()
+    pdf_bytes = response.content
 
-    file_name = io.BytesIO(response.content)
-    reader = PdfReader(file_name, strict=False)
+    pdf_file = io.BytesIO(pdf_bytes)
+    reader = PdfReader(pdf_file, strict=False)
 
     all_text = []
     for page in reader.pages:

--- a/bigframes/blob/_functions.py
+++ b/bigframes/blob/_functions.py
@@ -137,43 +137,27 @@ def pdf_chunking_func(src_obj_ref_rt: str, dst_obj_ref_rt: str) -> str:
     from pypdf import PdfReader  # type: ignore
     import requests
 
-    print("Entering pdf_chunking_func")  # Debug print
-
-    # Load the source and destination object reference runtime JSON strings
     src_obj_ref_rt_json = json.loads(src_obj_ref_rt)
     dst_obj_ref_rt_json = json.loads(dst_obj_ref_rt)
 
-    # Get the read URL from the source object reference
     src_url = src_obj_ref_rt_json["access_urls"]["read_url"]
     dst_url = dst_obj_ref_rt_json["access_urls"]["write_url"]
 
     print(f"Source URL: {src_url}")  # Debug print
     print(f"Destination URL: {dst_url}")  # Debug print
 
-    # Download the PDF file from the source URL
     response = requests.get(src_url, stream=True)
     response.raise_for_status()
 
-    print("PDF file downloaded successfully")  # Debug print
-
-    # Read the PDF content into a BytesIO object
     file_name = io.BytesIO(response.content)
-
-    # Initialize the PDF reader
     reader = PdfReader(file_name, strict=False)
 
-    print("PDF reader initialized")  # Debug print
-
-    # Extract text from each page
     all_text = []
     for page in reader.pages:
         page_extract_text = page.extract_text()
-        if page_extract_text:  # Ensure text is not None
+        if page_extract_text:
             all_text.append(page_extract_text)
 
-    print("Text extracted from PDF")  # Debug print
-
-    # Convert the extracted text to a JSON string
     all_text_json_string = json.dumps(all_text)
 
     # Upload the JSON string to the destination URL
@@ -185,7 +169,6 @@ def pdf_chunking_func(src_obj_ref_rt: str, dst_obj_ref_rt: str) -> str:
         },
     )
 
-    print("JSON string uploaded to destination URL")  # Debug print
     return dst_obj_ref_rt
 
 

--- a/bigframes/blob/_functions.py
+++ b/bigframes/blob/_functions.py
@@ -130,7 +130,7 @@ def image_blur_func(
 image_blur_def = FunctionDef(image_blur_func, ["opencv-python", "numpy", "requests"])
 
 
-def pdf_chunking_func(src_obj_ref_rt: str) -> str:
+def pdf_chunk_func(src_obj_ref_rt: str) -> str:
     import io
     import json
 
@@ -158,4 +158,4 @@ def pdf_chunking_func(src_obj_ref_rt: str) -> str:
     return all_text_json_string
 
 
-pdf_chunking_def = FunctionDef(pdf_chunking_func, ["pypdf", "requests"])
+pdf_chunk_def = FunctionDef(pdf_chunk_func, ["pypdf", "requests"])

--- a/bigframes/operations/blob.py
+++ b/bigframes/operations/blob.py
@@ -227,6 +227,10 @@ class BlobAccessor(base.SeriesMethods):
     def _resolve_connection(self, connection: Optional[str] = None) -> str:
         """Resovle the BigQuery connection.
 
+        .. note::
+            BigFrames Blob is still under experiments. It may not work and
+            subject to change in the future.
+
         Args:
             connection (str or None, default None): BQ connection used for
                 function internet transactions, and the output blob if "dst" is
@@ -250,6 +254,10 @@ class BlobAccessor(base.SeriesMethods):
         self, mode: str = "R", with_metadata: bool = False
     ) -> bigframes.series.Series:
         """Get the runtime and apply the ToJSONSTring transformation.
+
+        .. note::
+            BigFrames Blob is still under experiments. It may not work and
+            subject to change in the future.
 
         Args:
             mode(str or str, default "R"): the mode for accessing the runtime.
@@ -315,8 +323,12 @@ class BlobAccessor(base.SeriesMethods):
         return dst
 
     def pdf_extract(self, *, connection: Optional[str] = None) -> list:
-        """Extracts and chunks text from PDF files and saves the text as
-           array of string.
+        """Extracts and chunks text from PDF URLs and saves the text as
+           arrays of string.
+
+        .. note::
+            BigFrames Blob is still under experiments. It may not work and
+            subject to change in the future.
 
         Args:
             connection (str or None, default None): BQ connection used for
@@ -349,8 +361,12 @@ class BlobAccessor(base.SeriesMethods):
         chunk_size: int = 1000,
         overlap_size: int = 200,
     ) -> list:
-        """Extracts and chunks text from PDF files and saves the text as
-           array of string.
+        """Extracts and chunks text from PDF URLs and saves the text as
+           arrays of strings.
+
+        .. note::
+            BigFrames Blob is still under experiments. It may not work and
+            subject to change in the future.
 
         Args:
             connection (str or None, default None): BQ connection used for

--- a/bigframes/operations/blob.py
+++ b/bigframes/operations/blob.py
@@ -281,3 +281,55 @@ class BlobAccessor(base.SeriesMethods):
         res.cache()  # to execute the udf
 
         return dst
+
+    def pdf_chunking(
+        self,
+        *,
+        dst: Union[str, bigframes.series.Series],
+        connection: Optional[str] = None,
+    ) -> bigframes.series.Series:
+        """Extracts text from PDF files and saves the text as a JSON string.
+
+        Args:
+            dst (str or bigframes.series.Series): Destination GCS folder str or blob series.
+            connection (str or None, default None): BQ connection used for function internet transactions, and the output blob if "dst" is str. If None, uses default connection of the session.
+
+        Returns:
+            BigFrames Blob Series
+        """
+        import bigframes.blob._functions as blob_func
+
+        connection = connection or self._block.session._bq_connection
+        connection = clients.resolve_full_bq_connection_name(
+            connection,
+            default_project=self._block.session._project,
+            default_location=self._block.session._location,
+        )
+
+        if isinstance(dst, str):
+            dst = os.path.join(dst, "")
+            src_uri = bigframes.series.Series(self._block).struct.explode()["uri"]
+            # Replace src folder with dst folder, keep the file names.
+            dst_uri = src_uri.str.replace(r"^.*\/(.*)$", rf"{dst}\1", regex=True)
+            dst = cast(
+                bigframes.series.Series, dst_uri.str.to_blob(connection=connection)
+            )
+
+        pdf_chunking_udf = blob_func.TransformFunction(
+            blob_func.pdf_chunking_def,
+            session=self._block.session,
+            connection=connection,
+        ).udf()
+
+        src_rt = self._get_runtime(mode="R")
+        dst_rt = dst.blob._get_runtime(mode="RW")
+
+        src_rt = src_rt._apply_unary_op(ops.ToJSONString())
+        dst_rt = dst_rt._apply_unary_op(ops.ToJSONString())
+
+        df = src_rt.to_frame().join(dst_rt.to_frame(), how="outer")
+
+        res = df.apply(pdf_chunking_udf, axis=1)
+        res.cache()  # to execute the udf
+
+        return dst

--- a/bigframes/operations/blob.py
+++ b/bigframes/operations/blob.py
@@ -291,8 +291,11 @@ class BlobAccessor(base.SeriesMethods):
         """Extracts text from PDF files and saves the text as a JSON string.
 
         Args:
-            dst (str or bigframes.series.Series): Destination GCS folder str or blob series.
-            connection (str or None, default None): BQ connection used for function internet transactions, and the output blob if "dst" is str. If None, uses default connection of the session.
+            dst (str or bigframes.series.Series): Destination GCS folder str
+                or blob series.
+            connection (str or None, default None): BQ connection used for
+                function internet transactions, and the output blob if "dst"
+                is str. If None, uses default connection of the session.
 
         Returns:
             BigFrames Blob Series

--- a/bigframes/operations/blob.py
+++ b/bigframes/operations/blob.py
@@ -322,7 +322,7 @@ class BlobAccessor(base.SeriesMethods):
 
         return dst
 
-    def pdf_extract(self, *, connection: Optional[str] = None) -> list:
+    def pdf_extract(self, *, connection: Optional[str] = None) -> str:
         """Extracts and chunks text from PDF URLs and saves the text as
            arrays of string.
 
@@ -351,8 +351,9 @@ class BlobAccessor(base.SeriesMethods):
 
         src_rt = self._get_runtime_json_str(mode="R")
         res = src_rt.apply(pdf_chunk_udf)
-
-        return res
+        if res is None:
+            return ""
+        return res.to_string() or ""
 
     def pdf_chunk(
         self,

--- a/bigframes/operations/blob.py
+++ b/bigframes/operations/blob.py
@@ -21,7 +21,6 @@ import IPython.display as ipy_display
 import requests
 
 from bigframes import clients
-import bigframes.blob._functions as blob_func
 import bigframes.dataframe
 from bigframes.operations import base
 import bigframes.operations as ops
@@ -236,6 +235,9 @@ class BlobAccessor(base.SeriesMethods):
         Returns:
             str: the resolved BigQuery connection string in the format:
              "project.location.connection_id".
+
+        Raises:
+            ValueError: If the connection cannot be resolved to a valid string.
         """
         connection = connection or self._block.session._bq_connection
         return clients.resolve_full_bq_connection_name(
@@ -262,6 +264,9 @@ class BlobAccessor(base.SeriesMethods):
             raise ValueError(
                 "Connection cannot be None. Provie a valid conenction string or ensure a default connection is set."
             )
+
+        import bigframes.blob._functions as blob_func
+
         return blob_func.TransformFunction(
             function_def,
             session=self._block.session,
@@ -302,6 +307,8 @@ class BlobAccessor(base.SeriesMethods):
         Returns:
             BigFrames Blob Series
         """
+        import bigframes.blob._functions as blob_func
+
         connection = self._resolve_connection(connection)
 
         if isinstance(dst, str):
@@ -348,6 +355,7 @@ class BlobAccessor(base.SeriesMethods):
                 text as JSON strings.
         """
         import bigframes.bigquery as bbq
+        import bigframes.blob._functions as blob_func
         import bigframes.pandas as bpd
 
         connection = self._resolve_connection(connection)


### PR DESCRIPTION
Verified in test env screen/6VAwRjCVt9aqYj6 screen/9B3P7VQPD667HUr

pypdf is under BSD-3-Clause license: [https://pypdf.readthedocs.io/en/stable/meta/faq.html#which-license-does-pypdf-use](https://pypdf.readthedocs.io/en/stable/meta/faq.html#which-license-does-pypdf-use)

1) blob.pdf_chunk reads in GCS link as input, extract and chunk pdf file based on user specified chunk_size and overlap_size
2) blob.pdf_extract reads in GCS link as input, extract pdf files
2) refactor code of blob.image_blur for better readability
