### PR TITLE
fix!: make `dataset` and `name` params mandatory in `udf`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,7 @@ Version 2.0 introduces breaking changes for improved security and performance. K
   ``cloud_function_service_account="default"``. And network ingress now defaults to ``"internal-only"``.
 * **@remote_function Argument Passing:** Arguments other than ``input_types``, ``output_type``, and ``dataset``
   to ``remote_function`` must now be passed using keyword syntax, as positional arguments are no longer supported.
+* **@udf Argument Passing:** Arguments ``dataset`` and ``name`` to ``udf`` are now mandatory.
 * **Endpoint Connections:** Automatic fallback to locational endpoints in certain regions is removed.
 * **LLM Updates (Gemini Integration):** Integrations now default to the ``gemini-2.0-flash-001`` model.
   PaLM2 support has been removed; please migrate any existing PaLM2 usage to Gemini. **Note:** The current default

--- a/bigframes/functions/_function_session.py
+++ b/bigframes/functions/_function_session.py
@@ -793,7 +793,7 @@ class FunctionSession:
                 ``bigframes.pandas.reset_session``/
                 ``bigframes.pandas.clean_up_by_session_id``) does not clean up
                 the function, and leaves it for the user to manage the function
-                and the associated cloud function directly.
+                directly.
             packages (str[], Optional):
                 Explicit name of the external package dependencies. Each
                 dependency is added to the `requirements.txt` as is, and can be

--- a/bigframes/pandas/__init__.py
+++ b/bigframes/pandas/__init__.py
@@ -117,9 +117,9 @@ def udf(
     *,
     input_types: Union[None, type, Sequence[type]] = None,
     output_type: Optional[type] = None,
-    dataset: Optional[str] = None,
+    dataset: str,
     bigquery_connection: Optional[str] = None,
-    name: Optional[str] = None,
+    name: str,
     packages: Optional[Sequence[str]] = None,
 ):
     return global_session.with_default_session(

--- a/bigframes/session/__init__.py
+++ b/bigframes/session/__init__.py
@@ -1444,9 +1444,9 @@ class Session(
         *,
         input_types: Union[None, type, Sequence[type]] = None,
         output_type: Optional[type] = None,
-        dataset: Optional[str] = None,
+        dataset: str,
         bigquery_connection: Optional[str] = None,
-        name: Optional[str] = None,
+        name: str,
         packages: Optional[Sequence[str]] = None,
     ):
         """Decorator to turn a Python user defined function (udf) into a
@@ -1473,11 +1473,10 @@ class Session(
                 be specified. The supported output types are `bool`, `bytes`,
                 `float`, `int`, `str`, `list[bool]`, `list[float]`, `list[int]`
                 and `list[str]`.
-            dataset (str, Optional):
+            dataset (str):
                 Dataset in which to create a BigQuery managed function. It
                 should be in `<project_id>.<dataset_name>` or `<dataset_name>`
-                format. If this parameter is not provided then session dataset
-                id is used.
+                format.
             bigquery_connection (str, Optional):
                 Name of the BigQuery connection. It is used to provide an
                 identity to the serverless instances running the user code. It
@@ -1489,18 +1488,18 @@ class Session(
                 will be created without any connection. A udf without a
                 connection has no internet access and no access to other GCP
                 services.
-            name (str, Optional):
+            name (str):
                 Explicit name of the persisted BigQuery managed function. Use it
                 with caution, because more than one users working in the same
                 project and dataset could overwrite each other's managed
-                functions if they use the same persistent name. When an explicit
-                name is provided, any session specific clean up (
+                functions if they use the same persistent name. Please note that
+                any session specific clean up (
                 ``bigframes.session.Session.close``/
                 ``bigframes.pandas.close_session``/
                 ``bigframes.pandas.reset_session``/
                 ``bigframes.pandas.clean_up_by_session_id``) does not clean up
-                the function, and leaves it for the user to manage the function
-                and the associated cloud function directly.
+                this function, and leaves it for the user to manage the function
+                directly.
             packages (str[], Optional):
                 Explicit name of the external package dependencies. Each
                 dependency is added to the `requirements.txt` as is, and can be


### PR DESCRIPTION
This change will force the user to provide a dataset and name for the BigQuery managed python udf created through BigFrames, for easy discovery and cleanup when necessary.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes internal issue 409580589 🦕
