### PR TITLE
docs: add code snippet for storing dataframes to a CSV file

### DIFF
--- a/samples/snippets/conftest.py
+++ b/samples/snippets/conftest.py
@@ -12,12 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterator, Generator
+from typing import Generator, Iterator
 
-from google.cloud import bigquery
+from google.cloud import bigquery, storage
 import pytest
 import test_utils.prefixer
-from google.cloud import storage
 
 import bigframes.pandas as bpd
 
@@ -55,7 +54,7 @@ def project_id(bigquery_client: bigquery.Client) -> str:
 
 @pytest.fixture(scope="session")
 def gcs_bucket(storage_client) -> Generator[str, None, None]:
-    bucket_name =  "bigframes-gcs-test"
+    bucket_name = "bigframes-gcs-test"
 
     yield bucket_name
 

--- a/samples/snippets/conftest.py
+++ b/samples/snippets/conftest.py
@@ -43,7 +43,7 @@ def bigquery_client() -> bigquery.Client:
 
 
 @pytest.fixture(scope="session")
-def storage_client(project_id) -> storage.Client:
+def storage_client(project_id: str) -> storage.Client:
     return storage.Client(project=project_id)
 
 
@@ -53,7 +53,7 @@ def project_id(bigquery_client: bigquery.Client) -> str:
 
 
 @pytest.fixture(scope="session")
-def gcs_bucket(storage_client) -> Generator[str, None, None]:
+def gcs_bucket(storage_client: storage.Client) -> Generator[str, None, None]:
     bucket_name = "bigframes-gcs-test"
 
     yield bucket_name

--- a/samples/snippets/conftest.py
+++ b/samples/snippets/conftest.py
@@ -54,7 +54,7 @@ def project_id(bigquery_client: bigquery.Client) -> str:
 
 @pytest.fixture(scope="session")
 def gcs_bucket(storage_client: storage.Client) -> Generator[str, None, None]:
-    bucket_name = "bigframes-gcs-test"
+    bucket_name = "bigframes_blob_test"
 
     yield bucket_name
 

--- a/samples/snippets/multimodal_test.py
+++ b/samples/snippets/multimodal_test.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 
-def test_multimodal_dataframe(gcs_dst_bucket: str) -> None:
+def test_multimodal_dataframe(gcs_bucket: str) -> None:
     # destination folder must be in a GCS bucket that the BQ connection service account (default or user provided) has write access to.
-    dst_bucket = gcs_dst_bucket
+    dst_bucket = f"gs://{gcs_bucket}"
     # [START bigquery_dataframes_multimodal_dataframe_create]
     import bigframes
 

--- a/samples/snippets/sessions_and_io_test.py
+++ b/samples/snippets/sessions_and_io_test.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from google.cloud import storage
-
 
 def test_sessions_and_io(project_id: str, dataset_id: str, gcs_bucket: str) -> None:
     YOUR_PROJECT_ID = project_id

--- a/samples/snippets/sessions_and_io_test.py
+++ b/samples/snippets/sessions_and_io_test.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from google.cloud import storage
 
-def test_sessions_and_io(project_id: str, dataset_id: str) -> None:
+
+def test_sessions_and_io(project_id: str, dataset_id: str, gcs_bucket: str) -> None:
     YOUR_PROJECT_ID = project_id
     YOUR_LOCATION = "us"
+    YOUR_BUCKET = gcs_bucket
 
     # [START bigquery_dataframes_create_and_use_session_instance]
     import bigframes
@@ -136,6 +139,15 @@ def test_sessions_and_io(project_id: str, dataset_id: str) -> None:
     # Read a CSV file from GCS
     df = bpd.read_csv("gs://cloud-samples-data/bigquery/us-states/us-states.csv")
     # [END bigquery_dataframes_read_data_from_csv]
+    assert df is not None
+
+    # [START bigquery_dataframes_write_data_to_csv]
+    import bigframes.pandas as bpd
+
+    df = bpd.DataFrame({"my_col": [1, 2, 3]})
+    # Write a dataframe to a CSV file in GCS
+    df.to_csv(f"gs://{YOUR_BUCKET}/myfile*.csv")
+    # [END bigquery_dataframes_write_data_to_csv]
     assert df is not None
 
     # [START bigquery_dataframes_read_data_from_bigquery_table]


### PR DESCRIPTION
Main changes:

* Set up a GCS bucket fixture that automatically cleans up after the test
* Update both the session_and_io test and multimodel test to use this fixture.

Fixes #407575751 🦕
