### PR TITLE
feat: add allow_large_results to peek

### DIFF
--- a/bigframes/_config/bigquery_options.py
+++ b/bigframes/_config/bigquery_options.py
@@ -35,6 +35,12 @@ SESSION_STARTED_MESSAGE = (
 
 UNKNOWN_LOCATION_MESSAGE = "The location '{location}' is set to an unknown value. Did you mean '{possibility}'?"
 
+LARGE_RESULTS_WARNING_MESSAGE = (
+    "Sampling is disabled because 'allow_large_results' is set to False. "
+    "To prevent downloading excessive data, it is recommended to limit the data "
+    "fetched with methods like .head() or .sample() before proceeding with downloads."
+)
+
 
 def _get_validated_location(value: Optional[str]) -> Optional[str]:
 
@@ -99,6 +105,9 @@ class BigQueryOptions:
         self._application_name = application_name
         self._kms_key_name = kms_key_name
         self._skip_bq_connection_check = skip_bq_connection_check
+
+        if not allow_large_results:
+            warnings.warn(LARGE_RESULTS_WARNING_MESSAGE, UserWarning)
         self._allow_large_results = allow_large_results
         self._session_started = False
         # Determines the ordering strictness for the session.
@@ -252,6 +261,8 @@ class BigQueryOptions:
 
     @allow_large_results.setter
     def allow_large_results(self, value: bool):
+        if not value:
+            warnings.warn(LARGE_RESULTS_WARNING_MESSAGE, UserWarning)
         self._allow_large_results = value
 
     @property

--- a/bigframes/_config/bigquery_options.py
+++ b/bigframes/_config/bigquery_options.py
@@ -35,12 +35,6 @@ SESSION_STARTED_MESSAGE = (
 
 UNKNOWN_LOCATION_MESSAGE = "The location '{location}' is set to an unknown value. Did you mean '{possibility}'?"
 
-LARGE_RESULTS_WARNING_MESSAGE = (
-    "Sampling is disabled because 'allow_large_results' is set to False. "
-    "To prevent downloading excessive data, it is recommended to limit the data "
-    "fetched with methods like .head() or .sample() before proceeding with downloads."
-)
-
 
 def _get_validated_location(value: Optional[str]) -> Optional[str]:
 
@@ -105,9 +99,6 @@ class BigQueryOptions:
         self._application_name = application_name
         self._kms_key_name = kms_key_name
         self._skip_bq_connection_check = skip_bq_connection_check
-
-        if not allow_large_results:
-            warnings.warn(LARGE_RESULTS_WARNING_MESSAGE, UserWarning)
         self._allow_large_results = allow_large_results
         self._session_started = False
         # Determines the ordering strictness for the session.
@@ -261,8 +252,6 @@ class BigQueryOptions:
 
     @allow_large_results.setter
     def allow_large_results(self, value: bool):
-        if not value:
-            warnings.warn(LARGE_RESULTS_WARNING_MESSAGE, UserWarning)
         self._allow_large_results = value
 
     @property

--- a/bigframes/core/blocks.py
+++ b/bigframes/core/blocks.py
@@ -629,7 +629,7 @@ class Block:
         else:
             # Since we cannot acquire the table size without a query_job,
             # we skip the sampling.
-            fraction = 1
+            fraction = 2
 
         # TODO: Maybe materialize before downsampling
         # Some downsampling methods

--- a/bigframes/core/blocks.py
+++ b/bigframes/core/blocks.py
@@ -617,8 +617,7 @@ class Block:
             ordered=materialize_options.ordered,
             use_explicit_destination=materialize_options.allow_large_results,
         )
-        if materialize_options.allow_large_results:
-            assert execute_result.total_bytes is not None
+        if execute_result.total_bytes is not None:
             table_mb = execute_result.total_bytes / _BYTES_TO_MEGABYTES
             sample_config = materialize_options.downsampling
             max_download_size = sample_config.max_download_size

--- a/bigframes/core/blocks.py
+++ b/bigframes/core/blocks.py
@@ -617,9 +617,9 @@ class Block:
             ordered=materialize_options.ordered,
             use_explicit_destination=materialize_options.allow_large_results,
         )
+        sample_config = materialize_options.downsampling
         if execute_result.total_bytes is not None:
             table_mb = execute_result.total_bytes / _BYTES_TO_MEGABYTES
