### PR TITLE
chore: refactor `get_configuration` to use a dataclass

### DIFF
--- a/tests/benchmark/db_benchmark/groupby/q1.py
+++ b/tests/benchmark/db_benchmark/groupby/q1.py
@@ -18,21 +18,15 @@ import benchmark.utils as utils
 import bigframes_vendored.db_benchmark.groupby_queries as vendored_dbbenchmark_groupby_queries
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         vendored_dbbenchmark_groupby_queries.q1,
         current_path,
-        suffix,
-        project_id,
-        dataset_id,
-        table_id,
-        session,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.table_id,
+        config.session,
     )

--- a/tests/benchmark/db_benchmark/groupby/q10.py
+++ b/tests/benchmark/db_benchmark/groupby/q10.py
@@ -18,21 +18,15 @@ import benchmark.utils as utils
 import bigframes_vendored.db_benchmark.groupby_queries as vendored_dbbenchmark_groupby_queries
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         vendored_dbbenchmark_groupby_queries.q10,
         current_path,
-        suffix,
-        project_id,
-        dataset_id,
-        table_id,
-        session,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.table_id,
+        config.session,
     )

--- a/tests/benchmark/db_benchmark/groupby/q2.py
+++ b/tests/benchmark/db_benchmark/groupby/q2.py
@@ -18,21 +18,15 @@ import benchmark.utils as utils
 import bigframes_vendored.db_benchmark.groupby_queries as vendored_dbbenchmark_groupby_queries
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         vendored_dbbenchmark_groupby_queries.q2,
         current_path,
-        suffix,
-        project_id,
-        dataset_id,
-        table_id,
-        session,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.table_id,
+        config.session,
     )

--- a/tests/benchmark/db_benchmark/groupby/q3.py
+++ b/tests/benchmark/db_benchmark/groupby/q3.py
@@ -18,21 +18,15 @@ import benchmark.utils as utils
 import bigframes_vendored.db_benchmark.groupby_queries as vendored_dbbenchmark_groupby_queries
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         vendored_dbbenchmark_groupby_queries.q3,
         current_path,
-        suffix,
-        project_id,
-        dataset_id,
-        table_id,
-        session,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.table_id,
+        config.session,
     )

--- a/tests/benchmark/db_benchmark/groupby/q4.py
+++ b/tests/benchmark/db_benchmark/groupby/q4.py
@@ -18,21 +18,15 @@ import benchmark.utils as utils
 import bigframes_vendored.db_benchmark.groupby_queries as vendored_dbbenchmark_groupby_queries
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         vendored_dbbenchmark_groupby_queries.q4,
         current_path,
-        suffix,
-        project_id,
-        dataset_id,
-        table_id,
-        session,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.table_id,
+        config.session,
     )

--- a/tests/benchmark/db_benchmark/groupby/q5.py
+++ b/tests/benchmark/db_benchmark/groupby/q5.py
@@ -18,21 +18,15 @@ import benchmark.utils as utils
 import bigframes_vendored.db_benchmark.groupby_queries as vendored_dbbenchmark_groupby_queries
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         vendored_dbbenchmark_groupby_queries.q5,
         current_path,
-        suffix,
-        project_id,
-        dataset_id,
-        table_id,
-        session,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.table_id,
+        config.session,
     )

--- a/tests/benchmark/db_benchmark/groupby/q6.py
+++ b/tests/benchmark/db_benchmark/groupby/q6.py
@@ -18,21 +18,15 @@ import benchmark.utils as utils
 import bigframes_vendored.db_benchmark.groupby_queries as vendored_dbbenchmark_groupby_queries
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         vendored_dbbenchmark_groupby_queries.q6,
         current_path,
-        suffix,
-        project_id,
-        dataset_id,
-        table_id,
-        session,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.table_id,
+        config.session,
     )

--- a/tests/benchmark/db_benchmark/groupby/q7.py
+++ b/tests/benchmark/db_benchmark/groupby/q7.py
@@ -18,21 +18,15 @@ import benchmark.utils as utils
 import bigframes_vendored.db_benchmark.groupby_queries as vendored_dbbenchmark_groupby_queries
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         vendored_dbbenchmark_groupby_queries.q7,
         current_path,
-        suffix,
-        project_id,
-        dataset_id,
-        table_id,
-        session,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.table_id,
+        config.session,
     )

