### PR TITLE
chore: remove usage of deleted requirements.txt from nightly pipeline 

### DIFF
--- a/.kokoro/release-nightly.sh
+++ b/.kokoro/release-nightly.sh
@@ -57,8 +57,7 @@ git config --global --add safe.directory "${PROJECT_ROOT}"
 
 # Workaround for older pip not able to resolve dependencies. See internal
 # issue 316909553.
-python3.10 -m pip install pip==23.3.2
-python3.10 -m pip install --require-hashes -r .kokoro/requirements.txt
+python3.10 -m pip install pip==25.0.1
 
 # Disable buffering, so that the logs stream through.
 export PYTHONUNBUFFERED=1


### PR DESCRIPTION
This is needed after .kokoro/requirements.txt was deleted in PR #1453, due to which the nightly pipeline started failing.

https://github.com/googleapis/python-bigquery-dataframes/pull/1453/files#r2010758195

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
