### PR TITLE
fix: show slot_millis_sum warning only when `allow_large_results=False`

### DIFF
--- a/bigframes/session/__init__.py
+++ b/bigframes/session/__init__.py
@@ -339,13 +339,15 @@ class Session(
     @property
     def slot_millis_sum(self):
         """The sum of all slot time used by bigquery jobs in this session."""
-        msg = bfe.format_message(
-            "Queries executed with `allow_large_results=False` within the session will not "
-            "have their slot milliseconds counted in this sum.  If you need precise slot "
-            "milliseconds information, query the `INFORMATION_SCHEMA` tables "
-            "to get relevant metrics.",
-        )
-        warnings.warn(msg, UserWarning)
+        if not bigframes.options._allow_large_results:
+            msg = bfe.format_message(
+                "Queries executed with `allow_large_results=False` within the session will not "
+                "have their slot milliseconds counted in this sum.  If you need precise slot "
+                "milliseconds information, query the `INFORMATION_SCHEMA` tables "
+                "to get relevant metrics.",
+            )
+            warnings.warn(msg, UserWarning)
+
         return self._metrics.slot_millis
 
     @property


### PR DESCRIPTION
Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes internal issue 430478956 🦕
