### PR TITLE
chore: migrate 15 scalar operators to SQLGlot 

### DIFF
--- a/bigframes/core/compile/sqlglot/expressions/unary_compiler.py
+++ b/bigframes/core/compile/sqlglot/expressions/unary_compiler.py
@@ -185,6 +185,47 @@ def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
     return sge.Extract(this=sge.Identifier(this="DAY"), expression=expr.expr)
 
 
+@UNARY_OP_REGISTRATION.register(ops.dayofweek_op)
+def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
+    return sge.Extract(this=sge.Identifier(this="DAYOFWEEK"), expression=expr.expr)
+
+
+@UNARY_OP_REGISTRATION.register(ops.dayofyear_op)
+def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
+    return sge.Extract(this=sge.Identifier(this="DAYOFYEAR"), expression=expr.expr)
+
+
+@UNARY_OP_REGISTRATION.register(ops.exp_op)
+def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
+    return sge.Case(
+        ifs=[
+            sge.If(
+                this=expr.expr > sge.convert(709.78),
+                true=sge.func("IEEE_DIVIDE", sge.convert(1), sge.convert(0)),
+            )
+        ],
+        default=sge.func("EXP", expr.expr),
+    )
+
+
+@UNARY_OP_REGISTRATION.register(ops.expm1_op)
+def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
+    return sge.Case(
+        ifs=[
+            sge.If(
+                this=expr.expr > sge.convert(709.78),
+                true=sge.func("IEEE_DIVIDE", sge.convert(1), sge.convert(0)),
+            )
+        ],
+        default=sge.func("EXP", expr.expr),
+    ) - sge.convert(1)
+
+
+@UNARY_OP_REGISTRATION.register(ops.floor_op)
+def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
+    return sge.Floor(this=expr.expr)
+
+
 @UNARY_OP_REGISTRATION.register(ops.hash_op)
 def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
     return sge.func("FARM_FINGERPRINT", expr.expr)

--- a/bigframes/core/compile/sqlglot/expressions/unary_compiler.py
+++ b/bigframes/core/compile/sqlglot/expressions/unary_compiler.py
@@ -38,6 +38,11 @@ def compile(op: ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
     return UNARY_OP_REGISTRATION[op](op, expr)
 
 
+@UNARY_OP_REGISTRATION.register(ops.abs_op)
+def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
+    return sge.Abs(this=expr.expr)
+
+
 @UNARY_OP_REGISTRATION.register(ops.arccosh_op)
 def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
     return sge.Case(
@@ -142,6 +147,16 @@ def _(op: ops.ArraySliceOp, expr: TypedExpr) -> sge.Expression:
     return sge.array(selected_elements)
 
 
+@UNARY_OP_REGISTRATION.register(ops.capitalize_op)
+def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
+    return sge.Initcap(this=expr.expr)
+
+
+@UNARY_OP_REGISTRATION.register(ops.ceil_op)
+def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
+    return sge.Ceil(this=expr.expr)
+
+
 @UNARY_OP_REGISTRATION.register(ops.cos_op)
 def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
     return sge.func("COS", expr.expr)
@@ -158,6 +173,16 @@ def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
         ],
         default=sge.func("COSH", expr.expr),
     )
+
+
+@UNARY_OP_REGISTRATION.register(ops.date_op)
+def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
+    return sge.Date(this=expr.expr)
+
+
+@UNARY_OP_REGISTRATION.register(ops.day_op)
+def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
+    return sge.Extract(this=sge.Identifier(this="DAY"), expression=expr.expr)
 
 
 @UNARY_OP_REGISTRATION.register(ops.hash_op)

--- a/bigframes/core/compile/sqlglot/expressions/unary_compiler.py
+++ b/bigframes/core/compile/sqlglot/expressions/unary_compiler.py
@@ -49,7 +49,7 @@ def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
         ifs=[
             sge.If(
                 this=expr.expr < sge.convert(1),
-                true=sge.func("IEEE_DIVIDE", sge.convert(0), sge.convert(0)),
+                true=_NAN,
             )
         ],
         default=sge.func("ACOSH", expr.expr),
