### PR TITLE
feat: implement inplace parameter for `DataFrame.drop`

### DIFF
--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,24 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def polars_session():
+    pytest.importorskip("polars")
+
+    from bigframes.testing import polars_session
+
+    return polars_session.TestSession()

--- a/tests/unit/core/test_groupby.py
+++ b/tests/unit/core/test_groupby.py
@@ -23,14 +23,6 @@ pytest.importorskip("polars")
 pytest.importorskip("pandas", minversion="2.0.0")
 
 
-# All tests in this file require polars to be installed to pass.
-@pytest.fixture(scope="module")
-def polars_session():
-    from bigframes.testing import polars_session
-
-    return polars_session.TestSession()
-
-
 def test_groupby_df_iter_by_key_singular(polars_session):
     pd_df = pd.DataFrame({"colA": ["a", "a", "b", "c", "c"], "colB": [1, 2, 3, 4, 5]})
     bf_df = bpd.DataFrame(pd_df, session=polars_session)

--- a/tests/unit/test_dataframe.py
+++ b/tests/unit/test_dataframe.py
@@ -129,6 +129,35 @@ def test_dataframe_rename_axis_inplace_returns_none(monkeypatch: pytest.MonkeyPa
     assert list(dataframe.index.names) == ["a", "b"]
 
 
+def test_dataframe_drop_columns_inplace_returns_none(monkeypatch: pytest.MonkeyPatch):
+    dataframe = mocks.create_dataframe(
+        monkeypatch, data={"col1": [1], "col2": [2], "col3": [3]}
+    )
+    assert dataframe.columns.to_list() == ["col1", "col2", "col3"]
+    assert dataframe.drop(columns=["col1", "col3"], inplace=True) is None
+    assert dataframe.columns.to_list() == ["col2"]
+
+
+def test_dataframe_drop_index_inplace_returns_none(monkeypatch: pytest.MonkeyPatch):
+    dataframe = mocks.create_dataframe(
+        monkeypatch, data={"col1": [1, 2, 3], "index_col": [0, 1, 2]}
+    ).set_index("index_col")
+    # TODO(swast): Support dataframe.index.to_list()
+    # assert dataframe.index.to_list() == [0, 1, 2]
+    assert dataframe.drop(index=[0, 2], inplace=True) is None
+    # assert dataframe.index.to_list() == [1]
+
+
+def test_dataframe_drop_columns_returns_new_dataframe(monkeypatch: pytest.MonkeyPatch):
+    dataframe = mocks.create_dataframe(
+        monkeypatch, data={"col1": [1], "col2": [2], "col3": [3]}
+    )
+    assert dataframe.columns.to_list() == ["col1", "col2", "col3"]
+    new_dataframe = dataframe.drop(columns=["col1", "col3"])
+    assert dataframe.columns.to_list() == ["col1", "col2", "col3"]
+    assert new_dataframe.columns.to_list() == ["col2"]
+
+
 def test_dataframe_semantics_property_future_warning(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/tests/unit/test_local_engine.py
+++ b/tests/unit/test_local_engine.py
@@ -24,14 +24,6 @@ pytest.importorskip("polars")
 pytest.importorskip("pandas", minversion="2.0.0")
 
 
-# All tests in this file require polars to be installed to pass.
-@pytest.fixture(scope="module")
-def polars_session():
-    from bigframes.testing import polars_session
-
-    return polars_session.TestSession()
-
-
 @pytest.fixture(scope="module")
 def small_inline_frame() -> pd.DataFrame:
     df = pd.DataFrame(


### PR DESCRIPTION
This commit implements the `inplace` parameter for the `DataFrame.drop` method.

When `inplace=True`, the DataFrame is modified in place and the method returns `None`. When `inplace=False` (the default), a new DataFrame is returned.

Unit tests have been added to verify the functionality for both column and row dropping.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes b/385199126 🦕
