### PR TITLE
chore: remove read_gbq for large tables test.

### DIFF
--- a/tests/system/large/test_session.py
+++ b/tests/system/large/test_session.py
@@ -23,43 +23,6 @@ import bigframes.pandas as bpd
 import bigframes.session._io.bigquery
 
 
-@pytest.mark.parametrize(
-    ("query_or_table", "index_col"),
-    [
-        pytest.param(
-            "bigquery-public-data.patents_view.ipcr_201708",
-            (),
-            id="1g_table_w_default_index",
-        ),
-        pytest.param(
-            "bigquery-public-data.new_york_taxi_trips.tlc_yellow_trips_2011",
-            (),
-            id="30g_table_w_default_index",
-        ),
-        # TODO(chelsealin): Disable the long run tests until we have propertily
-        # ordering support to avoid materializating any data.
-        # # Adding default index to large tables would take much longer time,
-        # # e.g. ~5 mins for a 100G table, ~20 mins for a 1T table.
-        # pytest.param(
-        #     "bigquery-public-data.stackoverflow.post_history",
-        #     ["id"],
-        #     id="100g_table_w_unique_column_index",
-        # ),
-        # pytest.param(
-        #     "bigquery-public-data.wise_all_sky_data_release.all_wise",
-        #     ["cntr"],
-        #     id="1t_table_w_unique_column_index",
-        # ),
-    ],
-)
-def test_read_gbq_for_large_tables(
-    session: bigframes.Session, query_or_table, index_col
-):
-    """Verify read_gbq() is able to read large tables."""
-    df = session.read_gbq(query_or_table, index_col=index_col)
-    assert len(df.columns) != 0
-
-
 def test_close(session: bigframes.Session):
     # we will create two tables and confirm that they are deleted
     # when the session is closed


### PR DESCRIPTION
Remove the read_gbq table test, read_gbq won't actually execute a query against table, so this is not needed. And we have other similar tests.
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