--- a/tests/benchmark/db_benchmark/groupby/q8.py
+++ b/tests/benchmark/db_benchmark/groupby/q8.py
@@ -18,21 +18,15 @@ import benchmark.utils as utils
 import bigframes_vendored.db_benchmark.groupby_queries as vendored_dbbenchmark_groupby_queries
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         vendored_dbbenchmark_groupby_queries.q8,
         current_path,
-        suffix,
-        project_id,
-        dataset_id,
-        table_id,
-        session,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.table_id,
+        config.session,
     )

--- a/tests/benchmark/db_benchmark/join/q1.py
+++ b/tests/benchmark/db_benchmark/join/q1.py
@@ -18,22 +18,16 @@ import benchmark.utils as utils
 import bigframes_vendored.db_benchmark.join_queries as vendored_dbbenchmark_join_queries
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
 
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         vendored_dbbenchmark_join_queries.q1,
         current_path,
-        suffix,
-        project_id,
-        dataset_id,
-        table_id,
-        session,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.table_id,
+        config.session,
     )

--- a/tests/benchmark/db_benchmark/join/q2.py
+++ b/tests/benchmark/db_benchmark/join/q2.py
@@ -18,22 +18,16 @@ import benchmark.utils as utils
 import bigframes_vendored.db_benchmark.join_queries as vendored_dbbenchmark_join_queries
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
 
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         vendored_dbbenchmark_join_queries.q2,
         current_path,
-        suffix,
-        project_id,
-        dataset_id,
-        table_id,
-        session,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.table_id,
+        config.session,
     )

--- a/tests/benchmark/db_benchmark/join/q3.py
+++ b/tests/benchmark/db_benchmark/join/q3.py
@@ -18,22 +18,16 @@ import benchmark.utils as utils
 import bigframes_vendored.db_benchmark.join_queries as vendored_dbbenchmark_join_queries
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
 
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         vendored_dbbenchmark_join_queries.q3,
         current_path,
-        suffix,
-        project_id,
-        dataset_id,
-        table_id,
-        session,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.table_id,
+        config.session,
     )

--- a/tests/benchmark/db_benchmark/join/q4.py
+++ b/tests/benchmark/db_benchmark/join/q4.py
@@ -18,22 +18,16 @@ import benchmark.utils as utils
 import bigframes_vendored.db_benchmark.join_queries as vendored_dbbenchmark_join_queries
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
 
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         vendored_dbbenchmark_join_queries.q4,
         current_path,
-        suffix,
-        project_id,
-        dataset_id,
-        table_id,
-        session,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.table_id,
+        config.session,
     )

--- a/tests/benchmark/db_benchmark/join/q5.py
+++ b/tests/benchmark/db_benchmark/join/q5.py
@@ -18,22 +18,16 @@ import benchmark.utils as utils
 import bigframes_vendored.db_benchmark.join_queries as vendored_dbbenchmark_join_queries
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
 
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         vendored_dbbenchmark_join_queries.q5,
         current_path,
-        suffix,
-        project_id,
-        dataset_id,
-        table_id,
-        session,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.table_id,
+        config.session,
     )

--- a/tests/benchmark/db_benchmark/sort/q1.py
+++ b/tests/benchmark/db_benchmark/sort/q1.py
@@ -18,21 +18,15 @@ import benchmark.utils as utils
 import bigframes_vendored.db_benchmark.sort_queries as vendored_dbbenchmark_sort_queries
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         vendored_dbbenchmark_sort_queries.q1,
         current_path,
-        suffix,
-        project_id,
-        dataset_id,
-        table_id,
-        session,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.table_id,
+        config.session,
     )

--- a/tests/benchmark/read_gbq_colab/aggregate_output.py
+++ b/tests/benchmark/read_gbq_colab/aggregate_output.py
@@ -52,21 +52,15 @@ def aggregate_output(
 
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         aggregate_output,
         current_path,
-        suffix,
-        project_id=project_id,
-        dataset_id=dataset_id,
-        table_id=table_id,
-        session=session,
+        config.benchmark_suffix,
+        project_id=config.project_id,
+        dataset_id=config.dataset_id,
+        table_id=config.table_id,
+        session=config.session,
     )

