### PR TITLE
chore: Update dev dependencies and blob metadata tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -69,7 +69,6 @@ UNIT_TEST_PYTHON_VERSIONS = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 UNIT_TEST_STANDARD_DEPENDENCIES = [
     "mock",
     "asyncmock",
-    "freezegun",
     PYTEST_VERSION,
     "pytest-cov",
     "pytest-asyncio",

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ extras = {
         "pre-commit",
         "nox",
         "google-cloud-testutils",
+        "freezegun",
     ],
 }
 extras["all"] = list(sorted(frozenset(itertools.chain.from_iterable(extras.values()))))

--- a/tests/system/small/blob/test_properties.py
+++ b/tests/system/small/blob/test_properties.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import db_dtypes  # type: ignore
 import pandas as pd
 
 import bigframes

--- a/tests/system/small/blob/test_properties.py
+++ b/tests/system/small/blob/test_properties.py
@@ -16,6 +16,7 @@ import db_dtypes  # type: ignore
 import pandas as pd
 
 import bigframes
+import bigframes.dtypes as dtypes
 import bigframes.pandas as bpd
 
 
@@ -59,26 +60,24 @@ def test_blob_metadata(images_mm_df: bpd.DataFrame):
         actual = images_mm_df["blob_col"].blob.metadata().to_pandas()
         expected = pd.Series(
             [
-                {
-                    "content_type": "image/jpeg",
-                    "md5_hash": "e130ad042261a1883cd2cc06831cf748",
-                    "size": 338390,
-                    "updated": 1739574332000000,
-                },
-                {
-                    "content_type": "image/jpeg",
-                    "md5_hash": "e2ae3191ff2b809fd0935f01a537c650",
-                    "size": 43333,
-                    "updated": 1739574332000000,
-                },
+                (
+                    '{"content_type":"image/jpeg",'
+                    '"md5_hash":"e130ad042261a1883cd2cc06831cf748",'
+                    '"size":338390,'
+                    '"updated":1739574332000000}'
+                ),
+                (
+                    '{"content_type":"image/jpeg",'
+                    '"md5_hash":"e2ae3191ff2b809fd0935f01a537c650",'
+                    '"size":43333,'
+                    '"updated":1739574332000000}'
+                ),
             ],
             name="metadata",
-            dtype=db_dtypes.JSONDtype(),
+            dtype=dtypes.JSON_DTYPE,
         )
-
-        pd.testing.assert_series_equal(
-            actual, expected, check_dtype=False, check_index_type=False
-        )
+        expected.index = expected.index.astype(dtypes.INT_DTYPE)
+        pd.testing.assert_series_equal(actual, expected)
 
 
 def test_blob_content_type(images_mm_df: bpd.DataFrame):

--- a/tests/unit/session/test_time.py
+++ b/tests/unit/session/test_time.py
@@ -46,10 +46,7 @@ def bq_client():
 
 
 def test_bqsyncedclock_get_time(bq_client):
-    try:
-        import freezegun
-    except ImportError:
-        pytest.skip("Skip the test when freezegun is not intalled.")
+    freezegun = pytest.importorskip("freezegun")
 
     # this initial local time is actually irrelevant, only the ticks matter
     initial_local_datetime = datetime.datetime(

--- a/tests/unit/session/test_time.py
+++ b/tests/unit/session/test_time.py
@@ -15,7 +15,6 @@
 import datetime
 import unittest.mock as mock
 
-import freezegun
 import google.cloud.bigquery
 import pytest
 
@@ -47,6 +46,11 @@ def bq_client():
 
 
 def test_bqsyncedclock_get_time(bq_client):
+    try:
+        import freezegun
+    except ImportError:
+        pytest.skip("Skip the test when freezegun is not intalled.")
+
     # this initial local time is actually irrelevant, only the ticks matter
     initial_local_datetime = datetime.datetime(
         year=1, month=7, day=12, hour=15, minute=6, second=3


### PR DESCRIPTION
This PR includes two updates:
1.  Moves `freezegun` to development dependencies to improve IDE test discovery (e.g., VS Code loading `test_time.py`).
2.  Updates `test_blob_metadata` tests to correctly use the JSON Arrow extension dtype.