### PR TITLE
docs: remove model deprecation warning for gemini text generator

### DIFF
--- a/bigframes/ml/llm.py
+++ b/bigframes/ml/llm.py
@@ -21,6 +21,7 @@ import warnings
 
 import bigframes_vendored.constants as constants
 from google.cloud import bigquery
+import typing_extensions
 
 from bigframes import dtypes, exceptions
 import bigframes.bigquery as bbq
@@ -32,13 +33,6 @@ import bigframes.series
 _BQML_PARAMS_MAPPING = {
     "max_iterations": "maxIterations",
 }
-
-_TEXT_GENERATOR_BISON_ENDPOINT = "text-bison"
-_TEXT_GENERATOR_BISON_32K_ENDPOINT = "text-bison-32k"
-_TEXT_GENERATOR_ENDPOINTS = (
-    _TEXT_GENERATOR_BISON_ENDPOINT,
-    _TEXT_GENERATOR_BISON_32K_ENDPOINT,
-)
 
 _TEXT_EMBEDDING_005_ENDPOINT = "text-embedding-005"
 _TEXT_EMBEDDING_004_ENDPOINT = "text-embedding-004"
@@ -99,9 +93,7 @@ _CLAUDE_3_ENDPOINTS = (
     _CLAUDE_3_OPUS_ENDPOINT,
 )
 
-
 _ML_GENERATE_TEXT_STATUS = "ml_generate_text_status"
