### PR TITLE
fix: temporary fix for StreamingDataFrame not working backend bug

### DIFF
--- a/bigframes/streaming/dataframe.py
+++ b/bigframes/streaming/dataframe.py
@@ -286,7 +286,8 @@ class StreamingDataFrame(StreamingBase):
         original_table = self._original_table
         assert original_table is not None
 
-        appends_clause = f"APPENDS(TABLE `{original_table}`, NULL, NULL)"
+        # TODO(b/405691193): set start time back to NULL. Now set it slightly after 7 days max interval to avoid the bug.
+        appends_clause = f"APPENDS(TABLE `{original_table}`, CURRENT_TIMESTAMP() - (INTERVAL 7 DAY - INTERVAL 5 MINUTE))"
         sql_str = sql_str.replace(f"`{original_table}`", appends_clause)
         return sql_str
 


### PR DESCRIPTION
APPENDS with NULL start time isn't working now, made StreamingDataFrame doesn't work either. b/405691193
