### PR TITLE
fix: allow bigframes.options.bigquery.credentials to be `None`

### DIFF
--- a/bigframes/_config/bigquery_options.py
+++ b/bigframes/_config/bigquery_options.py
@@ -22,7 +22,6 @@ import warnings
 import google.auth.credentials
 import requests.adapters
 
-import bigframes._config.auth
 import bigframes._importing
 import bigframes.enums
 import bigframes.exceptions as bfe
@@ -38,7 +37,6 @@ UNKNOWN_LOCATION_MESSAGE = "The location '{location}' is set to an unknown value
 
 def _get_validated_location(value: Optional[str]) -> Optional[str]:
     import bigframes._tools.strings
-    import bigframes.constants
 
     if value is None or value in bigframes.constants.ALL_BIGQUERY_LOCATIONS:
         return value
@@ -143,52 +141,20 @@ class BigQueryOptions:
             )
         self._application_name = value
 
-    def _try_set_default_credentials_and_project(
-        self,
-    ) -> tuple[google.auth.credentials.Credentials, Optional[str]]:
-        # Don't fetch credentials or project if credentials is already set.
-        # If it's set, we've already authenticated, so if the user wants to
-        # re-auth, they should explicitly reset the credentials.
-        if self._credentials is not None:
-            return self._credentials, self._project
-
-        (
-            credentials,
-            credentials_project,
-        ) = bigframes._config.auth.get_default_credentials_with_project()
-        self._credentials = credentials
-
-        # Avoid overriding an explicitly set project with a default value.
-        if self._project is None:
-            self._project = credentials_project
-
-        return credentials, self._project
-
     @property
-    def credentials(self) -> google.auth.credentials.Credentials:
+    def credentials(self) -> Optional[google.auth.credentials.Credentials]:
         """The OAuth2 credentials to use for this client.
-
-        Set to None to force re-authentication.
 
         Returns:
             None or google.auth.credentials.Credentials:
                 google.auth.credentials.Credentials if exists; otherwise None.
         """
-        if self._credentials:
-            return self._credentials
-
-        credentials, _ = self._try_set_default_credentials_and_project()
-        return credentials
+        return self._credentials
 
     @credentials.setter
     def credentials(self, value: Optional[google.auth.credentials.Credentials]):
         if self._session_started and self._credentials is not value:
             raise ValueError(SESSION_STARTED_MESSAGE.format(attribute="credentials"))
-
-        if value is None:
-            # The user has _explicitly_ asked that we re-authenticate.
-            bigframes._config.auth.reset_default_credentials_and_project()
-
         self._credentials = value
 
     @property
@@ -217,11 +183,7 @@ class BigQueryOptions:
             None or str:
                 Google Cloud project ID as a string; otherwise None.
         """
-        if self._project:
-            return self._project
-
-        _, project = self._try_set_default_credentials_and_project()
-        return project
+        return self._project
 
     @project.setter
     def project(self, value: Optional[str]):

--- a/bigframes/session/clients.py
+++ b/bigframes/session/clients.py
@@ -32,7 +32,7 @@ import google.cloud.resourcemanager_v3
 import google.cloud.storage  # type: ignore
 import requests
 
-import bigframes._config
+import bigframes._config.auth
 import bigframes.constants
 import bigframes.version
 
@@ -48,6 +48,10 @@ _BIGQUERY_REGIONAL_ENDPOINT = "https://bigquery.{location}.rep.googleapis.com"
 # BigQuery Connection and Storage are gRPC APIs, which don't support the
 # https:// protocol in the API endpoint URL.
 _BIGQUERYSTORAGE_REGIONAL_ENDPOINT = "bigquerystorage.{location}.rep.googleapis.com"
+
+
+def _get_default_credentials_with_project():
+    return bigframes._config.auth.get_default_credentials_with_project()
 
 
 def _get_application_names():
@@ -84,8 +88,7 @@ class ClientsProvider:
     ):
         credentials_project = None
         if credentials is None:
-            credentials = bigframes._config.options.bigquery.credentials
-            credentials_project = bigframes._config.options.bigquery.project
+            credentials, credentials_project = _get_default_credentials_with_project()
 
         # Prefer the project in this order:
         # 1. Project explicitly specified by the user

--- a/tests/unit/_config/test_bigquery_options.py
+++ b/tests/unit/_config/test_bigquery_options.py
@@ -203,3 +203,8 @@ def test_default_options():
 
     assert options.allow_large_results is False
     assert options.ordering_mode == "strict"
+
+    # We should default to None as an indicator that the user hasn't set these
+    # explicitly. See internal issue b/445731915.
+    assert options.credentials is None
+    assert options.project is None


### PR DESCRIPTION
This is a partial revert of "perf: avoid re-authenticating if credentials have already been fetched (#2058)", commit 913de1b31f3bb0b306846fddae5dcaff6be3cec4.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes internal issue b/445731915 🦕
