### PR TITLE
feat: implement `Index.to_list()`

### DIFF
--- a/bigframes/core/indexes/base.py
+++ b/bigframes/core/indexes/base.py
@@ -740,6 +740,11 @@ class Index(vendored_pandas_index.Index):
 
     __array__ = to_numpy
 
+    def tolist(self, *, allow_large_results: Optional[bool] = None) -> list:
+        return self.to_pandas(allow_large_results=allow_large_results).to_list()
+
+    to_list = tolist
+
     def __len__(self):
         return self.shape[0]
 

--- a/bigframes/core/indexes/base.py
+++ b/bigframes/core/indexes/base.py
@@ -740,10 +740,8 @@ class Index(vendored_pandas_index.Index):
 
     __array__ = to_numpy
 
-    def tolist(self, *, allow_large_results: Optional[bool] = None) -> list:
+    def to_list(self, *, allow_large_results: Optional[bool] = None) -> list:
         return self.to_pandas(allow_large_results=allow_large_results).to_list()
-
-    to_list = tolist
 
     def __len__(self):
         return self.shape[0]

--- a/tests/system/small/test_index.py
+++ b/tests/system/small/test_index.py
@@ -638,6 +638,12 @@ def test_index_item_with_empty(session):
         bf_idx_empty.item()
 
 
+def test_index_to_list(scalars_df_index, scalars_pandas_df_index):
+    bf_result = scalars_df_index.index.to_list()
+    pd_result = scalars_pandas_df_index.index.to_list()
+    assert bf_result == pd_result
+
+
 @pytest.mark.parametrize(
     ("key", "value"),
     [

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -45,7 +45,7 @@ def test_index_to_list(monkeypatch: pytest.MonkeyPatch):
     pd_index = pd.Index([1, 2, 3], name="my_index")
     df = mocks.create_dataframe(
         monkeypatch,
-        data=pd.DataFrame({"my_index": [1, 2, 3]}).set_index("my_index"),
-    )
+        data={"my_index": [1, 2, 3]},
+    ).set_index("my_index")
     bf_index = df.index
     assert bf_index.to_list() == pd_index.to_list()

--- a/tests/unit/test_index.py
+++ b/tests/unit/test_index.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pandas as pd
 import pytest
 
 from bigframes.testing import mocks
@@ -38,3 +39,13 @@ def test_index_rename_inplace_returns_none(monkeypatch: pytest.MonkeyPatch):
     # Make sure the linked DataFrame is updated, too.
     assert dataframe.index.name == "my_index_name"
     assert index.name == "my_index_name"
+
+
+def test_index_to_list(monkeypatch: pytest.MonkeyPatch):
+    pd_index = pd.Index([1, 2, 3], name="my_index")
+    df = mocks.create_dataframe(
+        monkeypatch,
+        data=pd.DataFrame({"my_index": [1, 2, 3]}).set_index("my_index"),
+    )
+    bf_index = df.index
+    assert bf_index.to_list() == pd_index.to_list()


### PR DESCRIPTION
This commit implements the `Index.to_list()` method, which is an alias for `tolist()`. This new method provides a way to convert a BigQuery DataFrames Index to a Python list, similar to the existing `Series.to_list()` method.

The implementation follows the pattern of other methods in the library by first converting the Index to a pandas Index using `to_pandas()` and then calling the corresponding `.to_list()` method.

A unit test has been added to verify the functionality of the new method.

Follow-up to https://github.com/googleapis/python-bigquery-dataframes/pull/2105/files#r2369617190
🦕
