### PR TITLE
feat!: set `allow_large_results=False` by default

### DIFF
--- a/bigframes/_config/bigquery_options.py
+++ b/bigframes/_config/bigquery_options.py
@@ -89,7 +89,7 @@ class BigQueryOptions:
         kms_key_name: Optional[str] = None,
         skip_bq_connection_check: bool = False,
         *,
-        allow_large_results: bool = True,
+        allow_large_results: bool = False,
         ordering_mode: Literal["strict", "partial"] = "strict",
         client_endpoints_override: Optional[dict] = None,
     ):

--- a/tests/system/small/test_progress_bar.py
+++ b/tests/system/small/test_progress_bar.py
@@ -55,6 +55,19 @@ def test_progress_bar_scalar(penguins_df_default_index: bf.dataframe.DataFrame, 
     with bf.option_context("display.progress_bar", "terminal"):
         penguins_df_default_index["body_mass_g"].head(10).mean()
 
+    assert capsys.readouterr().out == ""
+
+
+def test_progress_bar_scalar_allow_large_results(
+    penguins_df_default_index: bf.dataframe.DataFrame, capsys
+):
+    capsys.readouterr()  # clear output
+
+    with bf.option_context(
+        "display.progress_bar", "terminal", "bigquery.allow_large_results", "True"
+    ):
+        penguins_df_default_index["body_mass_g"].head(10).mean()
+
     assert_loading_msg_exist(capsys.readouterr().out)
 
 

--- a/tests/unit/_config/test_bigquery_options.py
+++ b/tests/unit/_config/test_bigquery_options.py
@@ -183,3 +183,10 @@ def test_client_endpoints_override_set_shows_warning():
 
     with pytest.warns(UserWarning):
         options.client_endpoints_override = {"bqclient": "endpoint_address"}
+
+
+def test_default_options():
+    options = bigquery_options.BigQueryOptions()
+
+    assert options.allow_large_results is False
+    assert options.ordering_mode == "strict"


### PR DESCRIPTION
 This is to optimize small result operations (which are more common). If the result can exceed 10MB, set `bigframes.pandas.options.bigquery.allow_large_results=True` explicitly.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes internal issue 394658588 🦕
