### PR TITLE
feat: support pd.cut() for array-like type

### DIFF
--- a/bigframes/core/reshape/tile.py
+++ b/bigframes/core/reshape/tile.py
@@ -20,6 +20,7 @@ import bigframes_vendored.constants as constants
 import bigframes_vendored.pandas.core.reshape.tile as vendored_pandas_tile
 import pandas as pd
 
+import bigframes
 import bigframes.constants
 import bigframes.core.expression as ex
 import bigframes.core.ordering as order
@@ -32,7 +33,7 @@ import bigframes.series
 
 
 def cut(
-    x: bigframes.series.Series,
+    x,
     bins: typing.Union[
         int,
         pd.IntervalIndex,
@@ -60,8 +61,11 @@ def cut(
             f"but found {type(list(labels)[0])}. {constants.FEEDBACK_LINK}"
         )
 
-    if x.size == 0:
+    if len(x) == 0:
         raise ValueError("Cannot cut empty array.")
+
+    if not isinstance(x, bigframes.series.Series):
+        x = bigframes.series.Series(x)
 
     if isinstance(bins, int):
         if bins <= 0:

--- a/tests/system/small/test_pandas.py
+++ b/tests/system/small/test_pandas.py
@@ -520,6 +520,18 @@ def _convert_pandas_category(pd_s: pd.Series):
     )
 
 
+def test_cut_for_array():
+    """Avoid regressions for internal issue 329866195"""
+    sc = [30, 80, 40, 90, 60, 45, 95, 75, 55, 100, 65, 85]
+    x = [20, 40, 60, 80, 100]
+
+    pd_result: pd.Series = pd.Series(pd.cut(sc, x))
+    bf_result = bpd.cut(sc, x)
+
+    pd_result = _convert_pandas_category(pd_result)
+    pd.testing.assert_series_equal(bf_result.to_pandas(), pd_result)
+
+
 @pytest.mark.parametrize(
     ("right", "labels"),
     [

--- a/tests/unit/test_pandas.py
+++ b/tests/unit/test_pandas.py
@@ -122,6 +122,7 @@ def test_method_matches_session(method_name: str):
 )
 def test_cut_raises_with_invalid_labels(bins: int, labels, error_message: str):
     mock_series = mock.create_autospec(bigframes.pandas.Series, instance=True)
+    mock_series.__len__.return_value = 5
     with pytest.raises(ValueError, match=error_message):
         bigframes.pandas.cut(mock_series, bins, labels=labels)
 
@@ -160,6 +161,8 @@ def test_cut_raises_with_unsupported_labels():
 )
 def test_cut_raises_with_invalid_bins(bins: int, error_message: str):
     mock_series = mock.create_autospec(bigframes.pandas.Series, instance=True)
+    mock_series.__len__.return_value = 5
+
     with pytest.raises(ValueError, match=error_message):
         bigframes.pandas.cut(mock_series, bins, labels=False)
 

--- a/third_party/bigframes_vendored/pandas/core/reshape/tile.py
+++ b/third_party/bigframes_vendored/pandas/core/reshape/tile.py
@@ -8,11 +8,11 @@ import typing
 
 import pandas as pd
 
-from bigframes import constants, series
+from bigframes import constants
 
 
 def cut(
-    x: series.Series,
+    x,
     bins: typing.Union[
         int,
         pd.IntervalIndex,
@@ -113,7 +113,7 @@ def cut(
         dtype: struct<left_inclusive: int64, right_exclusive: int64>[pyarrow]
 
     Args:
-        x (bigframes.pandas.Series):
+        x (array-like):
             The input Series to be binned. Must be 1-dimensional.
         bins (int, pd.IntervalIndex, Iterable):
             The criteria to bin by.


### PR DESCRIPTION
Fixes internal issue 329866195 🦕
