### PR TITLE
feat: support index item assign in Series

### DIFF
--- a/bigframes/core/indexes/base.py
+++ b/bigframes/core/indexes/base.py
@@ -174,6 +174,11 @@ class Index(vendored_pandas_index.Index):
             index=typing.cast(typing.Tuple, self._block.index.names),
         )
 
+    def __setitem__(self, key, value) -> None:
+        """Index objects are immutable. Use Index constructor to create
+        modified Index."""
+        raise TypeError("Index does not support mutable operations")
+
     @property
     def size(self) -> int:
         return self.shape[0]

--- a/tests/system/small/test_index.py
+++ b/tests/system/small/test_index.py
@@ -499,3 +499,28 @@ def test_index_item_with_empty(session):
 
     with pytest.raises(ValueError, match=re.escape(expected_message)):
         bf_idx_empty.item()
+
+
+@pytest.mark.parametrize(
+    ("key", "value"),
+    [
+        (0, "string_value"),
+        (1, 42),
+        ("label", None),
+        (-1, 3.14),
+    ],
+)
+def test_index_setitem_different_types(scalars_dfs, key, value):
+    scalars_df, _ = scalars_dfs
+    index = scalars_df.index
+
+    with pytest.raises(TypeError, match="Index does not support mutable operations"):
+        index[key] = value
+
+
+def test_custom_index_setitem_error(session):
+    # Create a custom index
+    custom_index = bpd.Index([1, 2, 3, 4, 5], name="custom")
+
+    with pytest.raises(TypeError, match="Index does not support mutable operations"):
+        custom_index[2] = 999

--- a/tests/system/small/test_index.py
+++ b/tests/system/small/test_index.py
@@ -511,6 +511,7 @@ def test_index_item_with_empty(session):
     ],
 )
 def test_index_setitem_different_types(scalars_dfs, key, value):
+    """Tests that custom Index setitem raises TypeError."""
     scalars_df, _ = scalars_dfs
     index = scalars_df.index
 
@@ -518,8 +519,8 @@ def test_index_setitem_different_types(scalars_dfs, key, value):
         index[key] = value
 
 
-def test_custom_index_setitem_error(session):
-    # Create a custom index
+def test_custom_index_setitem_error():
+    """Tests that custom Index setitem raises TypeError."""
     custom_index = bpd.Index([1, 2, 3, 4, 5], name="custom")
 
     with pytest.raises(TypeError, match="Index does not support mutable operations"):


### PR DESCRIPTION
feat: support index item assign in Series. To align with pandas behavior, we raise an error

b/329860087

verified at: screen/aogLXHA4uUJRso6