### PR TITLE
chore: Add setuptools to lint_setup_py session installation

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -193,7 +193,7 @@ def format(session):
 @nox.session(python=DEFAULT_PYTHON_VERSION)
 def lint_setup_py(session):
     """Verify that setup.py is valid (including RST check)."""
-    session.install("docutils", "pygments")
+    session.install("docutils", "pygments", "setuptools")
     session.run("python", "setup.py", "check", "--restructuredtext", "--strict")
 
     session.install("twine", "wheel")


### PR DESCRIPTION
Fixes lint errors that started today. 🦕
