### PR TITLE
tests: fixing flaky test: test_create_job_configs_labels_log_adaptor_call_method_under_length_limit

### DIFF
--- a/tests/unit/session/test_io_bigquery.py
+++ b/tests/unit/session/test_io_bigquery.py
@@ -109,14 +109,15 @@ def test_create_job_configs_labels_log_adaptor_call_method_under_length_limit():
     labels = io_bq.create_job_configs_labels(
         job_configs_labels=cur_labels, api_methods=api_methods
     )
-    expected_dict = {
+    expected_labels = {
         "source": "bigquery-dataframes-temp",
         "bigframes-api": "dataframe-columns",
         "recent-bigframes-api-0": "dataframe-max",
         "recent-bigframes-api-1": "dataframe-head",
         "recent-bigframes-api-2": "dataframe-__init__",
     }
-    assert labels == expected_dict
+    # Asserts that all items in expected_labels are present in labels
+    assert labels.items() >= expected_labels.items()
 
 
 def test_create_job_configs_labels_length_limit_met_and_labels_is_none():


### PR DESCRIPTION
This change addresses flakiness in the `test_create_job_configs_labels_log_adaptor_call_method_under_length_limit` test. The test occasionally failed because a `session-__del__` label was unexpectedly included in the logged adaptor call methods, as shown in the diff below:

```
  Full diff:
    {
     'bigframes-api': 'dataframe-columns',
     'recent-bigframes-api-0': 'dataframe-max',
     'recent-bigframes-api-1': 'dataframe-head',
     'recent-bigframes-api-2': 'dataframe-__init__',
  +  'recent-bigframes-api-3': 'session-__del__',
     'source': 'bigquery-dataframes-temp',
    }
```
