### PR TITLE
style: Constrain footer to table width

### DIFF
--- a/bigframes/display/table_widget.css
+++ b/bigframes/display/table_widget.css
@@ -14,6 +14,10 @@
  * limitations under the License.
  */
 
+.bigframes-widget {
+	display: inline-block;
+}
+
 .bigframes-widget .table-container {
 	max-height: 620px;
 	overflow: auto;

--- a/bigframes/display/table_widget.js
+++ b/bigframes/display/table_widget.js
@@ -36,8 +36,7 @@ const Event = {
  */
 function render({ model, el }) {
 	// Main container with a unique class for CSS scoping
-	const container = document.createElement("div");
-	container.classList.add("bigframes-widget");
+	el.classList.add("bigframes-widget");
 
 	// Structure
 	const tableContainer = document.createElement("div");
@@ -149,10 +148,8 @@ function render({ model, el }) {
 	footer.appendChild(paginationContainer);
 	footer.appendChild(pageSizeContainer);
 
-	container.appendChild(tableContainer);
-	container.appendChild(footer);
-
-	el.appendChild(container);
+	el.appendChild(tableContainer);
+	el.appendChild(footer);
 
 	// Initial render
 	handleTableHTMLChange();


### PR DESCRIPTION
The anywidget display was taking up the full width of the container, even when the container was smaller than the widget. This change adjusts the CSS to use `display: inline-block` to ensure that the widget scales to the width of the container.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<b/437936940> 🦕

fixed, verified here: [screen/97bNvcwcnnwh2P7](https://screenshot.googleplex.com/97bNvcwcnnwh2P7) using bq studio. 
