### PR TITLE
feat: add bpd.options.reset() method

### DIFF
--- a/bigframes/_config/__init__.py
+++ b/bigframes/_config/__init__.py
@@ -56,12 +56,21 @@ class Options:
     """Global options affecting BigQuery DataFrames behavior."""
 
     def __init__(self):
+        self.reset()
+
+    def reset(self) -> Options:
+        """Reset the option settings to defaults.
+
+        Returns:
+            bigframes._config.Options: Options object with default values.
+        """
         self._local = ThreadLocalConfig()
 
         # BigQuery options are special because they can only be set once per
         # session, so we need an indicator as to whether we are using the
         # thread-local session or the global session.
         self._bigquery_options = bigquery_options.BigQueryOptions()
+        return self
 
     def _init_bigquery_thread_local(self):
         """Initialize thread-local options, based on current global options."""

--- a/bigframes/_config/experiment_options.py
+++ b/bigframes/_config/experiment_options.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import dataclasses
 from typing import Optional
 import warnings
 
@@ -19,6 +20,7 @@ import bigframes
 import bigframes.exceptions as bfe
 
 
+@dataclasses.dataclass
 class ExperimentOptions:
     """
     Encapsulates the configration for experiments

--- a/bigframes/_config/experiment_options.py
+++ b/bigframes/_config/experiment_options.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import dataclasses
 from typing import Optional
 import warnings
 
@@ -20,7 +19,6 @@ import bigframes
 import bigframes.exceptions as bfe
 
 
-@dataclasses.dataclass
 class ExperimentOptions:
     """
     Encapsulates the configration for experiments

--- a/samples/snippets/quickstart.py
+++ b/samples/snippets/quickstart.py
@@ -74,4 +74,4 @@ def run_quickstart(project_id: str) -> None:
 
     # close session and reset option so not to affect other tests
     bpd.close_session()
-    bpd.options.bigquery.ordering_mode = "strict"
+    bpd.options.reset()


### PR DESCRIPTION
follow up on https://github.com/googleapis/python-bigquery-dataframes/pull/1741#discussion_r2092139598

I think it will be useful to add a reset method for options.