### PR TITLE
test: fix test_read_gbq_query timeout on g3 python 3.13 tests

### DIFF
--- a/tests/unit/session/test_read_gbq_query.py
+++ b/tests/unit/session/test_read_gbq_query.py
@@ -35,3 +35,4 @@ def test_read_gbq_query_sets_destination_table():
 
     assert query == "SELECT 'my-test-query';"
     assert config.destination is not None
+    session.close()


### PR DESCRIPTION
Fixes internal issue 450524704🦕
