### PR TITLE
test: remove peek with allow_large_result test milisecond

### DIFF
--- a/tests/system/conftest.py
+++ b/tests/system/conftest.py
@@ -91,9 +91,12 @@ def gcs_folder(gcs_client: storage.Client):
     prefix = prefixer.create_prefix()
     path = f"gs://{bucket}/{prefix}/"
     yield path
-    for blob in gcs_client.list_blobs(bucket, prefix=prefix):
-        blob = typing.cast(storage.Blob, blob)
-        blob.delete()
+    try:
+        for blob in gcs_client.list_blobs(bucket, prefix=prefix):
+            blob = typing.cast(storage.Blob, blob)
+            blob.delete()
+    except Exception as exc:
+        traceback.print_exception(type(exc), exc, None)
 
 
 @pytest.fixture(scope="session")

--- a/tests/system/small/test_dataframe.py
+++ b/tests/system/small/test_dataframe.py
@@ -664,12 +664,8 @@ def test_rename(scalars_dfs):
 def test_df_peek(scalars_dfs_maybe_ordered):
     scalars_df, scalars_pandas_df = scalars_dfs_maybe_ordered
 
-    session = scalars_df._block.session
-    slot_millis_sum = session.slot_millis_sum
-    # allow_large_results=False needed to get slot_millis_sum statistics only
     peek_result = scalars_df.peek(n=3, force=False, allow_large_results=True)
 
-    assert session.slot_millis_sum - slot_millis_sum > 1000
     pd.testing.assert_index_equal(scalars_pandas_df.columns, peek_result.columns)
     assert len(peek_result) == 3
 
@@ -677,12 +673,8 @@ def test_df_peek(scalars_dfs_maybe_ordered):
 def test_df_peek_with_large_results_not_allowed(scalars_dfs_maybe_ordered):
     scalars_df, scalars_pandas_df = scalars_dfs_maybe_ordered
 
-    session = scalars_df._block.session
-    slot_millis_sum = session.slot_millis_sum
     peek_result = scalars_df.peek(n=3, force=False, allow_large_results=False)
 
-    # The metrics won't be fully updated when we call query_and_wait.
-    assert session.slot_millis_sum - slot_millis_sum < 500
     pd.testing.assert_index_equal(scalars_pandas_df.columns, peek_result.columns)
     assert len(peek_result) == 3
 


### PR DESCRIPTION
those are unreliable metrics and causing failures on head