-            sample_config = materialize_options.downsampling
             max_download_size = sample_config.max_download_size
             fraction = (
                 max_download_size / table_mb
@@ -629,6 +629,13 @@ class Block:
         else:
             # Since we cannot acquire the table size without a query_job,
             # we skip the sampling.
+            if sample_config.enable_downsampling:
+                warnings.warn(
+                    "Sampling is disabled and there is no download size limit when 'allow_large_results' is set to "
+                    "False. To prevent downloading excessive data, it is recommended to use the peek() method, or "
+                    "limit the data with methods like .head() or .sample() before proceeding with downloads.",
+                    UserWarning,
+                )
             fraction = 2
 
         # TODO: Maybe materialize before downsampling

--- a/bigframes/core/blocks.py
+++ b/bigframes/core/blocks.py
@@ -559,10 +559,12 @@ class Block:
         return df, query_job
 
     def try_peek(
-        self, n: int = 20, force: bool = False
+        self, n: int = 20, force: bool = False, allow_large_results=None
     ) -> typing.Optional[pd.DataFrame]:
         if force or self.expr.supports_fast_peek:
-            result = self.session._executor.peek(self.expr, n)
+            result = self.session._executor.peek(
+                self.expr, n, use_explicit_destination=allow_large_results
+            )
             df = io_pandas.arrow_to_pandas(result.to_arrow_table(), self.expr.schema)
             self._copy_index_to_pandas(df)
             return df
@@ -614,17 +616,21 @@ class Block:
             self.expr,
             ordered=materialize_options.ordered,
             use_explicit_destination=materialize_options.allow_large_results,
-            get_size_bytes=True,
         )
-        assert execute_result.total_bytes is not None
-        table_mb = execute_result.total_bytes / _BYTES_TO_MEGABYTES
-        sample_config = materialize_options.downsampling
-        max_download_size = sample_config.max_download_size
-        fraction = (
-            max_download_size / table_mb
-            if (max_download_size is not None) and (table_mb != 0)
-            else 2
-        )
+        if materialize_options.allow_large_results:
+            assert execute_result.total_bytes is not None
+            table_mb = execute_result.total_bytes / _BYTES_TO_MEGABYTES
+            sample_config = materialize_options.downsampling
+            max_download_size = sample_config.max_download_size
+            fraction = (
+                max_download_size / table_mb
+                if (max_download_size is not None) and (table_mb != 0)
+                else 2
+            )
+        else:
+            # Since we cannot acquire the table size without a query_job,
+            # we skip the sampling.
+            fraction = 1
 
         # TODO: Maybe materialize before downsampling
         # Some downsampling methods

--- a/bigframes/core/indexes/base.py
+++ b/bigframes/core/indexes/base.py
@@ -505,7 +505,8 @@ class Index(vendored_pandas_index.Index):
         df, query_job = self._block.index.to_pandas(
             ordered=True, allow_large_results=allow_large_results
         )
-        self._query_job = query_job
+        if query_job:
+            self._query_job = query_job
         return df
 
     def to_numpy(self, dtype=None, *, allow_large_results=None, **kwargs) -> np.ndarray:

--- a/bigframes/functions/_function_client.py
+++ b/bigframes/functions/_function_client.py
@@ -167,7 +167,7 @@ class FunctionClient:
             create_function_ddl,
             job_config=bigquery.QueryJobConfig(),
         )
-
+        assert query_job is not None
         logger.info(f"Created remote function {query_job.ddl_target_routine}")
 
     def get_cloud_function_fully_qualified_parent(self):

