### PR TITLE
refactor: support agg_ops.AllOp and AnyValueOp in sqlglot compiler

### DIFF
--- a/bigframes/core/compile/sqlglot/aggregations/unary_compiler.py
+++ b/bigframes/core/compile/sqlglot/aggregations/unary_compiler.py
@@ -69,6 +69,15 @@ def _(
     return sge.func("APPROX_TOP_COUNT", column.expr, sge.convert(op.number))
 
 
+@UNARY_OP_REGISTRATION.register(agg_ops.AnyValueOp)
+def _(
+    op: agg_ops.AnyValueOp,
+    column: typed_expr.TypedExpr,
+    window: typing.Optional[window_spec.WindowSpec] = None,
+) -> sge.Expression:
+    return apply_window_if_present(sge.func("ANY_VALUE", column.expr), window)
+
+
 @UNARY_OP_REGISTRATION.register(agg_ops.CountOp)
 def _(
     op: agg_ops.CountOp,

--- a/bigframes/core/compile/sqlglot/aggregations/unary_compiler.py
+++ b/bigframes/core/compile/sqlglot/aggregations/unary_compiler.py
@@ -38,6 +38,17 @@ def compile(
     return UNARY_OP_REGISTRATION[op](op, column, window=window)
 
 
+@UNARY_OP_REGISTRATION.register(agg_ops.AllOp)
+def _(
+    op: agg_ops.AllOp,
+    column: typed_expr.TypedExpr,
+    window: typing.Optional[window_spec.WindowSpec] = None,
+) -> sge.Expression:
+    # BQ will return null for empty column, result would be false in pandas.
+    result = apply_window_if_present(sge.func("LOGICAL_AND", column.expr), window)
+    return sge.func("IFNULL", result, sge.true())
+
+
 @UNARY_OP_REGISTRATION.register(agg_ops.ApproxQuartilesOp)
 def _(
     op: agg_ops.ApproxQuartilesOp,

--- a/tests/unit/core/compile/sqlglot/aggregations/snapshots/test_unary_compiler/test_all/out.sql
+++ b/tests/unit/core/compile/sqlglot/aggregations/snapshots/test_unary_compiler/test_all/out.sql
@@ -1,0 +1,12 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `bool_col` AS `bfcol_0`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    COALESCE(LOGICAL_AND(`bfcol_0`), TRUE) AS `bfcol_1`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_1` AS `bool_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/aggregations/snapshots/test_unary_compiler/test_any_value/out.sql
+++ b/tests/unit/core/compile/sqlglot/aggregations/snapshots/test_unary_compiler/test_any_value/out.sql
@@ -1,0 +1,12 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `int64_col` AS `bfcol_0`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    ANY_VALUE(`bfcol_0`) AS `bfcol_1`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_1` AS `int64_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/aggregations/test_unary_compiler.py
+++ b/tests/unit/core/compile/sqlglot/aggregations/test_unary_compiler.py
@@ -87,6 +87,15 @@ def test_approx_top_count(scalar_types_df: bpd.DataFrame, snapshot):
     snapshot.assert_match(sql, "out.sql")
 
 
+def test_any_value(scalar_types_df: bpd.DataFrame, snapshot):
+    col_name = "int64_col"
+    bf_df = scalar_types_df[[col_name]]
+    agg_expr = agg_ops.AnyValueOp().as_expr(col_name)
+    sql = _apply_unary_agg_ops(bf_df, [agg_expr], [col_name])
+
+    snapshot.assert_match(sql, "out.sql")
+
+
 def test_count(scalar_types_df: bpd.DataFrame, snapshot):
     col_name = "int64_col"
     bf_df = scalar_types_df[[col_name]]

--- a/tests/unit/core/compile/sqlglot/aggregations/test_unary_compiler.py
+++ b/tests/unit/core/compile/sqlglot/aggregations/test_unary_compiler.py
@@ -63,6 +63,15 @@ def _apply_unary_window_op(
     return sql
 
 
+def test_all(scalar_types_df: bpd.DataFrame, snapshot):
+    col_name = "bool_col"
+    bf_df = scalar_types_df[[col_name]]
+    agg_expr = agg_ops.AllOp().as_expr(col_name)
+    sql = _apply_unary_agg_ops(bf_df, [agg_expr], [col_name])
+
+    snapshot.assert_match(sql, "out.sql")
+
+
 def test_approx_quartiles(scalar_types_df: bpd.DataFrame, snapshot):
     col_name = "int64_col"
     bf_df = scalar_types_df[[col_name]]


### PR DESCRIPTION
Fixes internal issue 445774480🦕
