### PR TITLE
chore: double the stale cloud function cleanup rate

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -990,7 +990,7 @@ def cleanup(session):
     # project within the "Number of functions" quota
     # https://cloud.google.com/functions/quotas#resource_limits
     recency_cutoff_hours = 12
-    cleanup_count_per_location = 20
+    cleanup_count_per_location = 40
     cleanup_options.extend(
         [
             f"--recency-cutoff={recency_cutoff_hours}",


### PR DESCRIPTION
The stale cloud functions have started accumulating again in the project where doctest is run. This change should make clean up more aggressive.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