--- a/bigframes/session/__init__.py
+++ b/bigframes/session/__init__.py
@@ -345,7 +345,7 @@ class Session(
     def bytes_processed_sum(self):
         """The sum of all bytes processed by bigquery jobs using this session."""
         warnings.warn(
-            "Queries executed with `allow_large_results` within the session will not "
+            "Queries executed with `allow_large_results=False` within the session will not "
             "have their bytes processed counted in this sum. If you need precise "
             "bytes processed information, query the `INFORMATION_SCHEMA` tables "
             "to get relevant metrics.",
@@ -357,7 +357,7 @@ class Session(
     def slot_millis_sum(self):
         """The sum of all slot time used by bigquery jobs in this session."""
         warnings.warn(
-            "Queries executed with `allow_large_results` within the session will not "
+            "Queries executed with `allow_large_results=False` within the session will not "
             "have their slot milliseconds counted in this sum.  If you need precise slot "
             "milliseconds information, query the `INFORMATION_SCHEMA` tables "
             "to get relevant metrics.",

--- a/bigframes/session/__init__.py
+++ b/bigframes/session/__init__.py
@@ -1612,10 +1612,12 @@ class Session(
         # so we must reset any encryption set in the job config
         # https://cloud.google.com/bigquery/docs/customer-managed-encryption#encrypt-model
         job_config.destination_encryption_configuration = None
-
-        return bf_io_bigquery.start_query_with_client(
+        iterator, query_job = bf_io_bigquery.start_query_with_client(
             self.bqclient, sql, job_config=job_config, metrics=self._metrics
         )
+
+        assert query_job is not None
+        return iterator, query_job
 
     def _create_object_table(self, path: str, connection: str) -> str:
         """Create a random id Object Table from the input path and connection."""

--- a/bigframes/session/__init__.py
+++ b/bigframes/session/__init__.py
@@ -344,11 +344,25 @@ class Session(
     @property
     def bytes_processed_sum(self):
         """The sum of all bytes processed by bigquery jobs using this session."""
+        warnings.warn(
+            "Queries executed with `allow_large_results` within the session will not "
+            "have their bytes processed counted in this sum. If you need precise "
+            "bytes processed information, query the `INFORMATION_SCHEMA` tables "
+            "to get relevant metrics.",
+            UserWarning,
+        )
         return self._metrics.bytes_processed
 
     @property
     def slot_millis_sum(self):
         """The sum of all slot time used by bigquery jobs in this session."""
+        warnings.warn(
+            "Queries executed with `allow_large_results` within the session will not "
+            "have their slot milliseconds counted in this sum.  If you need precise slot "
+            "milliseconds information, query the `INFORMATION_SCHEMA` tables "
+            "to get relevant metrics.",
+            UserWarning,
+        )
         return self._metrics.slot_millis
 
     @property

--- a/bigframes/session/_io/bigquery/__init__.py
+++ b/bigframes/session/_io/bigquery/__init__.py
@@ -246,6 +246,8 @@ def start_query_with_client(
                 project=project,
                 api_timeout=timeout,
             )
+            if metrics is not None:
+                metrics.count_job_stats()
             return results_iterator, None
 
         query_job = bq_client.query(

--- a/bigframes/session/_io/bigquery/__init__.py
+++ b/bigframes/session/_io/bigquery/__init__.py
@@ -246,7 +246,7 @@ def start_query_with_client(
                 project=project,
                 api_timeout=timeout,
             )
-            return results_iterator, None
+            return results_iterator, None  # type: ignore
 
         query_job = bq_client.query(
             sql,

--- a/bigframes/session/_io/bigquery/__init__.py
+++ b/bigframes/session/_io/bigquery/__init__.py
@@ -230,7 +230,7 @@ def start_query_with_client(
     metrics: Optional[bigframes.session.metrics.ExecutionMetrics] = None,
     *,
     query_with_job: bool = True,
-) -> Tuple[bigquery.table.RowIterator, bigquery.QueryJob]:
+) -> Tuple[bigquery.table.RowIterator, Optional[bigquery.QueryJob]]:
     """
     Starts query job and waits for results.
     """
@@ -246,7 +246,7 @@ def start_query_with_client(
                 project=project,
                 api_timeout=timeout,
             )
-            return results_iterator, None  # type: ignore
+            return results_iterator, None
 
         query_job = bq_client.query(
             sql,
@@ -350,6 +350,7 @@ def create_bq_dataset_reference(
     # to the dataset, no BigQuery Session required. Note: there is a
     # different anonymous dataset per location. See:
     # https://cloud.google.com/bigquery/docs/cached-results#how_cached_results_are_stored
+    assert query_job is not None
     query_destination = query_job.destination
     return bigquery.DatasetReference(
         query_destination.project,

--- a/bigframes/session/_io/bigquery/__init__.py
+++ b/bigframes/session/_io/bigquery/__init__.py
@@ -228,6 +228,8 @@ def start_query_with_client(
     timeout: Optional[float] = None,
     api_name: Optional[str] = None,
     metrics: Optional[bigframes.session.metrics.ExecutionMetrics] = None,
+    *,
+    query_with_job: bool = True,
 ) -> Tuple[bigquery.table.RowIterator, bigquery.QueryJob]:
     """
     Starts query job and waits for results.
@@ -236,6 +238,16 @@ def start_query_with_client(
         # Note: Ensure no additional labels are added to job_config after this point,
         # as `add_and_trim_labels` ensures the label count does not exceed 64.
         add_and_trim_labels(job_config, api_name=api_name)
+        if not query_with_job:
+            results_iterator = bq_client.query_and_wait(
+                sql,
+                job_config=job_config,
+                location=location,
+                project=project,
+                api_timeout=timeout,
+            )
+            return results_iterator, None
+
         query_job = bq_client.query(
             sql,
             job_config=job_config,

--- a/bigframes/session/executor.py
+++ b/bigframes/session/executor.py
@@ -329,8 +329,7 @@ class BigQueryCachingExecutor(Executor):
         if if_exists != "append" and has_timedelta_col:
             # Only update schema if this is not modifying an existing table, and the
             # new table contains timedelta columns.
-            assert query_job is not None and query_job.destination is not None
-            table = self.bqclient.get_table(query_job.destination)
+            table = self.bqclient.get_table(destination)
             table.schema = array_value.schema.to_bigquery()
             self.bqclient.update_table(table, ["schema"])
 

--- a/bigframes/session/executor.py
+++ b/bigframes/session/executor.py
@@ -264,7 +264,7 @@ class BigQueryCachingExecutor(Executor):
         def iterator_supplier():
             return iterator.to_arrow_iterable(bqstorage_client=self.bqstoragereadclient)
 
-        if use_explicit_destination:
+        if query_job:
             size_bytes = self.bqclient.get_table(query_job.destination).num_bytes
         else:
             size_bytes = None
@@ -485,7 +485,7 @@ class BigQueryCachingExecutor(Executor):
         page_size: Optional[int] = None,
         max_results: Optional[int] = None,
         query_with_job: bool = True,
-    ) -> Tuple[bq_table.RowIterator, bigquery.QueryJob]:
+    ) -> Tuple[bq_table.RowIterator, Optional[bigquery.QueryJob]]:
         """
         Starts BigQuery query job and waits for results.
         """
@@ -513,7 +513,6 @@ class BigQueryCachingExecutor(Executor):
                 metrics=self.metrics,
                 query_with_job=query_with_job,
             )
-            assert query_job is not None
             return iterator, query_job
 
         except google.api_core.exceptions.BadRequest as e:
@@ -645,7 +644,7 @@ class BigQueryCachingExecutor(Executor):
             job_config=job_config,
             api_name="cached",
         )
-        query_job.destination
+        assert query_job is not None
         query_job.result()
         return query_job.destination
 

--- a/bigframes/session/executor.py
+++ b/bigframes/session/executor.py
@@ -503,7 +503,7 @@ class BigQueryCachingExecutor(Executor):
         # as `add_and_trim_labels` ensures the label count does not exceed 64.
         bq_io.add_and_trim_labels(job_config, api_name=api_name)
         try:
-            return bq_io.start_query_with_client(
+            iterator, query_job = bq_io.start_query_with_client(
                 self.bqclient,
                 sql,
                 job_config=job_config,
@@ -513,6 +513,8 @@ class BigQueryCachingExecutor(Executor):
                 metrics=self.metrics,
                 query_with_job=query_with_job,
             )
+            assert query_job is not None
+            return iterator, query_job
 
         except google.api_core.exceptions.BadRequest as e:
             # Unfortunately, this error type does not have a separate error code or exception type

--- a/bigframes/session/executor.py
+++ b/bigframes/session/executor.py
@@ -329,7 +329,7 @@ class BigQueryCachingExecutor(Executor):
         if if_exists != "append" and has_timedelta_col:
             # Only update schema if this is not modifying an existing table, and the
             # new table contains timedelta columns.
-            assert query_job.destination is not None
+            assert query_job is not None and query_job.destination is not None
             table = self.bqclient.get_table(query_job.destination)
             table.schema = array_value.schema.to_bigquery()
             self.bqclient.update_table(table, ["schema"])

--- a/bigframes/session/executor.py
+++ b/bigframes/session/executor.py
@@ -232,7 +232,7 @@ class BigQueryCachingExecutor(Executor):
         array_value: bigframes.core.ArrayValue,
         *,
         ordered: bool = True,
-        use_explicit_destination: Optional[bool] = False,
+        use_explicit_destination: Optional[bool] = None,
         page_size: Optional[int] = None,
         max_results: Optional[int] = None,
     ):
@@ -363,7 +363,7 @@ class BigQueryCachingExecutor(Executor):
         self,
         array_value: bigframes.core.ArrayValue,
         n_rows: int,
-        use_explicit_destination: Optional[bool] = False,
+        use_explicit_destination: Optional[bool] = None,
     ) -> ExecuteResult:
         """
         A 'peek' efficiently accesses a small number of rows in the dataframe.

--- a/bigframes/session/loader.py
+++ b/bigframes/session/loader.py
@@ -726,7 +726,7 @@ class GbqDataLoader:
             job_config.maximum_bytes_billed = (
                 bigframes.options.compute.maximum_bytes_billed
             )
-        return bf_io_bigquery.start_query_with_client(
+        iterator, query_job = bf_io_bigquery.start_query_with_client(
             self._bqclient,
             sql,
             job_config=job_config,
@@ -734,6 +734,8 @@ class GbqDataLoader:
             timeout=timeout,
             api_name=api_name,
         )
+        assert query_job is not None
+        return iterator, query_job
 
 
 def _transform_read_gbq_configuration(configuration: Optional[dict]) -> dict:

--- a/bigframes/session/metrics.py
+++ b/bigframes/session/metrics.py
@@ -32,7 +32,11 @@ class ExecutionMetrics:
     execution_secs: float = 0
     query_char_count: int = 0
 
-    def count_job_stats(self, query_job: bq_job.QueryJob):
+    def count_job_stats(self, query_job: Optional[bq_job.QueryJob] = None):
+        if query_job is None:
+            self.execution_count += 1
+            return
+
         stats = get_performance_stats(query_job)
         if stats is not None:
             bytes_processed, slot_millis, execution_secs, query_char_count = stats

--- a/tests/system/small/test_dataframe.py
+++ b/tests/system/small/test_dataframe.py
@@ -664,10 +664,10 @@ def test_df_peek(scalars_dfs_maybe_ordered):
     scalars_df, scalars_pandas_df = scalars_dfs_maybe_ordered
 
     session = scalars_df._block.session
-    execution_count = session._metrics.execution_count
+    slot_millis_sum = session.slot_millis_sum
     peek_result = scalars_df.peek(n=3, force=False)
 
-    assert session._metrics.execution_count > execution_count
+    assert session.slot_millis_sum - slot_millis_sum > 1000
     pd.testing.assert_index_equal(scalars_pandas_df.columns, peek_result.columns)
     assert len(peek_result) == 3
 
@@ -676,11 +676,11 @@ def test_df_peek_with_large_results_not_allowed(scalars_dfs_maybe_ordered):
     scalars_df, scalars_pandas_df = scalars_dfs_maybe_ordered
 
     session = scalars_df._block.session
-    execution_count = session._metrics.execution_count
+    slot_millis_sum = session.slot_millis_sum
     peek_result = scalars_df.peek(n=3, force=False, allow_large_results=False)
 
-    # The metrics won't be updated when we call query_and_wait.
-    assert session._metrics.execution_count == execution_count
+    # The metrics won't be fully updated when we call query_and_wait.
+    assert session.slot_millis_sum - slot_millis_sum < 500
     pd.testing.assert_index_equal(scalars_pandas_df.columns, peek_result.columns)
     assert len(peek_result) == 3
 

--- a/tests/system/small/test_dataframe.py
+++ b/tests/system/small/test_dataframe.py
@@ -662,7 +662,25 @@ def test_rename(scalars_dfs):
 
 def test_df_peek(scalars_dfs_maybe_ordered):
     scalars_df, scalars_pandas_df = scalars_dfs_maybe_ordered
+
+    session = scalars_df._block.session
+    execution_count = session._metrics.execution_count
     peek_result = scalars_df.peek(n=3, force=False)
+
+    assert session._metrics.execution_count > execution_count
+    pd.testing.assert_index_equal(scalars_pandas_df.columns, peek_result.columns)
+    assert len(peek_result) == 3
+
+
+def test_df_peek_with_large_results_not_allowed(scalars_dfs_maybe_ordered):
+    scalars_df, scalars_pandas_df = scalars_dfs_maybe_ordered
+
+    session = scalars_df._block.session
+    execution_count = session._metrics.execution_count
+    peek_result = scalars_df.peek(n=3, force=False, allow_large_results=False)
+
+    # The metrics won't be updated when we call query_and_wait.
+    assert session._metrics.execution_count == execution_count
     pd.testing.assert_index_equal(scalars_pandas_df.columns, peek_result.columns)
     assert len(peek_result) == 3
 

--- a/tests/system/small/test_dataframe_io.py
+++ b/tests/system/small/test_dataframe_io.py
@@ -250,27 +250,21 @@ def test_to_pandas_array_struct_correct_result(session):
 
 
 def test_to_pandas_override_global_option(scalars_df_index):
-    # Direct call to_pandas uses global default setting (allow_large_results=True),
-    # table has 'bqdf' prefix.
-    scalars_df_index.to_pandas()
-    assert scalars_df_index._query_job.destination.table_id.startswith("bqdf")
-
-    # When allow_large_results=False, a destination table is implicitly created,
-    # table has 'anon' prefix.
+    session = scalars_df_index._block.session
+    execution_count = session._metrics.execution_count
     scalars_df_index.to_pandas(allow_large_results=False)
-    assert scalars_df_index._query_job.destination.table_id.startswith("anon")
+
+    # The metrics won't be updated when we call query_and_wait.
+    assert session._metrics.execution_count == execution_count
 
 
 def test_to_arrow_override_global_option(scalars_df_index):
-    # Direct call to_pandas uses global default setting (allow_large_results=True),
-    # table has 'bqdf' prefix.
-    scalars_df_index.to_arrow()
-    assert scalars_df_index._query_job.destination.table_id.startswith("bqdf")
-
-    # When allow_large_results=False, a destination table is implicitly created,
-    # table has 'anon' prefix.
+    session = scalars_df_index._block.session
+    execution_count = session._metrics.execution_count
     scalars_df_index.to_arrow(allow_large_results=False)
-    assert scalars_df_index._query_job.destination.table_id.startswith("anon")
+
+    # The metrics won't be updated when we call query_and_wait.
+    assert session._metrics.execution_count == execution_count
 
 
 def test_load_json_w_unboxed_py_value(session):

--- a/tests/system/small/test_dataframe_io.py
+++ b/tests/system/small/test_dataframe_io.py
@@ -253,21 +253,29 @@ def test_to_pandas_array_struct_correct_result(session):
 
 
 def test_to_pandas_override_global_option(scalars_df_index):
-    session = scalars_df_index._block.session
-    execution_count = session._metrics.execution_count
-    scalars_df_index.to_pandas(allow_large_results=False)
+    # Direct call to_pandas uses global default setting (allow_large_results=True),
+    # table has 'bqdf' prefix.
+    scalars_df_index.to_pandas()
+    table_id = scalars_df_index._query_job.destination.table_id
+    assert table_id.startswith("bqdf")
 
-    # The metrics won't be updated when we call query_and_wait.
-    assert session._metrics.execution_count == execution_count
+    # When allow_large_results=False, a query_job object should not be created.
+    # Therefore, the table_id should remain unchanged.
+    scalars_df_index.to_pandas(allow_large_results=False)
+    assert scalars_df_index._query_job.destination.table_id == table_id
 
 
 def test_to_arrow_override_global_option(scalars_df_index):
-    session = scalars_df_index._block.session
-    execution_count = session._metrics.execution_count
-    scalars_df_index.to_arrow(allow_large_results=False)
+    # Direct call to_arrow uses global default setting (allow_large_results=True),
+    # table has 'bqdf' prefix.
+    scalars_df_index.to_arrow()
+    table_id = scalars_df_index._query_job.destination.table_id
+    assert table_id.startswith("bqdf")
 
-    # The metrics won't be updated when we call query_and_wait.
-    assert session._metrics.execution_count == execution_count
+    # When allow_large_results=False, a query_job object should not be created.
+    # Therefore, the table_id should remain unchanged.
+    scalars_df_index.to_arrow(allow_large_results=False)
+    assert scalars_df_index._query_job.destination.table_id == table_id
 
 
 def test_load_json_w_unboxed_py_value(session):

--- a/tests/system/small/test_index_io.py
+++ b/tests/system/small/test_index_io.py
@@ -16,20 +16,28 @@
 def test_to_pandas_override_global_option(scalars_df_index):
     bf_index = scalars_df_index.index
 
-    session = bf_index._block.session
-    execution_count = session._metrics.execution_count
-    bf_index.to_pandas(allow_large_results=False)
+    # Direct call to_pandas uses global default setting (allow_large_results=True),
+    # table has 'bqdf' prefix.
+    bf_index.to_pandas()
+    table_id = bf_index._query_job.destination.table_id
+    assert table_id.startswith("bqdf")
 
-    # The metrics won't be updated when we call query_and_wait.
-    assert session._metrics.execution_count == execution_count
+    # When allow_large_results=False, a query_job object should not be created.
+    # Therefore, the table_id should remain unchanged.
+    bf_index.to_pandas(allow_large_results=False)
+    assert bf_index._query_job.destination.table_id == table_id
 
 
 def test_to_numpy_override_global_option(scalars_df_index):
     bf_index = scalars_df_index.index
 
-    session = bf_index._block.session
-    execution_count = session._metrics.execution_count
-    bf_index.to_numpy(allow_large_results=False)
+    # Direct call to_numpy uses global default setting (allow_large_results=True),
+    # table has 'bqdf' prefix.
+    bf_index.to_numpy()
+    table_id = bf_index._query_job.destination.table_id
+    assert table_id.startswith("bqdf")
 
-    # The metrics won't be updated when we call query_and_wait.
-    assert session._metrics.execution_count == execution_count
+    # When allow_large_results=False, a query_job object should not be created.
+    # Therefore, the table_id should remain unchanged.
+    bf_index.to_numpy(allow_large_results=False)
+    assert bf_index._query_job.destination.table_id == table_id

--- a/tests/system/small/test_index_io.py
+++ b/tests/system/small/test_index_io.py
@@ -15,25 +15,21 @@
 
 def test_to_pandas_override_global_option(scalars_df_index):
     bf_index = scalars_df_index.index
-    # Direct call to_pandas uses global default setting (allow_large_results=True),
-    # table has 'bqdf' prefix.
-    bf_index.to_pandas()
-    assert bf_index._query_job.destination.table_id.startswith("bqdf")
 
-    # When allow_large_results=False, a destination table is implicitly created,
-    # table has 'anon' prefix.
+    session = bf_index._block.session
+    execution_count = session._metrics.execution_count
     bf_index.to_pandas(allow_large_results=False)
-    assert bf_index._query_job.destination.table_id.startswith("anon")
+
+    # The metrics won't be updated when we call query_and_wait.
+    assert session._metrics.execution_count == execution_count
 
 
 def test_to_numpy_override_global_option(scalars_df_index):
     bf_index = scalars_df_index.index
-    # Direct call to_pandas uses global default setting (allow_large_results=True),
-    # table has 'bqdf' prefix.
-    bf_index.to_numpy()
-    assert bf_index._query_job.destination.table_id.startswith("bqdf")
 
-    # When allow_large_results=False, a destination table is implicitly created,
-    # table has 'anon' prefix.
+    session = bf_index._block.session
+    execution_count = session._metrics.execution_count
     bf_index.to_numpy(allow_large_results=False)
-    assert bf_index._query_job.destination.table_id.startswith("anon")
+
+    # The metrics won't be updated when we call query_and_wait.
+    assert session._metrics.execution_count == execution_count

--- a/tests/system/small/test_series.py
+++ b/tests/system/small/test_series.py
@@ -2271,31 +2271,34 @@ def test_series_peek(scalars_dfs):
     scalars_df, scalars_pandas_df = scalars_dfs
 
     session = scalars_df._block.session
-    execution_count = session._metrics.execution_count
+    slot_millis_sum = session.slot_millis_sum
     peek_result = scalars_df["float64_col"].peek(n=3, force=False)
 
-    assert session._metrics.execution_count > execution_count
+    assert session.slot_millis_sum - slot_millis_sum > 1000
     pd.testing.assert_series_equal(
         peek_result,
         scalars_pandas_df["float64_col"].reindex_like(peek_result),
     )
+    assert len(peek_result) == 3
 
 
 def test_series_peek_with_large_results_not_allowed(scalars_dfs):
     scalars_df, scalars_pandas_df = scalars_dfs
 
     session = scalars_df._block.session
-    execution_count = session._metrics.execution_count
+    slot_millis_sum = session.slot_millis_sum
     peek_result = scalars_df["float64_col"].peek(
         n=3, force=False, allow_large_results=False
     )
 
-    # The metrics won't be updated when we call query_and_wait.
-    assert session._metrics.execution_count == execution_count
+    # The metrics won't be fully updated when we call query_and_wait.
+    print(session.slot_millis_sum - slot_millis_sum)
+    assert session.slot_millis_sum - slot_millis_sum < 500
     pd.testing.assert_series_equal(
         peek_result,
         scalars_pandas_df["float64_col"].reindex_like(peek_result),
     )
+    assert len(peek_result) == 3
 
 
 def test_series_peek_multi_index(scalars_dfs):

--- a/tests/system/small/test_series_io.py
+++ b/tests/system/small/test_series_io.py
@@ -13,14 +13,12 @@
 # limitations under the License.
 
 
-def test_to_pandas_override_global_option(scalars_df_index):
+def test_to_pandas_override_global_option(scalars_df_index, session):
     bf_series = scalars_df_index["int64_col"]
-    # Direct call to_pandas uses global default setting (allow_large_results=True),
-    # table has 'bqdf' prefix.
-    bf_series.to_pandas()
-    assert bf_series._query_job.destination.table_id.startswith("bqdf")
 
-    # When allow_large_results=False, a destination table is implicitly created,
-    # table has 'anon' prefix.
+    session = bf_series._block.session
+    execution_count = session._metrics.execution_count
     bf_series.to_pandas(allow_large_results=False)
-    assert bf_series._query_job.destination.table_id.startswith("anon")
+
+    # The metrics won't be updated when we call query_and_wait.
+    assert session._metrics.execution_count == execution_count

--- a/tests/system/small/test_series_io.py
+++ b/tests/system/small/test_series_io.py
@@ -16,9 +16,17 @@
 def test_to_pandas_override_global_option(scalars_df_index):
     bf_series = scalars_df_index["int64_col"]
 
+    # Direct call to_pandas uses global default setting (allow_large_results=True),
+    # table has 'bqdf' prefix.
+    bf_series.to_pandas()
+    table_id = bf_series._query_job.destination.table_id
+    assert table_id.startswith("bqdf")
+
     session = bf_series._block.session
     execution_count = session._metrics.execution_count
-    bf_series.to_pandas(allow_large_results=False)
 
-    # The metrics won't be updated when we call query_and_wait.
-    assert session._metrics.execution_count == execution_count
+    # When allow_large_results=False, a query_job object should not be created.
+    # Therefore, the table_id should remain unchanged.
+    bf_series.to_pandas(allow_large_results=False)
+    assert bf_series._query_job.destination.table_id == table_id
+    assert session._metrics.execution_count - execution_count == 1

--- a/tests/system/small/test_series_io.py
+++ b/tests/system/small/test_series_io.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-def test_to_pandas_override_global_option(scalars_df_index, session):
+def test_to_pandas_override_global_option(scalars_df_index):
     bf_series = scalars_df_index["int64_col"]
 
     session = bf_series._block.session

--- a/tests/unit/polars_session.py
+++ b/tests/unit/polars_session.py
@@ -40,7 +40,6 @@ class TestExecutor(bigframes.session.executor.Executor):
         *,
         ordered: bool = True,
         use_explicit_destination: Optional[bool] = False,
-        get_size_bytes: bool = False,
         page_size: Optional[int] = None,
         max_results: Optional[int] = None,
     ):


### PR DESCRIPTION
1. Added allow_large_results to peek
2. Switched allow_large_results to query_and_wait.
3. Added warning messages to metrics and allow_large_results option to warn user that we won't have metrics and won't sampling.
4. skip sampling when allow_large_results=False as we can't get the table size.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
