### PR TITLE
deps: avoid `gcsfs==2025.5.0`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dependencies = [
     # please keep these in sync with the minimum versions in testing/constraints-3.9.txt
     "cloudpickle >= 2.0.0",
     "fsspec >=2023.3.0",
-    "gcsfs >=2023.3.0,<2025.5.0",
+    "gcsfs >=2023.3.0, !=2025.5.0",
     "geopandas >=0.12.2",
     "google-auth >=2.15.0,<3.0",
     "google-cloud-bigquery[bqstorage,pandas] >=3.31.0",

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ dependencies = [
     # please keep these in sync with the minimum versions in testing/constraints-3.9.txt
     "cloudpickle >= 2.0.0",
     "fsspec >=2023.3.0",
-    "gcsfs >=2023.3.0",
+    "gcsfs >=2023.3.0,<2025.5.0",
     "geopandas >=0.12.2",
     "google-auth >=2.15.0,<3.0",
     "google-cloud-bigquery[bqstorage,pandas] >=3.31.0",


### PR DESCRIPTION
The latest gcsfs release broke BigFrames, so pinning its version to the last known good version.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
