### PR TITLE
chore: Migrate strconcat_op operator to SQLGlot

### DIFF
--- a/bigframes/core/compile/sqlglot/expressions/string_ops.py
+++ b/bigframes/core/compile/sqlglot/expressions/string_ops.py
@@ -279,7 +279,7 @@ def _(expr: TypedExpr) -> sge.Expression:
 
 @register_binary_op(ops.strconcat_op)
 def _(left: TypedExpr, right: TypedExpr) -> sge.Expression:
-    return sge.Concat(this=left.expr, expression=right.expr)
+    return sge.Concat(expressions=[left.expr, right.expr])
 
 
 @register_unary_op(ops.ZfillOp, pass_op=True)

--- a/bigframes/core/compile/sqlglot/expressions/string_ops.py
+++ b/bigframes/core/compile/sqlglot/expressions/string_ops.py
@@ -23,6 +23,7 @@ from bigframes.core.compile.sqlglot.expressions.typed_expr import TypedExpr
 import bigframes.core.compile.sqlglot.scalar_compiler as scalar_compiler
 
 register_unary_op = scalar_compiler.scalar_op_compiler.register_unary_op
+register_binary_op = scalar_compiler.scalar_op_compiler.register_binary_op
 
 
 @register_unary_op(ops.capitalize_op)
@@ -274,6 +275,11 @@ def _(expr: TypedExpr, op: ops.StrSliceOp) -> sge.Expression:
 @register_unary_op(ops.upper_op)
 def _(expr: TypedExpr) -> sge.Expression:
     return sge.Upper(this=expr.expr)
+
+
+@register_binary_op(ops.strconcat_op)
+def _(left: TypedExpr, right: TypedExpr) -> sge.Expression:
+    return sge.Concat(this=left.expr, expression=right.expr)
 
 
 @register_unary_op(ops.ZfillOp, pass_op=True)

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_string_ops/test_strconcat/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_string_ops/test_strconcat/out.sql
@@ -1,0 +1,13 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `string_col` AS `bfcol_0`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    *,
+    CONCAT() AS `bfcol_1`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_1` AS `string_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_string_ops/test_strconcat/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_string_ops/test_strconcat/out.sql
@@ -5,7 +5,7 @@ WITH `bfcte_0` AS (
 ), `bfcte_1` AS (
   SELECT
     *,
-    CONCAT() AS `bfcol_1`
+    CONCAT(`bfcol_0`, 'a') AS `bfcol_1`
   FROM `bfcte_0`
 )
 SELECT

--- a/tests/unit/core/compile/sqlglot/expressions/test_string_ops.py
+++ b/tests/unit/core/compile/sqlglot/expressions/test_string_ops.py
@@ -311,3 +311,10 @@ def test_add_string(scalar_types_df: bpd.DataFrame, snapshot):
     sql = utils._apply_binary_op(bf_df, ops.add_op, "string_col", ex.const("a"))
 
     snapshot.assert_match(sql, "out.sql")
+
+
+def test_strconcat(scalar_types_df: bpd.DataFrame, snapshot):
+    bf_df = scalar_types_df[["string_col"]]
+    sql = utils._apply_binary_op(bf_df, ops.strconcat_op, "string_col", ex.const("a"))
+
+    snapshot.assert_match(sql, "out.sql")


### PR DESCRIPTION
Migrated the `strconcat_op` operator from the Ibis compiler to the new SQLGlot compiler. This includes the implementation of the compiler logic and a corresponding unit test with a snapshot.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
