### PR TITLE
feat!: reading JSON data as a custom arrow extension type

### DIFF
--- a/bigframes/bigquery/_operations/json.py
+++ b/bigframes/bigquery/_operations/json.py
@@ -53,7 +53,7 @@ def json_set(
         >>> s = bpd.read_gbq("SELECT JSON '{\\\"a\\\": 1}' AS data")["data"]
         >>> bbq.json_set(s, json_path_value_pairs=[("$.a", 100), ("$.b", "hi")])
             0    {"a":100,"b":"hi"}
-            Name: data, dtype: dbjson
+            Name: data, dtype: extension<dbjson<JSONArrowType>>[pyarrow]
 
     Args:
         input (bigframes.series.Series):
@@ -253,7 +253,7 @@ def parse_json(
         dtype: string
         >>> bbq.parse_json(s)
         0    {"class":{"students":[{"id":5},{"id":12}]}}
-        dtype: dbjson
+        dtype: extension<dbjson<JSONArrowType>>[pyarrow]
 
     Args:
         input (bigframes.series.Series):

--- a/bigframes/core/array_value.py
+++ b/bigframes/core/array_value.py
@@ -108,7 +108,7 @@ class ArrayValue:
             raise ValueError("must set at most one of 'offests', 'primary_key'")
         if any(i.field_type == "JSON" for i in table.schema if i.name in schema.names):
             msg = bfe.format_message(
-                "JSON column interpretation as a custom PyArrow extention in `db_dtypes`  "
+                "JSON column interpretation as a custom PyArrow extention in `db_dtypes` "
                 "is a preview feature and subject to change."
             )
             warnings.warn(msg, bfe.PreviewWarning)

--- a/bigframes/core/array_value.py
+++ b/bigframes/core/array_value.py
@@ -108,8 +108,8 @@ class ArrayValue:
             raise ValueError("must set at most one of 'offests', 'primary_key'")
         if any(i.field_type == "JSON" for i in table.schema if i.name in schema.names):
             msg = bfe.format_message(
-                "Interpreting JSON column(s) as the `db_dtypes.dbjson` extension type is "
-                "in preview; this behavior may change in future versions."
+                "JSON column interpretation as a custom PyArrow extention in `db_dtypes`  "
+                "is a preview feature and subject to change."
             )
             warnings.warn(msg, bfe.PreviewWarning)
         # define data source only for needed columns, this makes row-hashing cheaper

--- a/bigframes/core/compile/ibis_types.py
+++ b/bigframes/core/compile/ibis_types.py
@@ -75,7 +75,7 @@ BIDIRECTIONAL_MAPPINGS: Iterable[Tuple[IbisDtype, bigframes.dtypes.Dtype]] = (
         IBIS_GEO_TYPE,
         gpd.array.GeometryDtype(),
     ),
-    (ibis_dtypes.json, db_dtypes.JSONDtype()),
+    (ibis_dtypes.json, pd.ArrowDtype(db_dtypes.JSONArrowType())),
 )
 
 BIGFRAMES_TO_IBIS: Dict[bigframes.dtypes.Dtype, ibis_dtypes.DataType] = {

--- a/bigframes/dtypes.py
+++ b/bigframes/dtypes.py
@@ -62,7 +62,7 @@ BIGNUMERIC_DTYPE = pd.ArrowDtype(pa.decimal256(76, 38))
 # No arrow equivalent
 GEO_DTYPE = gpd.array.GeometryDtype()
 # JSON
-JSON_DTYPE = db_dtypes.JSONDtype()
+JSON_DTYPE = pd.ArrowDtype(db_dtypes.JSONArrowType())
 OBJ_REF_DTYPE = pd.ArrowDtype(
     pa.struct(
         (

--- a/bigframes/dtypes.py
+++ b/bigframes/dtypes.py
@@ -301,7 +301,6 @@ def is_object_like(type_: Union[ExpressionType, str]) -> bool:
     return type_ in ("object", "O") or (
         getattr(type_, "kind", None) == "O"
         and getattr(type_, "storage", None) != "pyarrow"
-        and getattr(type_, "name", None) != "dbjson"
     )
 
 

--- a/bigframes/dtypes.py
+++ b/bigframes/dtypes.py
@@ -62,7 +62,9 @@ BIGNUMERIC_DTYPE = pd.ArrowDtype(pa.decimal256(76, 38))
 # No arrow equivalent
 GEO_DTYPE = gpd.array.GeometryDtype()
 # JSON
-JSON_DTYPE = pd.ArrowDtype(db_dtypes.JSONArrowType())
+# TODO: switch to pyarrow.json_(pyarrow.string()) when available.
+JSON_ARROW_TYPE = db_dtypes.JSONArrowType()
+JSON_DTYPE = pd.ArrowDtype(JSON_ARROW_TYPE)
 OBJ_REF_DTYPE = pd.ArrowDtype(
     pa.struct(
         (
@@ -80,7 +82,7 @@ OBJ_REF_DTYPE = pd.ArrowDtype(
             ),
             pa.field(
                 "details",
-                db_dtypes.JSONArrowType(),
+                JSON_ARROW_TYPE,
             ),
         )
     )

--- a/bigframes/session/_io/pandas.py
+++ b/bigframes/session/_io/pandas.py
@@ -18,7 +18,6 @@ import typing
 from typing import Collection, Union
 
 import bigframes_vendored.constants as constants
-import db_dtypes  # type: ignore
 import geopandas  # type: ignore
 import numpy as np
 import pandas
@@ -125,8 +124,6 @@ def arrow_to_pandas(
             )
         elif isinstance(dtype, pandas.ArrowDtype):
             series = _arrow_to_pandas_arrowdtype(column, dtype)
-        elif isinstance(dtype, db_dtypes.JSONDtype):
-            series = db_dtypes.JSONArray(column)
         else:
             series = column.to_pandas(types_mapper=lambda _: dtype)
 

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,8 @@ dependencies = [
     "ipywidgets >=7.7.1",
     "humanize >=4.6.0",
     "matplotlib >=3.7.1",
-    "db-dtypes >=1.4.0",
+    "db-dtypes@ git+https://github.com/googleapis/python-db-dtypes-pandas.git@main",
+    # "db-dtypes >=1.4.0",
     # For vendored ibis-framework.
     "atpublic>=2.3,<6",
     "parsy>=2,<3",

--- a/setup.py
+++ b/setup.py
@@ -60,8 +60,7 @@ dependencies = [
     "ipywidgets >=7.7.1",
     "humanize >=4.6.0",
     "matplotlib >=3.7.1",
-    "db-dtypes@ git+https://github.com/googleapis/python-db-dtypes-pandas.git@main",
-    # "db-dtypes >=1.4.0",
+    "db-dtypes >=1.4.2",
     # For vendored ibis-framework.
     "atpublic>=2.3,<6",
     "parsy>=2,<3",

--- a/testing/constraints-3.9.txt
+++ b/testing/constraints-3.9.txt
@@ -25,7 +25,7 @@ tabulate==0.9
 ipywidgets==7.7.1
 humanize==4.6.0
 matplotlib==3.7.1
-db-dtypes==1.4.0
+db-dtypes==1.4.2
 # For vendored ibis-framework.
 atpublic==2.3
 parsy==2.0

--- a/tests/system/small/test_dataframe_io.py
+++ b/tests/system/small/test_dataframe_io.py
@@ -304,7 +304,7 @@ def test_load_json_w_unboxed_py_value(session):
     """
     df = session.read_gbq(sql, index_col="id")
 
-    assert df.dtypes["json_col"] == db_dtypes.JSONDtype()
+    assert df.dtypes["json_col"] == pd.ArrowDtype(db_dtypes.JSONArrowType())
     assert isinstance(df["json_col"][0], dict)
 
     assert df["json_col"][0]["boolean"]
@@ -321,13 +321,13 @@ def test_load_json_w_unboxed_py_value(session):
 
 def test_load_json_to_pandas_has_correct_result(session):
     df = session.read_gbq("SELECT JSON_OBJECT('foo', 10, 'bar', TRUE) AS json_col")
-    assert df.dtypes["json_col"] == db_dtypes.JSONDtype()
+    assert df.dtypes["json_col"] == pd.ArrowDtype(db_dtypes.JSONArrowType())
     result = df.to_pandas()
 
     # The order of keys within the JSON object shouldn't matter for equality checks.
     pd_df = pd.DataFrame(
         {"json_col": [{"bar": True, "foo": 10}]},
-        dtype=db_dtypes.JSONDtype(),
+        dtype=pd.ArrowDtype(db_dtypes.JSONArrowType()),
     )
     pd_df.index = pd_df.index.astype("Int64")
     pd.testing.assert_series_equal(result.dtypes, pd_df.dtypes)
@@ -365,7 +365,7 @@ def test_load_json_in_struct(session):
     assert isinstance(df.dtypes["struct_col"].pyarrow_dtype, pa.StructType)
 
     data = df["struct_col"].struct.field("data")
-    assert data.dtype == db_dtypes.JSONDtype()
+    assert data.dtype == pd.ArrowDtype(db_dtypes.JSONArrowType())
 
     assert data[0]["boolean"]
     assert data[1]["int"] == 100
@@ -406,7 +406,7 @@ def test_load_json_in_array(session):
 
     data = df["array_col"].list
     assert data.len()[0] == 7
-    assert data[0].dtype == db_dtypes.JSONDtype()
+    assert data[0].dtype == pd.ArrowDtype(db_dtypes.JSONArrowType())
 
     assert data[0][0]["boolean"]
     assert data[1][0]["int"] == 100

--- a/tests/system/small/test_dataframe_io.py
+++ b/tests/system/small/test_dataframe_io.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
 from typing import Tuple
 
 import db_dtypes  # type:ignore
@@ -36,7 +35,6 @@ import typing
 from google.cloud import bigquery
 
 import bigframes
-from bigframes import dtypes
 import bigframes.dataframe
 import bigframes.features
 import bigframes.pandas as bpd

--- a/tests/system/small/test_dataframe_io.py
+++ b/tests/system/small/test_dataframe_io.py
@@ -316,7 +316,7 @@ def test_load_json_w_json_string_items(session):
 
     # Verifies JSON strings preserve array order, regardless of dictionary key order.
     assert df["json_col"][6] == '{"a":1,"b":2}'
-    assert df["json_col"][7] == '{"dict":{"array":[{"bar":"hello"},{"foo":1}],"int":1}}'
+    assert df["json_col"][7] == '{"dict":{"array":[{"foo":1},{"bar":"hello"}],"int":1}}'
 
 
 def test_load_json_to_pandas_has_correct_result(session):
@@ -355,7 +355,7 @@ def test_load_json_in_struct(session):
                 'dict',
                 JSON_OBJECT(
                     'int', 1,
-                    'array', [JSON_OBJECT('bar', 'hello'), JSON_OBJECT('foo', 1)]
+                    'array', [JSON_OBJECT('foo', 1), JSON_OBJECT('bar', 'hello')]
                 )
             ), 7),
     """
@@ -373,7 +373,7 @@ def test_load_json_in_struct(session):
     assert data[3] == '{"string":"hello world"}'
     assert data[4] == '{"array":[8,9,10]}'
     assert data[5] == '{"null":null}'
-    assert data[6] == '{"dict":{"array":[{"bar":"hello"},{"foo":1}],"int":1}}'
+    assert data[6] == '{"dict":{"array":[{"foo":1},{"bar":"hello"}],"int":1}}'
 
 
 def test_load_json_in_array(session):

--- a/tests/system/small/test_series.py
+++ b/tests/system/small/test_series.py
@@ -317,7 +317,6 @@ def test_series_construct_w_dtype_for_json():
     assert s[0] == "1"
     assert s[1] == '"str"'
     assert s[2] == "false"
-    # TODO: check old branch results for null.
     assert s[3] == '["a",{"b":1},null]'
     assert pd.isna(s[4])
     assert s[5] == '{"a":{"b":[1,2,3],"c":true}}'

--- a/tests/system/small/test_series.py
+++ b/tests/system/small/test_series.py
@@ -26,6 +26,7 @@ import pyarrow as pa  # type: ignore
 import pytest
 import shapely  # type: ignore
 
+import bigframes.dtypes as dtypes
 import bigframes.features
 import bigframes.pandas
 import bigframes.series as series
@@ -304,22 +305,22 @@ def test_series_construct_w_dtype_for_array_struct():
 
 def test_series_construct_w_dtype_for_json():
     data = [
-        1,
-        "str",
-        False,
-        ["a", {"b": 1}, None],
+        "1",
+        '"str"',
+        "false",
+        '["a", {"b": 1}, null]',
         None,
-        {"a": {"b": [1, 2, 3], "c": True}},
+        '{"a": {"b": [1, 2, 3], "c": true}}',
     ]
-    s = bigframes.pandas.Series(data, dtype=db_dtypes.JSONDtype())
+    s = bigframes.pandas.Series(data, dtype=dtypes.JSON_DTYPE)
 
-    assert s[0] == 1
-    assert s[1] == "str"
-    assert s[2] is False
-    assert s[3][0] == "a"
-    assert s[3][1]["b"] == 1
+    assert s[0] == "1"
+    assert s[1] == '"str"'
+    assert s[2] == "false"
+    # TODO: check old branch results for null.
+    assert s[3] == '["a",{"b":1},null]'
     assert pd.isna(s[4])
-    assert s[5]["a"] == {"b": [1, 2, 3], "c": True}
+    assert s[5] == '{"a":{"b":[1,2,3],"c":true}}'
 
 
 def test_series_keys(scalars_dfs):

--- a/tests/system/small/test_series.py
+++ b/tests/system/small/test_series.py
@@ -383,7 +383,7 @@ def test_get_column(scalars_dfs, col_name, expected_dtype):
 def test_get_column_w_json(json_df, json_pandas_df):
     series = json_df["json_col"]
     series_pandas = series.to_pandas()
-    assert series.dtype == db_dtypes.JSONDtype()
+    assert series.dtype == pd.ArrowDtype(db_dtypes.JSONArrowType())
     assert series_pandas.shape[0] == json_pandas_df.shape[0]
 
 

--- a/tests/system/small/test_session.py
+++ b/tests/system/small/test_session.py
@@ -22,7 +22,6 @@ from typing import List, Optional, Sequence
 import warnings
 
 import bigframes_vendored.pandas.io.gbq as vendored_pandas_gbq
-import db_dtypes  # type: ignore
 import google
 import google.cloud.bigquery as bigquery
 import numpy as np

--- a/tests/system/small/test_session.py
+++ b/tests/system/small/test_session.py
@@ -759,13 +759,13 @@ def test_read_pandas_timedelta_index(session, write_engine):
 )
 def test_read_pandas_json_dataframes(session, write_engine):
     json_data = [
-        1,
+        "1",
         None,
-        ["1", "3", "5"],
-        {"a": 1, "b": ["x", "y"], "c": {"z": False, "x": []}},
+        '["1","3","5"]',
+        '{"a":1,"b":["x","y"],"c":{"x":[],"z":false}}',
     ]
     expected_df = pd.DataFrame(
-        {"my_col": pd.Series(json_data, dtype=db_dtypes.JSONDtype())}
+        {"my_col": pd.Series(json_data, dtype=bigframes.dtypes.JSON_DTYPE)}
     )
 
     actual_result = session.read_pandas(
@@ -783,12 +783,12 @@ def test_read_pandas_json_dataframes(session, write_engine):
 )
 def test_read_pandas_json_series(session, write_engine):
     json_data = [
-        1,
+        "1",
         None,
-        ["1", "3", "5"],
-        {"a": 1, "b": ["x", "y"], "c": {"z": False, "x": []}},
+        '["1","3","5"]',
+        '{"a":1,"b":["x","y"],"c":{"x":[],"z":false}}',
     ]
-    expected_series = pd.Series(json_data, dtype=db_dtypes.JSONDtype())
+    expected_series = pd.Series(json_data, dtype=bigframes.dtypes.JSON_DTYPE)
 
     actual_result = session.read_pandas(
         expected_series, write_engine=write_engine
@@ -807,12 +807,12 @@ def test_read_pandas_json_series(session, write_engine):
 )
 def test_read_pandas_json_index(session, write_engine):
     json_data = [
-        1,
+        "1",
         None,
-        ["1", "3", "5"],
-        {"a": 1, "b": ["x", "y"], "c": {"z": False, "x": []}},
+        '["1","3","5"]',
+        '{"a":1,"b":["x","y"],"c":{"x":[],"z":false}}',
     ]
-    expected_index = pd.Index(json_data, dtype=db_dtypes.JSONDtype())
+    expected_index: pd.Index = pd.Index(json_data, dtype=bigframes.dtypes.JSON_DTYPE)
     actual_result = session.read_pandas(
         expected_index, write_engine=write_engine
     ).to_pandas()


### PR DESCRIPTION
We initially implemented a local pandas extension (`db_dtypes.JSONType`) for handling JSON data. Subsequently, the Arrow project introduced a native JSON data type in pyarrow after v19.0. We've opted to adopt this native type as our primary solution (see go/bf-json2 for internal design document). To ensure compatibility for users with older pyarrow versions, we've been using a custom Arrow extension as a fallback. This change transitions to using this custom Arrow extension as a stepping stone towards fully integrating the native pyarrow JSON type.

Release-As: 1.40.0

- [X] Fixes internal issue 401054811
- [X] Ensure the tests and linter pass
- [X] Code coverage does not decrease (if any source code was changed)
- [X] Appropriate docs were updated (if necessary)

Fixes internal issue 401054811🦕
