### PR TITLE
test: move test_struct_from_dataframe with allow_large_result=False

### DIFF
--- a/tests/system/small/bigquery/test_struct.py
+++ b/tests/system/small/bigquery/test_struct.py
@@ -53,10 +53,9 @@ def test_struct_from_dataframe(columns_arg):
     srs = series.Series(
         columns_arg,
     )
-    # Use allow_large_results=True, due to b/403028465
     pd.testing.assert_series_equal(
-        srs.to_pandas(allow_large_results=True),
-        bbq.struct(srs.struct.explode()).to_pandas(allow_large_results=True),
+        srs.to_pandas(),
+        bbq.struct(srs.struct.explode()).to_pandas(),
         check_index_type=False,
         check_dtype=False,
     )


### PR DESCRIPTION
Fixes internal issue 403028465 🦕
