### PR TITLE
chore: remove discontinued sqlglot type attribute from the vendored ibis code

### DIFF
--- a/third_party/bigframes_vendored/ibis/backends/sql/datatypes.py
+++ b/third_party/bigframes_vendored/ibis/backends/sql/datatypes.py
@@ -63,7 +63,6 @@ _from_sqlglot_types = {
     typecode.VARBINARY: dt.Binary,
     typecode.VARCHAR: dt.String,
     typecode.VARIANT: dt.JSON,
-    typecode.UNIQUEIDENTIFIER: dt.UUID,
     typecode.SET: partial(dt.Array, dt.string),
     #############################
     # Unsupported sqlglot types #


### PR DESCRIPTION
The type attribute `UNIQUEIDENTIFIER` has been removed in sqlglot head
https://github.com/tobymao/sqlglot/commit/b12aba9be6043053f79ff50f7bdcdfdff19ddf52#diff-7857fedd1d1451b1b9a5b8efaa1cc292c02e7ee4f0d04d7e2f9d5bfb9565802c which is causing `unit_prerelease` tests fail with `AttributeError: type object 'Type' has no attribute 'UNIQUEIDENTIFIER'`:

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes internal issue 395193422 🦕
