### PR TITLE
feat: set vscode and jupyter environments in the BQ jobs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,6 @@ repos:
     rev: v1.10.0
     hooks:
     -   id: mypy
-        additional_dependencies: [types-requests, types-tabulate, pandas-stubs]
+        additional_dependencies: [types-requests, types-tabulate, pandas-stubs<=2.2.3.241126]
         exclude: "^third_party"
         args: ["--check-untyped-defs", "--explicit-package-bases", "--ignore-missing-imports"]

--- a/bigframes/session/clients.py
+++ b/bigframes/session/clients.py
@@ -35,6 +35,8 @@ import bigframes.constants
 import bigframes.exceptions as bfe
 import bigframes.version
 
+from . import environment
+
 _ENV_DEFAULT_PROJECT = "GOOGLE_CLOUD_PROJECT"
 _APPLICATION_NAME = f"bigframes/{bigframes.version.__version__} ibis/9.2.0"
 _SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
@@ -55,6 +57,21 @@ _BIGQUERYSTORAGE_REGIONAL_ENDPOINT = (
 
 def _get_default_credentials_with_project():
     return pydata_google_auth.default(scopes=_SCOPES, use_local_webserver=False)
+
+
+def _get_application_names():
+    apps = [_APPLICATION_NAME]
+
+    if environment.is_vscode():
+        apps.append("vscode")
+        if environment.is_vscode_google_cloud_code_extension_installed():
+            apps.append(environment.GOOGLE_CLOUD_CODE_EXTENSION_NAME)
+    elif environment.is_jupyter():
+        apps.append("jupyter")
+        if environment.is_jupyter_bigquery_plugin_installed():
+            apps.append(environment.BIGQUERY_JUPYTER_PLUGIN_NAME)
+
+    return " ".join(apps)
 
 
 class ClientsProvider:
@@ -91,9 +108,9 @@ class ClientsProvider:
             )
 
         self._application_name = (
-            f"{_APPLICATION_NAME} {application_name}"
+            f"{_get_application_names()} {application_name}"
             if application_name
-            else _APPLICATION_NAME
+            else _get_application_names()
         )
         self._project = project
 

--- a/bigframes/session/environment.py
+++ b/bigframes/session/environment.py
@@ -1,0 +1,110 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib
+import json
+import os
+
+# The identifier for GCP VS Code extension
+# https://cloud.google.com/code/docs/vscode/install
+GOOGLE_CLOUD_CODE_EXTENSION_NAME = "googlecloudtools.cloudcode"
+
+
+# The identifier for BigQuery Jupyter notebook plugin
+# https://cloud.google.com/bigquery/docs/jupyterlab-plugin
+BIGQUERY_JUPYTER_PLUGIN_NAME = "bigquery_jupyter_plugin"
+
+
+def _is_vscode_extension_installed(extension_id: str) -> bool:
+    """
+    Checks if a given Visual Studio Code extension is installed.
+
+    Args:
+        extension_id: The ID of the extension (e.g., "ms-python.python").
+
+    Returns:
+        True if the extension is installed, False otherwise.
+    """
+    try:
+        # Determine the user's VS Code extensions directory.
+        user_home = os.path.expanduser("~")
+        if os.name == "nt":  # Windows
+            vscode_extensions_dir = os.path.join(user_home, ".vscode", "extensions")
+        elif os.name == "posix":  # macOS and Linux
+            vscode_extensions_dir = os.path.join(user_home, ".vscode", "extensions")
+        else:
+            raise OSError("Unsupported operating system.")
+
+        # Check if the extensions directory exists.
+        if not os.path.exists(vscode_extensions_dir):
+            return False
+
+        # Iterate through the subdirectories in the extensions directory.
+        for item in os.listdir(vscode_extensions_dir):
+            item_path = os.path.join(vscode_extensions_dir, item)
+            if os.path.isdir(item_path) and item.startswith(
+                extension_id + "-"
+            ):  # check if the folder starts with the extension ID.
+                # Further check for manifest file, as a more robust check.
+                manifest_path = os.path.join(item_path, "package.json")
+                if os.path.exists(manifest_path):
+                    try:
+                        with open(manifest_path, "r", encoding="utf-8") as f:
+                            json.load(
+                                f
+                            )  # attempt to load json, if it fails, the extension is likely corrupted.
+                        return True
+                    except (FileNotFoundError, json.JSONDecodeError):
+                        pass  # Corrupted or incomplete extension, or manifest missing.
+        return False
+
+    except OSError as e:
+        print(f"Error: {e}")
+        return False
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        return False
+
+
+def _is_package_installed(package_name: str) -> bool:
+    """
+    Checks if a Python package is installed.
+
+    Args:
+        package_name: The name of the package to check (e.g., "requests", "numpy").
+
+    Returns:
+        True if the package is installed, False otherwise.
+    """
+    try:
+        importlib.import_module(package_name)
+        return True
+    except ImportError:
+        return False
+
+
+def is_vscode() -> bool:
+    return os.getenv("VSCODE_PID") is not None
+
+
+def is_jupyter() -> bool:
+    return os.getenv("JPY_PARENT_PID") is not None
+
+
+def is_vscode_google_cloud_code_extension_installed() -> bool:
+    return _is_vscode_extension_installed(GOOGLE_CLOUD_CODE_EXTENSION_NAME)
+
+
+def is_jupyter_bigquery_plugin_installed() -> bool:
+    return _is_package_installed(BIGQUERY_JUPYTER_PLUGIN_NAME)

--- a/bigframes/session/environment.py
+++ b/bigframes/session/environment.py
@@ -51,9 +51,8 @@ def _is_vscode_extension_installed(extension_id: str) -> bool:
             # Iterate through the subdirectories in the extensions directory.
             for item in os.listdir(vscode_extensions_dir):
                 item_path = os.path.join(vscode_extensions_dir, item)
-                if os.path.isdir(item_path) and item.startswith(
-                    extension_id + "-"
-                ):  # check if the folder starts with the extension ID.
+                if os.path.isdir(item_path) and item.startswith(extension_id + "-"):
+                    # Check if the folder starts with the extension ID.
                     # Further check for manifest file, as a more robust check.
                     manifest_path = os.path.join(item_path, "package.json")
                     if os.path.exists(manifest_path):


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
chore: instrument vscode and jupyter environments in the BQ jobs (#1527)
END_COMMIT_OVERRIDE

In this change we are including the vscode and jupyter environments in the application name set in the BigQuery jobs. This would help understand the BigFrames usage coming from those environments. Here is demo of various scenarios: screen/5VkX8yp9S7PTzBv

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes internal issue 398019864 🦕