--- a/tests/benchmark/read_gbq_colab/dry_run.py
+++ b/tests/benchmark/read_gbq_colab/dry_run.py
@@ -28,21 +28,15 @@ def dry_run(*, project_id, dataset_id, table_id, session: bigframes.session.Sess
 
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         dry_run,
         current_path,
-        suffix,
-        project_id=project_id,
-        dataset_id=dataset_id,
-        table_id=table_id,
-        session=session,
+        config.benchmark_suffix,
+        project_id=config.project_id,
+        dataset_id=config.dataset_id,
+        table_id=config.table_id,
+        session=config.session,
     )

--- a/tests/benchmark/read_gbq_colab/filter_output.py
+++ b/tests/benchmark/read_gbq_colab/filter_output.py
@@ -44,21 +44,15 @@ def filter_output(
 
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         filter_output,
         current_path,
-        suffix,
-        project_id=project_id,
-        dataset_id=dataset_id,
-        table_id=table_id,
-        session=session,
+        config.benchmark_suffix,
+        project_id=config.project_id,
+        dataset_id=config.dataset_id,
+        table_id=config.table_id,
+        session=config.session,
     )

--- a/tests/benchmark/read_gbq_colab/first_page.py
+++ b/tests/benchmark/read_gbq_colab/first_page.py
@@ -33,21 +33,15 @@ def first_page(*, project_id, dataset_id, table_id, session: bigframes.session.S
 
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         first_page,
         current_path,
-        suffix,
-        project_id=project_id,
-        dataset_id=dataset_id,
-        table_id=table_id,
-        session=session,
+        config.benchmark_suffix,
+        project_id=config.project_id,
+        dataset_id=config.dataset_id,
+        table_id=config.table_id,
+        session=config.session,
     )

--- a/tests/benchmark/read_gbq_colab/last_page.py
+++ b/tests/benchmark/read_gbq_colab/last_page.py
@@ -34,21 +34,15 @@ def last_page(*, project_id, dataset_id, table_id, session: bigframes.session.Se
 
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         last_page,
         current_path,
-        suffix,
-        project_id=project_id,
-        dataset_id=dataset_id,
-        table_id=table_id,
-        session=session,
+        config.benchmark_suffix,
+        project_id=config.project_id,
+        dataset_id=config.dataset_id,
+        table_id=config.table_id,
+        session=config.session,
     )

--- a/tests/benchmark/read_gbq_colab/sort_output.py
+++ b/tests/benchmark/read_gbq_colab/sort_output.py
@@ -44,21 +44,15 @@ def sort_output(
 
 
 if __name__ == "__main__":
-    (
-        project_id,
-        dataset_id,
-        table_id,
-        session,
-        suffix,
-    ) = utils.get_configuration(include_table_id=True)
+    config = utils.get_configuration(include_table_id=True)
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
         sort_output,
         current_path,
-        suffix,
-        project_id=project_id,
-        dataset_id=dataset_id,
-        table_id=table_id,
-        session=session,
+        config.benchmark_suffix,
+        project_id=config.project_id,
+        dataset_id=config.dataset_id,
+        table_id=config.table_id,
+        session=config.session,
     )

