### PR TITLE
docs: update gsutil commands to gcloud commands

### DIFF
--- a/notebooks/generative_ai/bq_dataframes_llm_code_generation.ipynb
+++ b/notebooks/generative_ai/bq_dataframes_llm_code_generation.ipynb
@@ -1093,7 +1093,7 @@
         "import uuid\n",
         "BUCKET_ID = \"code-samples-\" + str(uuid.uuid1())\n",
         "\n",
-        "!gsutil mb gs://{BUCKET_ID}"
+        "!gcloud storage buckets create gs://{BUCKET_ID}"
       ]
     },
     {
@@ -1272,7 +1272,7 @@
       "outputs": [],
       "source": [
         "# # Delete the Google Cloud Storage bucket and files\n",
-        "# ! gsutil rm -r gs://{BUCKET_ID}\n",
+        "# ! gcloud storage rm gs://{BUCKET_ID} --recursive\n",
         "# print(f\"Deleted bucket '{BUCKET_ID}'.\")"
       ]
     }


### PR DESCRIPTION
Change `gsutil` commands to `gcloud storage` in notebook samples. gsutil is the legacy CLI for interacting with Cloud Storage, and we want to encourage migration to `gcloud storage`.