@@ -98,7 +98,7 @@ def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
         ifs=[
             sge.If(
                 this=sge.func("ABS", expr.expr) > sge.convert(1),
-                true=sge.func("IEEE_DIVIDE", sge.convert(0), sge.convert(0)),
+                true=_NAN,
             )
         ],
         default=sge.func("ATANH", expr.expr),
@@ -168,7 +168,7 @@ def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
         ifs=[
             sge.If(
                 this=sge.func("ABS", expr.expr) > sge.convert(709.78),
-                true=sge.func("IEEE_DIVIDE", sge.convert(1), sge.convert(0)),
+                true=_INF,
             )
         ],
         default=sge.func("COSH", expr.expr),

--- a/bigframes/core/compile/sqlglot/expressions/unary_compiler.py
+++ b/bigframes/core/compile/sqlglot/expressions/unary_compiler.py
@@ -200,8 +200,8 @@ def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
     return sge.Case(
         ifs=[
             sge.If(
-                this=expr.expr > sge.convert(709.78),
-                true=sge.func("IEEE_DIVIDE", sge.convert(1), sge.convert(0)),
+                this=expr.expr > _FLOAT64_EXP_BOUND,
+                true=_INF,
             )
         ],
         default=sge.func("EXP", expr.expr),
@@ -213,8 +213,8 @@ def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
     return sge.Case(
         ifs=[
             sge.If(
-                this=expr.expr > sge.convert(709.78),
-                true=sge.func("IEEE_DIVIDE", sge.convert(1), sge.convert(0)),
+                this=expr.expr > _FLOAT64_EXP_BOUND,
+                true=_INF,
             )
         ],
         default=sge.func("EXP", expr.expr),

--- a/bigframes/core/compile/sqlglot/expressions/unary_compiler.py
+++ b/bigframes/core/compile/sqlglot/expressions/unary_compiler.py
@@ -187,7 +187,10 @@ def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
 
 @UNARY_OP_REGISTRATION.register(ops.dayofweek_op)
 def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
-    return sge.Extract(this=sge.Identifier(this="DAYOFWEEK"), expression=expr.expr)
+    # Adjust the 1-based day-of-week index (from SQL) to a 0-based index.
+    return sge.Extract(
+        this=sge.Identifier(this="DAYOFWEEK"), expression=expr.expr
+    ) - sge.convert(1)
 
 
 @UNARY_OP_REGISTRATION.register(ops.dayofyear_op)

--- a/bigframes/core/compile/sqlglot/expressions/unary_compiler.py
+++ b/bigframes/core/compile/sqlglot/expressions/unary_compiler.py
@@ -38,6 +38,19 @@ def compile(op: ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
     return UNARY_OP_REGISTRATION[op](op, expr)
 
 
+@UNARY_OP_REGISTRATION.register(ops.arccosh_op)
+def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
+    return sge.Case(
+        ifs=[
+            sge.If(
+                this=expr.expr < sge.convert(1),
+                true=sge.func("IEEE_DIVIDE", sge.convert(0), sge.convert(0)),
+            )
+        ],
+        default=sge.func("ACOSH", expr.expr),
+    )
+
+
 @UNARY_OP_REGISTRATION.register(ops.arccos_op)
 def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
     return sge.Case(
@@ -64,9 +77,27 @@ def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
     )
 
 
+@UNARY_OP_REGISTRATION.register(ops.arcsinh_op)
+def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
+    return sge.func("ASINH", expr.expr)
+
+
 @UNARY_OP_REGISTRATION.register(ops.arctan_op)
 def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
     return sge.func("ATAN", expr.expr)
+
+
+@UNARY_OP_REGISTRATION.register(ops.arctanh_op)
+def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
+    return sge.Case(
+        ifs=[
+            sge.If(
+                this=sge.func("ABS", expr.expr) > sge.convert(1),
+                true=sge.func("IEEE_DIVIDE", sge.convert(0), sge.convert(0)),
+            )
+        ],
+        default=sge.func("ATANH", expr.expr),
+    )
 
 
 @UNARY_OP_REGISTRATION.register(ops.ArrayToStringOp)
@@ -116,6 +147,19 @@ def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
     return sge.func("COS", expr.expr)
 
 
+@UNARY_OP_REGISTRATION.register(ops.cosh_op)
+def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
+    return sge.Case(
+        ifs=[
+            sge.If(
+                this=sge.func("ABS", expr.expr) > sge.convert(709.78),
+                true=sge.func("IEEE_DIVIDE", sge.convert(1), sge.convert(0)),
+            )
+        ],
+        default=sge.func("COSH", expr.expr),
+    )
+
+
 @UNARY_OP_REGISTRATION.register(ops.hash_op)
 def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
     return sge.func("FARM_FINGERPRINT", expr.expr)
@@ -152,6 +196,11 @@ def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
 @UNARY_OP_REGISTRATION.register(ops.tan_op)
 def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
     return sge.func("TAN", expr.expr)
+
+
+@UNARY_OP_REGISTRATION.register(ops.tanh_op)
+def _(op: ops.base_ops.UnaryOp, expr: TypedExpr) -> sge.Expression:
+    return sge.func("TANH", expr.expr)
 
 
 # JSON Ops

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_abs/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_abs/out.sql
@@ -1,0 +1,13 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `float64_col` AS `bfcol_0`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    *,
+    ABS(`bfcol_0`) AS `bfcol_1`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_1` AS `float64_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_arccosh/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_arccosh/out.sql
@@ -5,7 +5,7 @@ WITH `bfcte_0` AS (
 ), `bfcte_1` AS (
   SELECT
     *,
-    CASE WHEN `bfcol_0` < 1 THEN IEEE_DIVIDE(0, 0) ELSE ACOSH(`bfcol_0`) END AS `bfcol_1`
+    CASE WHEN `bfcol_0` < 1 THEN CAST('NaN' AS FLOAT64) ELSE ACOSH(`bfcol_0`) END AS `bfcol_1`
   FROM `bfcte_0`
 )
 SELECT

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_arccosh/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_arccosh/out.sql
@@ -1,0 +1,13 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `float64_col` AS `bfcol_0`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    *,
+    CASE WHEN `bfcol_0` < 1 THEN IEEE_DIVIDE(0, 0) ELSE ACOSH(`bfcol_0`) END AS `bfcol_1`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_1` AS `float64_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_arcsinh/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_arcsinh/out.sql
@@ -1,0 +1,13 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `float64_col` AS `bfcol_0`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    *,
+    ASINH(`bfcol_0`) AS `bfcol_1`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_1` AS `float64_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_arctanh/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_arctanh/out.sql
@@ -1,0 +1,13 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `float64_col` AS `bfcol_0`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    *,
+    CASE WHEN ABS(`bfcol_0`) > 1 THEN IEEE_DIVIDE(0, 0) ELSE ATANH(`bfcol_0`) END AS `bfcol_1`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_1` AS `float64_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_arctanh/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_arctanh/out.sql
@@ -5,7 +5,7 @@ WITH `bfcte_0` AS (
 ), `bfcte_1` AS (
   SELECT
     *,
-    CASE WHEN ABS(`bfcol_0`) > 1 THEN IEEE_DIVIDE(0, 0) ELSE ATANH(`bfcol_0`) END AS `bfcol_1`
+    CASE WHEN ABS(`bfcol_0`) > 1 THEN CAST('NaN' AS FLOAT64) ELSE ATANH(`bfcol_0`) END AS `bfcol_1`
   FROM `bfcte_0`
 )
 SELECT

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_capitalize/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_capitalize/out.sql
@@ -1,0 +1,13 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `string_col` AS `bfcol_0`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    *,
+    INITCAP(`bfcol_0`) AS `bfcol_1`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_1` AS `string_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_ceil/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_ceil/out.sql
@@ -1,0 +1,13 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `float64_col` AS `bfcol_0`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    *,
+    CEIL(`bfcol_0`) AS `bfcol_1`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_1` AS `float64_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_cosh/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_cosh/out.sql
@@ -5,7 +5,11 @@ WITH `bfcte_0` AS (
 ), `bfcte_1` AS (
   SELECT
     *,
-    CASE WHEN ABS(`bfcol_0`) > 709.78 THEN IEEE_DIVIDE(1, 0) ELSE COSH(`bfcol_0`) END AS `bfcol_1`
+    CASE
+      WHEN ABS(`bfcol_0`) > 709.78
+      THEN CAST('Infinity' AS FLOAT64)
+      ELSE COSH(`bfcol_0`)
+    END AS `bfcol_1`
   FROM `bfcte_0`
 )
 SELECT

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_cosh/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_cosh/out.sql
@@ -1,0 +1,13 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `float64_col` AS `bfcol_0`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    *,
+    CASE WHEN ABS(`bfcol_0`) > 709.78 THEN IEEE_DIVIDE(1, 0) ELSE COSH(`bfcol_0`) END AS `bfcol_1`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_1` AS `float64_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_date/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_date/out.sql
@@ -1,0 +1,13 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `timestamp_col` AS `bfcol_0`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    *,
+    DATE(`bfcol_0`) AS `bfcol_1`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_1` AS `timestamp_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_day/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_day/out.sql
@@ -1,0 +1,13 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `timestamp_col` AS `bfcol_0`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    *,
+    EXTRACT(DAY FROM `bfcol_0`) AS `bfcol_1`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_1` AS `timestamp_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_dayofweek/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_dayofweek/out.sql
@@ -1,0 +1,13 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `timestamp_col` AS `bfcol_0`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    *,
+    EXTRACT(DAYOFWEEK FROM `bfcol_0`) AS `bfcol_1`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_1` AS `timestamp_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_dayofweek/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_dayofweek/out.sql
@@ -5,7 +5,7 @@ WITH `bfcte_0` AS (
 ), `bfcte_1` AS (
   SELECT
     *,
-    EXTRACT(DAYOFWEEK FROM `bfcol_0`) AS `bfcol_1`
+    EXTRACT(DAYOFWEEK FROM `bfcol_0`) - 1 AS `bfcol_1`
   FROM `bfcte_0`
 )
 SELECT

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_dayofyear/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_dayofyear/out.sql
@@ -1,0 +1,13 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `timestamp_col` AS `bfcol_0`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    *,
+    EXTRACT(DAYOFYEAR FROM `bfcol_0`) AS `bfcol_1`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_1` AS `timestamp_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_exp/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_exp/out.sql
@@ -5,7 +5,11 @@ WITH `bfcte_0` AS (
 ), `bfcte_1` AS (
   SELECT
     *,
-    CASE WHEN `bfcol_0` > 709.78 THEN IEEE_DIVIDE(1, 0) ELSE EXP(`bfcol_0`) END AS `bfcol_1`
+    CASE
+      WHEN `bfcol_0` > 709.78
+      THEN CAST('Infinity' AS FLOAT64)
+      ELSE EXP(`bfcol_0`)
+    END AS `bfcol_1`
   FROM `bfcte_0`
 )
 SELECT

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_exp/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_exp/out.sql
@@ -1,0 +1,13 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `float64_col` AS `bfcol_0`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    *,
+    CASE WHEN `bfcol_0` > 709.78 THEN IEEE_DIVIDE(1, 0) ELSE EXP(`bfcol_0`) END AS `bfcol_1`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_1` AS `float64_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_expm1/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_expm1/out.sql
@@ -5,7 +5,11 @@ WITH `bfcte_0` AS (
 ), `bfcte_1` AS (
   SELECT
     *,
-    CASE WHEN `bfcol_0` > 709.78 THEN IEEE_DIVIDE(1, 0) ELSE EXP(`bfcol_0`) END - 1 AS `bfcol_1`
+    CASE
+      WHEN `bfcol_0` > 709.78
+      THEN CAST('Infinity' AS FLOAT64)
+      ELSE EXP(`bfcol_0`)
+    END - 1 AS `bfcol_1`
   FROM `bfcte_0`
 )
 SELECT

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_expm1/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_expm1/out.sql
@@ -1,0 +1,13 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `float64_col` AS `bfcol_0`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    *,
+    CASE WHEN `bfcol_0` > 709.78 THEN IEEE_DIVIDE(1, 0) ELSE EXP(`bfcol_0`) END - 1 AS `bfcol_1`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_1` AS `float64_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_floor/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_floor/out.sql
@@ -1,0 +1,13 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `float64_col` AS `bfcol_0`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    *,
+    FLOOR(`bfcol_0`) AS `bfcol_1`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_1` AS `float64_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_tanh/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_unary_compiler/test_tanh/out.sql
@@ -1,0 +1,13 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `float64_col` AS `bfcol_0`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    *,
+    TANH(`bfcol_0`) AS `bfcol_1`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_1` AS `float64_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/expressions/test_unary_compiler.py
+++ b/tests/unit/core/compile/sqlglot/expressions/test_unary_compiler.py
@@ -73,6 +73,36 @@ def test_arctanh(scalar_types_df: bpd.DataFrame, snapshot):
     snapshot.assert_match(sql, "out.sql")
 
 
+def test_abs(scalar_types_df: bpd.DataFrame, snapshot):
+    bf_df = scalar_types_df[["float64_col"]]
+    sql = _apply_unary_op(bf_df, ops.abs_op, "float64_col")
+    snapshot.assert_match(sql, "out.sql")
+
+
+def test_capitalize(scalar_types_df: bpd.DataFrame, snapshot):
+    bf_df = scalar_types_df[["string_col"]]
+    sql = _apply_unary_op(bf_df, ops.capitalize_op, "string_col")
+    snapshot.assert_match(sql, "out.sql")
+
+
+def test_ceil(scalar_types_df: bpd.DataFrame, snapshot):
+    bf_df = scalar_types_df[["float64_col"]]
+    sql = _apply_unary_op(bf_df, ops.ceil_op, "float64_col")
+    snapshot.assert_match(sql, "out.sql")
+
+
+def test_date(scalar_types_df: bpd.DataFrame, snapshot):
+    bf_df = scalar_types_df[["timestamp_col"]]
+    sql = _apply_unary_op(bf_df, ops.date_op, "timestamp_col")
+    snapshot.assert_match(sql, "out.sql")
+
+
+def test_day(scalar_types_df: bpd.DataFrame, snapshot):
+    bf_df = scalar_types_df[["timestamp_col"]]
+    sql = _apply_unary_op(bf_df, ops.day_op, "timestamp_col")
+    snapshot.assert_match(sql, "out.sql")
+
+
 def test_array_to_string(repeated_types_df: bpd.DataFrame, snapshot):
     bf_df = repeated_types_df[["string_list_col"]]
     sql = _apply_unary_op(bf_df, ops.ArrayToStringOp(delimiter="."), "string_list_col")

--- a/tests/unit/core/compile/sqlglot/expressions/test_unary_compiler.py
+++ b/tests/unit/core/compile/sqlglot/expressions/test_unary_compiler.py
@@ -34,6 +34,12 @@ def _apply_unary_op(obj: bpd.DataFrame, op: ops.UnaryOp, arg: str) -> str:
     return sql
 
 
+def test_arccosh(scalar_types_df: bpd.DataFrame, snapshot):
+    bf_df = scalar_types_df[["float64_col"]]
+    sql = _apply_unary_op(bf_df, ops.arccosh_op, "float64_col")
+    snapshot.assert_match(sql, "out.sql")
+
+
 def test_arccos(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df = scalar_types_df[["float64_col"]]
     sql = _apply_unary_op(bf_df, ops.arccos_op, "float64_col")
@@ -48,10 +54,22 @@ def test_arcsin(scalar_types_df: bpd.DataFrame, snapshot):
     snapshot.assert_match(sql, "out.sql")
 
 
+def test_arcsinh(scalar_types_df: bpd.DataFrame, snapshot):
+    bf_df = scalar_types_df[["float64_col"]]
+    sql = _apply_unary_op(bf_df, ops.arcsinh_op, "float64_col")
+    snapshot.assert_match(sql, "out.sql")
+
+
 def test_arctan(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df = scalar_types_df[["float64_col"]]
     sql = _apply_unary_op(bf_df, ops.arctan_op, "float64_col")
 
+    snapshot.assert_match(sql, "out.sql")
+
+
+def test_arctanh(scalar_types_df: bpd.DataFrame, snapshot):
+    bf_df = scalar_types_df[["float64_col"]]
+    sql = _apply_unary_op(bf_df, ops.arctanh_op, "float64_col")
     snapshot.assert_match(sql, "out.sql")
 
 
@@ -87,6 +105,12 @@ def test_cos(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df = scalar_types_df[["float64_col"]]
     sql = _apply_unary_op(bf_df, ops.cos_op, "float64_col")
 
+    snapshot.assert_match(sql, "out.sql")
+
+
+def test_cosh(scalar_types_df: bpd.DataFrame, snapshot):
+    bf_df = scalar_types_df[["float64_col"]]
+    sql = _apply_unary_op(bf_df, ops.cosh_op, "float64_col")
     snapshot.assert_match(sql, "out.sql")
 
 
@@ -129,6 +153,12 @@ def test_tan(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df = scalar_types_df[["float64_col"]]
     sql = _apply_unary_op(bf_df, ops.tan_op, "float64_col")
 
+    snapshot.assert_match(sql, "out.sql")
+
+
+def test_tanh(scalar_types_df: bpd.DataFrame, snapshot):
+    bf_df = scalar_types_df[["float64_col"]]
+    sql = _apply_unary_op(bf_df, ops.tanh_op, "float64_col")
     snapshot.assert_match(sql, "out.sql")
 
 

--- a/tests/unit/core/compile/sqlglot/expressions/test_unary_compiler.py
+++ b/tests/unit/core/compile/sqlglot/expressions/test_unary_compiler.py
@@ -37,6 +37,7 @@ def _apply_unary_op(obj: bpd.DataFrame, op: ops.UnaryOp, arg: str) -> str:
 def test_arccosh(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df = scalar_types_df[["float64_col"]]
     sql = _apply_unary_op(bf_df, ops.arccosh_op, "float64_col")
+
     snapshot.assert_match(sql, "out.sql")
 
 
@@ -57,6 +58,7 @@ def test_arcsin(scalar_types_df: bpd.DataFrame, snapshot):
 def test_arcsinh(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df = scalar_types_df[["float64_col"]]
     sql = _apply_unary_op(bf_df, ops.arcsinh_op, "float64_col")
+
     snapshot.assert_match(sql, "out.sql")
 
 
@@ -70,18 +72,21 @@ def test_arctan(scalar_types_df: bpd.DataFrame, snapshot):
 def test_arctanh(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df = scalar_types_df[["float64_col"]]
     sql = _apply_unary_op(bf_df, ops.arctanh_op, "float64_col")
+
     snapshot.assert_match(sql, "out.sql")
 
 
 def test_abs(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df = scalar_types_df[["float64_col"]]
     sql = _apply_unary_op(bf_df, ops.abs_op, "float64_col")
+
     snapshot.assert_match(sql, "out.sql")
 
 
 def test_capitalize(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df = scalar_types_df[["string_col"]]
     sql = _apply_unary_op(bf_df, ops.capitalize_op, "string_col")
+
     snapshot.assert_match(sql, "out.sql")
 
 
@@ -94,42 +99,49 @@ def test_ceil(scalar_types_df: bpd.DataFrame, snapshot):
 def test_date(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df = scalar_types_df[["timestamp_col"]]
     sql = _apply_unary_op(bf_df, ops.date_op, "timestamp_col")
+
     snapshot.assert_match(sql, "out.sql")
 
 
 def test_day(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df = scalar_types_df[["timestamp_col"]]
     sql = _apply_unary_op(bf_df, ops.day_op, "timestamp_col")
+
     snapshot.assert_match(sql, "out.sql")
 
 
 def test_dayofweek(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df = scalar_types_df[["timestamp_col"]]
     sql = _apply_unary_op(bf_df, ops.dayofweek_op, "timestamp_col")
+
     snapshot.assert_match(sql, "out.sql")
 
 
 def test_dayofyear(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df = scalar_types_df[["timestamp_col"]]
     sql = _apply_unary_op(bf_df, ops.dayofyear_op, "timestamp_col")
+
     snapshot.assert_match(sql, "out.sql")
 
 
 def test_exp(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df = scalar_types_df[["float64_col"]]
     sql = _apply_unary_op(bf_df, ops.exp_op, "float64_col")
+
     snapshot.assert_match(sql, "out.sql")
 
 
 def test_expm1(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df = scalar_types_df[["float64_col"]]
     sql = _apply_unary_op(bf_df, ops.expm1_op, "float64_col")
+
     snapshot.assert_match(sql, "out.sql")
 
 
 def test_floor(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df = scalar_types_df[["float64_col"]]
     sql = _apply_unary_op(bf_df, ops.floor_op, "float64_col")
+
     snapshot.assert_match(sql, "out.sql")
 
 
@@ -171,6 +183,7 @@ def test_cos(scalar_types_df: bpd.DataFrame, snapshot):
 def test_cosh(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df = scalar_types_df[["float64_col"]]
     sql = _apply_unary_op(bf_df, ops.cosh_op, "float64_col")
+
     snapshot.assert_match(sql, "out.sql")
 
 
@@ -219,6 +232,7 @@ def test_tan(scalar_types_df: bpd.DataFrame, snapshot):
 def test_tanh(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df = scalar_types_df[["float64_col"]]
     sql = _apply_unary_op(bf_df, ops.tanh_op, "float64_col")
+
     snapshot.assert_match(sql, "out.sql")
 
 

--- a/tests/unit/core/compile/sqlglot/expressions/test_unary_compiler.py
+++ b/tests/unit/core/compile/sqlglot/expressions/test_unary_compiler.py
@@ -103,6 +103,36 @@ def test_day(scalar_types_df: bpd.DataFrame, snapshot):
     snapshot.assert_match(sql, "out.sql")
 
 
+def test_dayofweek(scalar_types_df: bpd.DataFrame, snapshot):
+    bf_df = scalar_types_df[["timestamp_col"]]
+    sql = _apply_unary_op(bf_df, ops.dayofweek_op, "timestamp_col")
+    snapshot.assert_match(sql, "out.sql")
+
+
+def test_dayofyear(scalar_types_df: bpd.DataFrame, snapshot):
+    bf_df = scalar_types_df[["timestamp_col"]]
+    sql = _apply_unary_op(bf_df, ops.dayofyear_op, "timestamp_col")
+    snapshot.assert_match(sql, "out.sql")
+
+
+def test_exp(scalar_types_df: bpd.DataFrame, snapshot):
+    bf_df = scalar_types_df[["float64_col"]]
+    sql = _apply_unary_op(bf_df, ops.exp_op, "float64_col")
+    snapshot.assert_match(sql, "out.sql")
+
+
+def test_expm1(scalar_types_df: bpd.DataFrame, snapshot):
+    bf_df = scalar_types_df[["float64_col"]]
+    sql = _apply_unary_op(bf_df, ops.expm1_op, "float64_col")
+    snapshot.assert_match(sql, "out.sql")
+
+
+def test_floor(scalar_types_df: bpd.DataFrame, snapshot):
+    bf_df = scalar_types_df[["float64_col"]]
+    sql = _apply_unary_op(bf_df, ops.floor_op, "float64_col")
+    snapshot.assert_match(sql, "out.sql")
+
+
 def test_array_to_string(repeated_types_df: bpd.DataFrame, snapshot):
     bf_df = repeated_types_df[["string_list_col"]]
     sql = _apply_unary_op(bf_df, ops.ArrayToStringOp(delimiter="."), "string_list_col")


### PR DESCRIPTION
This change contains three commits generated by Gemini CLI tool:

- Migrated cosh_op, tanh_op, arcsinh_op, arccosh_op, and arctanh_op scalar operators to SQLGlot.
- Migrated abs_op, capitalize_op, ceil_op, date_op, and day_op scalar operators to SQLGlot.
- Migrated dayofweek_op, dayofyear_op, exp_op, expm1_op, and floor_op scalar operators to SQLGlot.

Fixes internal issue 430133370
