### PR TITLE
fix: pandas.cut returns labels index for numeric breaks when labels=False

### DIFF
--- a/bigframes/core/reshape/tile.py
+++ b/bigframes/core/reshape/tile.py
@@ -60,14 +60,19 @@ def cut(
             bins = tuple((bin.left.item(), bin.right.item()) for bin in bins)
             # To maintain consistency with pandas' behavior
             right = True
+            labels = None
         elif len(list(bins)) == 0:
             as_index = pd.IntervalIndex.from_tuples(list(bins))
             bins = tuple()
+            # To maintain consistency with pandas' behavior
+            right = True
+            labels = None
         elif isinstance(list(bins)[0], tuple):
             as_index = pd.IntervalIndex.from_tuples(list(bins))
             bins = tuple(bins)
             # To maintain consistency with pandas' behavior
             right = True
+            labels = None
         elif pd.api.types.is_number(list(bins)[0]):
             bins_list = list(bins)
             as_index = pd.IntervalIndex.from_breaks(bins_list)

--- a/bigframes/core/reshape/tile.py
+++ b/bigframes/core/reshape/tile.py
@@ -46,6 +46,8 @@ def cut(
             "The 'labels' parameter must be either False or None. "
             "Please provide a valid value for 'labels'."
         )
+    if x.size == 0:
+        raise ValueError("Cannot cut empty array.")
 
     if isinstance(bins, int):
         if bins <= 0:
@@ -83,9 +85,13 @@ def cut(
         if as_index.is_overlapping:
             raise ValueError("Overlapping IntervalIndex is not accepted.")
         elif len(as_index) == 0:
-            op = agg_ops.CutOp(bins, right=right, labels=labels)
+            dtype = agg_ops.CutOp(bins, right=right, labels=labels).output_type()
             return bigframes.series.Series(
-                [pd.NA] * len(x), dtype=op.output_type(), name=x.name
+                [pd.NA] * len(x),
+                dtype=dtype,
+                name=x.name,
+                index=x.index,
+                session=x._session,
             )
         else:
             op = agg_ops.CutOp(bins, right=right, labels=labels)

--- a/bigframes/operations/aggregations.py
+++ b/bigframes/operations/aggregations.py
@@ -347,7 +347,7 @@ class CutOp(UnaryWindowOp):
         return False
 
     def output_type(self, *input_types: dtypes.ExpressionType) -> dtypes.ExpressionType:
-        if isinstance(self.bins, int) and (self.labels is False):
+        if self.labels is False:
             return dtypes.INT_DTYPE
         else:
             # Assumption: buckets use same numeric type


### PR DESCRIPTION
Fixes internal issue 404338651 🦕
