### PR TITLE
test: ignore `bigframes/testing` folder from testing

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -424,6 +424,8 @@ def doctest(session: nox.sessions.Session):
             "third_party/bigframes_vendored/ibis",
             "--ignore",
             "bigframes/core/compile/polars",
+            "--ignore",
+            "bigframes/testing",
         ),
         test_folder="bigframes",
         check_cov=True,


### PR DESCRIPTION
This is to disable failures like the following:

_____________ ERROR collecting bigframes/testing/polars_session.py _____________
bigframes/testing/polars_session.py:19: in <module>
    import polars
E   ModuleNotFoundError: No module named 'polars'

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
