### PR TITLE
feat: add Series.to_pandas_batches() method

### DIFF
--- a/bigframes/core/blocks.py
+++ b/bigframes/core/blocks.py
@@ -590,6 +590,7 @@ class Block:
         page_size: Optional[int] = None,
         max_results: Optional[int] = None,
         allow_large_results: Optional[bool] = None,
+        squeeze: Optional[bool] = False,
     ):
         """Download results one message at a time.
 
@@ -605,7 +606,10 @@ class Block:
         for record_batch in execute_result.arrow_batches():
             df = io_pandas.arrow_to_pandas(record_batch, self.expr.schema)
             self._copy_index_to_pandas(df)
-            yield df
+            if squeeze:
+                yield df.squeeze(axis=1)
+            else:
+                yield df
 
     def _copy_index_to_pandas(self, df: pd.DataFrame):
         """Set the index on pandas DataFrame to match this block.

--- a/tests/system/small/test_series_io.py
+++ b/tests/system/small/test_series_io.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import pandas as pd
+import pytest
+
 import bigframes
 
 
@@ -32,3 +35,51 @@ def test_to_pandas_override_global_option(scalars_df_index):
         bf_series.to_pandas(allow_large_results=False)
         assert bf_series._query_job.destination.table_id == table_id
         assert session._metrics.execution_count - execution_count == 1
+
+
+@pytest.mark.parametrize(
+    ("page_size", "max_results", "allow_large_results"),
+    [
+        pytest.param(None, None, True),
+        pytest.param(2, None, False),
+        pytest.param(None, 1, True),
+        pytest.param(2, 5, False),
+        pytest.param(3, 6, True),
+        pytest.param(3, 100, False),
+        pytest.param(100, 100, True),
+    ],
+)
+def test_to_pandas_batches(scalars_dfs, page_size, max_results, allow_large_results):
+    scalars_df, scalars_pandas_df = scalars_dfs
+    bf_series = scalars_df["int64_col"]
+    pd_series = scalars_pandas_df["int64_col"]
+
+    total_rows = 0
+    expected_total_rows = (
+        min(max_results, len(pd_series)) if max_results else len(pd_series)
+    )
+
+    hit_last_page = False
+    for s in bf_series.to_pandas_batches(
+        page_size=page_size,
+        max_results=max_results,
+        allow_large_results=allow_large_results,
+    ):
+        assert not hit_last_page
+
+        actual_rows = s.shape[0]
+        expected_rows = (
+            min(page_size, expected_total_rows) if page_size else expected_total_rows
+        )
+
+        assert actual_rows <= expected_rows
+        if actual_rows < expected_rows:
+            assert page_size
+            hit_last_page = True
+
+        pd.testing.assert_series_equal(
+            s, pd_series[total_rows : total_rows + actual_rows]
+        )
+        total_rows += actual_rows
+
+    assert total_rows == expected_total_rows


### PR DESCRIPTION
This change is adding `Series.to_pandas_batches()` method, which is an alternative solution for the deprecated parameter mentioned at #1573
