### PR TITLE
feat: Add "dayofyear" property for `dt` accessors

### DIFF
--- a/bigframes/core/compile/scalar_op_compiler.py
+++ b/bigframes/core/compile/scalar_op_compiler.py
@@ -679,9 +679,7 @@ def dayofweek_op_impl(x: ibis_types.Value):
 @scalar_op_compiler.register_unary_op(ops.dayofyear_op)
 def dayofyear_op_impl(x: ibis_types.Value):
     return (
-        typing.cast(ibis_types.TimestampValue, x)
-        .day_of_year()
-        .cast(ibis_dtypes.int64)
+        typing.cast(ibis_types.TimestampValue, x).day_of_year().cast(ibis_dtypes.int64)
     )
 
 

--- a/bigframes/core/compile/scalar_op_compiler.py
+++ b/bigframes/core/compile/scalar_op_compiler.py
@@ -676,6 +676,15 @@ def dayofweek_op_impl(x: ibis_types.Value):
     )
 
 
+@scalar_op_compiler.register_unary_op(ops.dayofyear_op)
+def dayofyear_op_impl(x: ibis_types.Value):
+    return (
+        typing.cast(ibis_types.TimestampValue, x)
+        .day_of_year()
+        .cast(ibis_dtypes.int64)
+    )
+
+
 @scalar_op_compiler.register_unary_op(ops.hour_op)
 def hour_op_impl(x: ibis_types.Value):
     return typing.cast(ibis_types.TimestampValue, x).hour().cast(ibis_dtypes.int64)

--- a/bigframes/operations/__init__.py
+++ b/bigframes/operations/__init__.py
@@ -42,6 +42,7 @@ from bigframes.operations.date_ops import (
     date_diff_op,
     day_op,
     dayofweek_op,
+    dayofyear_op,
     month_op,
     quarter_op,
     year_op,
@@ -261,6 +262,7 @@ __all__ = [
     "month_op",
     "year_op",
     "dayofweek_op",
+    "dayofyear_op",
     "quarter_op",
     # Time ops
     "hour_op",

--- a/bigframes/operations/date_ops.py
+++ b/bigframes/operations/date_ops.py
@@ -39,6 +39,11 @@ dayofweek_op = base_ops.create_unary_op(
     type_signature=op_typing.DATELIKE_ACCESSOR,
 )
 
+dayofyear_op = base_ops.create_unary_op(
+    name="dayofyear",
+    type_signature=op_typing.DATELIKE_ACCESSOR,
+)
+
 quarter_op = base_ops.create_unary_op(
     name="quarter",
     type_signature=op_typing.DATELIKE_ACCESSOR,

--- a/bigframes/operations/datetimes.py
+++ b/bigframes/operations/datetimes.py
@@ -44,6 +44,10 @@ class DatetimeMethods(
         return self._apply_unary_op(ops.dayofweek_op)
 
     @property
+    def dayofyear(self) -> series.Series:
+        return self._apply_unary_op(ops.dayofyear_op)
+
+    @property
     def date(self) -> series.Series:
         return self._apply_unary_op(ops.date_op)
 

--- a/tests/system/small/operations/test_datetimes.py
+++ b/tests/system/small/operations/test_datetimes.py
@@ -83,6 +83,20 @@ def test_dt_dayofweek(scalars_dfs, col_name):
 
 @pytest.mark.parametrize(
     ("col_name",),
+    DATE_COLUMNS,
+)
+def test_dt_dayofyear(scalars_dfs, col_name):
+    pytest.importorskip("pandas", minversion="2.0.0")
+    scalars_df, scalars_pandas_df = scalars_dfs
+    bf_series: bigframes.series.Series = scalars_df[col_name]
+    bf_result = bf_series.dt.dayofyear.to_pandas()
+    pd_result = scalars_pandas_df[col_name].dt.dayofyear
+
+    assert_series_equal(pd_result, bf_result, check_dtype=False)
+
+
+@pytest.mark.parametrize(
+    ("col_name",),
     DATETIME_COL_NAMES,
 )
 def test_dt_hour(scalars_dfs, col_name):

--- a/third_party/bigframes_vendored/pandas/core/indexes/accessor.py
+++ b/third_party/bigframes_vendored/pandas/core/indexes/accessor.py
@@ -67,6 +67,35 @@ class DatetimeProperties:
         raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
 
     @property
+    def dayofyear(self):
+        """The ordinal day of the year.
+
+        **Examples:**
+
+            >>> import pandas as pd
+            >>> import bigframes.pandas as bpd
+            >>> bpd.options.display.progress_bar = None
+            >>> s = bpd.Series(
+            ...     pd.date_range('2016-12-28', '2017-01-03', freq='D').to_series()
+            ... )
+            >>> s.dt.dayofyear
+            2016-12-28 00:00:00    363
+            2016-12-29 00:00:00    364
+            2016-12-30 00:00:00    365
+            2016-12-31 00:00:00    366
+            2017-01-01 00:00:00      1
+            2017-01-02 00:00:00      2
+            2017-01-03 00:00:00      3
+            dtype: Int64
+            dtype: Int64
+
+        Returns:
+            Series: Containing integers indicating the day number.
+        """
+
+        raise NotImplementedError(constants.ABSTRACT_METHOD_ERROR_MESSAGE)
+
+    @property
     def date(self):
         """Returns a Series with the date part of Timestamps without time and
         timezone information.


### PR DESCRIPTION
Now you can get the day of year for dates, datetimes and timestamps.