-_ML_EMBED_TEXT_STATUS = "ml_embed_text_status"
 _ML_GENERATE_EMBEDDING_STATUS = "ml_generate_embedding_status"
 
 _MODEL_NOT_SUPPORTED_WARNING = (
@@ -111,7 +103,13 @@ _MODEL_NOT_SUPPORTED_WARNING = (
     "You should use this model name only if you are sure that it is supported in BigQuery."
 )
 
+_REMOVE_DEFAULT_MODEL_WARNING = "Due to the frequent deprecation of LLM models, the default model will be removed in BigFrames 3.0."
 
+
+@typing_extensions.deprecated(
+    _REMOVE_DEFAULT_MODEL_WARNING,
+    category=exceptions.ApiDeprecationWarning,
+)
 @log_adapter.class_logger
 class TextEmbeddingGenerator(base.RetriableRemotePredictor):
     """Text embedding generator LLM model.
@@ -254,6 +252,10 @@ class TextEmbeddingGenerator(base.RetriableRemotePredictor):
         return new_model.session.read_gbq_model(model_name)
 
 
+@typing_extensions.deprecated(
+    _REMOVE_DEFAULT_MODEL_WARNING,
+    category=exceptions.ApiDeprecationWarning,
+)
 @log_adapter.class_logger
 class MultimodalEmbeddingGenerator(base.RetriableRemotePredictor):
     """Multimodal embedding generator LLM model.
@@ -402,6 +404,10 @@ class MultimodalEmbeddingGenerator(base.RetriableRemotePredictor):
         return new_model.session.read_gbq_model(model_name)
 
 
+@typing_extensions.deprecated(
+    _REMOVE_DEFAULT_MODEL_WARNING,
+    category=exceptions.ApiDeprecationWarning,
+)
 @log_adapter.class_logger
 class GeminiTextGenerator(base.RetriableRemotePredictor):
     """Gemini text generator LLM model.
@@ -784,6 +790,10 @@ class GeminiTextGenerator(base.RetriableRemotePredictor):
         return new_model.session.read_gbq_model(model_name)
 
 
+@typing_extensions.deprecated(
+    _REMOVE_DEFAULT_MODEL_WARNING,
+    category=exceptions.ApiDeprecationWarning,
+)
 @log_adapter.class_logger
 class Claude3TextGenerator(base.RetriableRemotePredictor):
     """Claude3 text generator LLM model.

--- a/bigframes/ml/llm.py
+++ b/bigframes/ml/llm.py
@@ -21,7 +21,6 @@ import warnings
 
 import bigframes_vendored.constants as constants
 from google.cloud import bigquery
-import typing_extensions
 
 from bigframes import dtypes, exceptions
 import bigframes.bigquery as bbq
@@ -403,10 +402,6 @@ class MultimodalEmbeddingGenerator(base.RetriableRemotePredictor):
         return new_model.session.read_gbq_model(model_name)
 
 
-@typing_extensions.deprecated(
-    "gemini-1.5-X are going to be deprecated. Use gemini-2.0-X (https://cloud.google.com/python/docs/reference/bigframes/latest/bigframes.ml.llm.GeminiTextGenerator) instead. ",
-    category=exceptions.ApiDeprecationWarning,
-)
 @log_adapter.class_logger
 class GeminiTextGenerator(base.RetriableRemotePredictor):
     """Gemini text generator LLM model.

--- a/bigframes/ml/llm.py
+++ b/bigframes/ml/llm.py
@@ -21,7 +21,6 @@ import warnings
 
 import bigframes_vendored.constants as constants
 from google.cloud import bigquery
-import typing_extensions
 
 from bigframes import dtypes, exceptions
 import bigframes.bigquery as bbq
@@ -33,6 +32,13 @@ import bigframes.series
 _BQML_PARAMS_MAPPING = {
     "max_iterations": "maxIterations",
 }
+
+_TEXT_GENERATOR_BISON_ENDPOINT = "text-bison"
+_TEXT_GENERATOR_BISON_32K_ENDPOINT = "text-bison-32k"
+_TEXT_GENERATOR_ENDPOINTS = (
+    _TEXT_GENERATOR_BISON_ENDPOINT,
+    _TEXT_GENERATOR_BISON_32K_ENDPOINT,
+)
 
 _TEXT_EMBEDDING_005_ENDPOINT = "text-embedding-005"
 _TEXT_EMBEDDING_004_ENDPOINT = "text-embedding-004"
@@ -93,7 +99,9 @@ _CLAUDE_3_ENDPOINTS = (
     _CLAUDE_3_OPUS_ENDPOINT,
 )
 
+
 _ML_GENERATE_TEXT_STATUS = "ml_generate_text_status"
+_ML_EMBED_TEXT_STATUS = "ml_embed_text_status"
 _ML_GENERATE_EMBEDDING_STATUS = "ml_generate_embedding_status"
 
 _MODEL_NOT_SUPPORTED_WARNING = (
@@ -103,13 +111,7 @@ _MODEL_NOT_SUPPORTED_WARNING = (
     "You should use this model name only if you are sure that it is supported in BigQuery."
 )
 
-_REMOVE_DEFAULT_MODEL_WARNING = "Due to the frequent deprecation of LLM models, the default model will be removed in BigFrames 3.0."
 
-
-@typing_extensions.deprecated(
-    _REMOVE_DEFAULT_MODEL_WARNING,
-    category=exceptions.ApiDeprecationWarning,
-)
 @log_adapter.class_logger
 class TextEmbeddingGenerator(base.RetriableRemotePredictor):
     """Text embedding generator LLM model.
@@ -252,10 +254,6 @@ class TextEmbeddingGenerator(base.RetriableRemotePredictor):
         return new_model.session.read_gbq_model(model_name)
 
 
-@typing_extensions.deprecated(
-    _REMOVE_DEFAULT_MODEL_WARNING,
-    category=exceptions.ApiDeprecationWarning,
-)
 @log_adapter.class_logger
 class MultimodalEmbeddingGenerator(base.RetriableRemotePredictor):
     """Multimodal embedding generator LLM model.
@@ -404,10 +402,6 @@ class MultimodalEmbeddingGenerator(base.RetriableRemotePredictor):
         return new_model.session.read_gbq_model(model_name)
 
 
-@typing_extensions.deprecated(
-    _REMOVE_DEFAULT_MODEL_WARNING,
-    category=exceptions.ApiDeprecationWarning,
-)
 @log_adapter.class_logger
 class GeminiTextGenerator(base.RetriableRemotePredictor):
     """Gemini text generator LLM model.
@@ -790,10 +784,6 @@ class GeminiTextGenerator(base.RetriableRemotePredictor):
         return new_model.session.read_gbq_model(model_name)
 
 
-@typing_extensions.deprecated(
-    _REMOVE_DEFAULT_MODEL_WARNING,
-    category=exceptions.ApiDeprecationWarning,
-)
 @log_adapter.class_logger
 class Claude3TextGenerator(base.RetriableRemotePredictor):
     """Claude3 text generator LLM model.

--- a/tests/system/small/ml/test_llm.py
+++ b/tests/system/small/ml/test_llm.py
@@ -810,20 +810,6 @@ def test_llm_gemini_pro_score_params(llm_fine_tune_df_default_index, model_name)
 @pytest.mark.parametrize(
     "model_name",
     (
-        "gemini-1.5-pro-001",
-        "gemini-1.5-pro-002",
-        "gemini-1.5-flash-001",
-        "gemini-1.5-flash-002",
-    ),
-)
-def test_gemini_text_generator_deprecated(model_name):
-    with pytest.warns(exceptions.ApiDeprecationWarning):
-        llm.GeminiTextGenerator(model_name=model_name)
-
-
-@pytest.mark.parametrize(
-    "model_name",
-    (
         "gemini-1.5-pro-preview-0514",
         "gemini-1.5-flash-preview-0514",
         "gemini-2.0-flash-exp",


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
 docs: remove gemini-1.5 deprecation warning for `GeminiTextGenerator` (#1562)
END_COMMIT_OVERRIDE