### PR TITLE
chore: remove ANSI color codes from warning messages

### DIFF
--- a/bigframes/exceptions.py
+++ b/bigframes/exceptions.py
@@ -95,7 +95,6 @@ class ObsoleteVersionWarning(Warning):
     """The BigFrames version is too old."""
 
 
-
 def format_message(message: str, fill: bool = True):
     """Formats a warning message with ANSI color codes for the warning color.
 

--- a/bigframes/exceptions.py
+++ b/bigframes/exceptions.py
@@ -95,10 +95,6 @@ class ObsoleteVersionWarning(Warning):
     """The BigFrames version is too old."""
 
 
-class ColorFormatter:
-    WARNING = "\033[93m"
-    ENDC = "\033[0m"
-
 
 def format_message(message: str, fill: bool = True):
     """Formats a warning message with ANSI color codes for the warning color.
@@ -110,10 +106,9 @@ def format_message(message: str, fill: bool = True):
             especially if the message already contains newlines.
 
     Returns:
-        The formatted message string, with ANSI color codes for warning color
-        if color is supported, otherwise the original message.  If `fill` is
-        True, the message will be wrapped to fit the terminal width.
+        The formatted message string. If `fill` is True, the message will be wrapped
+        to fit the terminal width.
     """
     if fill:
         message = textwrap.fill(message)
-    return ColorFormatter.WARNING + message + ColorFormatter.ENDC
+    return message


### PR DESCRIPTION
Fixes internal issue 400400035 🦕