--- a/tests/benchmark/tpch/q1.py
+++ b/tests/benchmark/tpch/q1.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q1 as vendored_tpch_q1
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q1.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q1.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q10.py
+++ b/tests/benchmark/tpch/q10.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q10 as vendored_tpch_q10
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q10.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q10.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q11.py
+++ b/tests/benchmark/tpch/q11.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q11 as vendored_tpch_q11
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q11.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q11.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q12.py
+++ b/tests/benchmark/tpch/q12.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q12 as vendored_tpch_q12
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q12.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q12.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q13.py
+++ b/tests/benchmark/tpch/q13.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q13 as vendored_tpch_q13
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q13.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q13.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q14.py
+++ b/tests/benchmark/tpch/q14.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q14 as vendored_tpch_q14
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q14.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q14.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q15.py
+++ b/tests/benchmark/tpch/q15.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q15 as vendored_tpch_q15
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q15.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q15.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q16.py
+++ b/tests/benchmark/tpch/q16.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q16 as vendored_tpch_q16
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q16.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q16.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q17.py
+++ b/tests/benchmark/tpch/q17.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q17 as vendored_tpch_q17
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q17.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q17.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q18.py
+++ b/tests/benchmark/tpch/q18.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q18 as vendored_tpch_q18
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q18.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q18.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q19.py
+++ b/tests/benchmark/tpch/q19.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q19 as vendored_tpch_q19
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q19.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q19.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q2.py
+++ b/tests/benchmark/tpch/q2.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q2 as vendored_tpch_q2
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q2.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q2.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q20.py
+++ b/tests/benchmark/tpch/q20.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q20 as vendored_tpch_q20
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q20.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q20.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q21.py
+++ b/tests/benchmark/tpch/q21.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q21 as vendored_tpch_q21
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q21.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q21.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q22.py
+++ b/tests/benchmark/tpch/q22.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q22 as vendored_tpch_q22
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q22.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q22.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q3.py
+++ b/tests/benchmark/tpch/q3.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q3 as vendored_tpch_q3
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q3.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q3.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q4.py
+++ b/tests/benchmark/tpch/q4.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q4 as vendored_tpch_q4
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q4.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q4.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q5.py
+++ b/tests/benchmark/tpch/q5.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q5 as vendored_tpch_q5
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q5.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q5.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q6.py
+++ b/tests/benchmark/tpch/q6.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q6 as vendored_tpch_q6
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q6.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q6.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q7.py
+++ b/tests/benchmark/tpch/q7.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q7 as vendored_tpch_q7
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q7.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q7.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q8.py
+++ b/tests/benchmark/tpch/q8.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q8 as vendored_tpch_q8
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q8.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q8.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/tpch/q9.py
+++ b/tests/benchmark/tpch/q9.py
@@ -17,9 +17,14 @@ import benchmark.utils as utils
 import bigframes_vendored.tpch.queries.q9 as vendored_tpch_q9
 
 if __name__ == "__main__":
-    project_id, dataset_id, session, suffix = utils.get_configuration()
+    config = utils.get_configuration()
     current_path = pathlib.Path(__file__).absolute()
 
     utils.get_execution_time(
-        vendored_tpch_q9.q, current_path, suffix, project_id, dataset_id, session
+        vendored_tpch_q9.q,
+        current_path,
+        config.benchmark_suffix,
+        config.project_id,
+        config.dataset_id,
+        config.session,
     )

--- a/tests/benchmark/utils.py
+++ b/tests/benchmark/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+import dataclasses
 import time
 
 import bigframes
@@ -20,7 +21,16 @@ import bigframes
 READ_GBQ_COLAB_PAGE_SIZE = 100
 
 
-def get_configuration(include_table_id=False):
+@dataclasses.dataclass(frozen=True)
+class BenchmarkConfig:
+    project_id: str
+    dataset_id: str
+    session: bigframes.Session
+    benchmark_suffix: str | None
+    table_id: str | None = None
+
+
+def get_configuration(include_table_id=False) -> BenchmarkConfig:
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--project_id",
@@ -57,21 +67,13 @@ def get_configuration(include_table_id=False):
     args = parser.parse_args()
     session = _initialize_session(_str_to_bool(args.ordered))
 
-    if include_table_id:
-        return (
-            args.project_id,
-            args.dataset_id,
-            args.table_id,
-            session,
-            args.benchmark_suffix,
-        )
-    else:
-        return (
-            args.project_id,
-            args.dataset_id,
-            session,
-            args.benchmark_suffix,
-        )
+    return BenchmarkConfig(
+        project_id=args.project_id,
+        dataset_id=args.dataset_id,
+        table_id=args.table_id if include_table_id else None,
+        session=session,
+        benchmark_suffix=args.benchmark_suffix,
+    )
 
 
 def get_execution_time(func, current_path, suffix, *args, **kwargs):


### PR DESCRIPTION
I've introduced a new `BenchmarkConfig` frozen dataclass to provide a more structured way of handling benchmark configurations.

I updated the `get_configuration` function in `tests/benchmark/utils.py` to return an instance of this dataclass.

I have partially updated the call sites for `get_configuration` to use the new dataclass object. The following directories have been updated:
- tests/benchmark/db_benchmark/groupby/
- tests/benchmark/db_benchmark/join/
- tests/benchmark/db_benchmark/sort/
- tests/benchmark/read_gbq_colab/ (except for sort_output.py)

The remaining call sites in `tests/benchmark/read_gbq_colab/sort_output.py` and `tests/benchmark/tpch/` still need to be updated.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
