### PR TITLE
chore: Migrate coalesce_op operator to SQLGlot

### DIFF
--- a/bigframes/core/compile/sqlglot/expressions/generic_ops.py
+++ b/bigframes/core/compile/sqlglot/expressions/generic_ops.py
@@ -24,6 +24,7 @@ from bigframes.core.compile.sqlglot.expressions.typed_expr import TypedExpr
 import bigframes.core.compile.sqlglot.scalar_compiler as scalar_compiler
 
 register_unary_op = scalar_compiler.scalar_op_compiler.register_unary_op
+register_binary_op = scalar_compiler.scalar_op_compiler.register_binary_op
 register_nary_op = scalar_compiler.scalar_op_compiler.register_nary_op
 register_ternary_op = scalar_compiler.scalar_op_compiler.register_ternary_op
 
@@ -157,6 +158,13 @@ def _(*cases_and_outputs: TypedExpr) -> sge.Expression:
             for predicate, output in zip(cases_and_outputs[::2], result_values)
         ],
     )
+
+
+@register_binary_op(ops.coalesce_op)
+def _(left: TypedExpr, right: TypedExpr) -> sge.Expression:
+    if left.expr == right.expr:
+        return left.expr
+    return sge.Coalesce(this=left.expr, expressions=[right.expr])
 
 
 @register_nary_op(ops.RowKey)

--- a/tests/system/small/engines/test_generic_ops.py
+++ b/tests/system/small/engines/test_generic_ops.py
@@ -329,7 +329,7 @@ def test_engines_where_op(scalars_array_value: array_value.ArrayValue, engine):
     assert_equivalence_execution(arr.node, REFERENCE_ENGINE, engine)
 
 
-@pytest.mark.parametrize("engine", ["polars", "bq"], indirect=True)
+@pytest.mark.parametrize("engine", ["polars", "bq", "bq-sqlglot"], indirect=True)
 def test_engines_coalesce_op(scalars_array_value: array_value.ArrayValue, engine):
     arr, _ = scalars_array_value.compute_values(
         [

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_generic_ops/test_coalesce/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_generic_ops/test_coalesce/out.sql
@@ -6,9 +6,11 @@ WITH `bfcte_0` AS (
 ), `bfcte_1` AS (
   SELECT
     *,
-    COALESCE(`bfcol_0`, `bfcol_1`) AS `bfcol_2`
+    `bfcol_0` AS `bfcol_2`,
+    COALESCE(`bfcol_1`, `bfcol_0`) AS `bfcol_3`
   FROM `bfcte_0`
 )
 SELECT
-  `bfcol_2` AS `int64_col`
+  `bfcol_2` AS `int64_col`,
+  `bfcol_3` AS `int64_too`
 FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_generic_ops/test_coalesce/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_generic_ops/test_coalesce/out.sql
@@ -1,0 +1,14 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `int64_col` AS `bfcol_0`,
+    `int64_too` AS `bfcol_1`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    *,
+    COALESCE(`bfcol_0`, `bfcol_1`) AS `bfcol_2`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_2` AS `int64_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/expressions/test_generic_ops.py
+++ b/tests/unit/core/compile/sqlglot/expressions/test_generic_ops.py
@@ -211,8 +211,15 @@ def test_case_when_op(scalar_types_df: bpd.DataFrame, snapshot):
 
 def test_coalesce(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df = scalar_types_df[["int64_col", "int64_too"]]
-    sql = utils._apply_binary_op(bf_df, ops.coalesce_op, "int64_col", "int64_too")
 
+    sql = utils._apply_ops_to_sql(
+        bf_df,
+        [
+            ops.coalesce_op.as_expr("int64_col", "int64_col"), 
+            ops.coalesce_op.as_expr("int64_too", "int64_col"),
+        ],
+        ["int64_col", "int64_too"],
+    )
     snapshot.assert_match(sql, "out.sql")
 
 

--- a/tests/unit/core/compile/sqlglot/expressions/test_generic_ops.py
+++ b/tests/unit/core/compile/sqlglot/expressions/test_generic_ops.py
@@ -215,7 +215,7 @@ def test_coalesce(scalar_types_df: bpd.DataFrame, snapshot):
     sql = utils._apply_ops_to_sql(
         bf_df,
         [
-            ops.coalesce_op.as_expr("int64_col", "int64_col"), 
+            ops.coalesce_op.as_expr("int64_col", "int64_col"),
             ops.coalesce_op.as_expr("int64_too", "int64_col"),
         ],
         ["int64_col", "int64_too"],

--- a/tests/unit/core/compile/sqlglot/expressions/test_generic_ops.py
+++ b/tests/unit/core/compile/sqlglot/expressions/test_generic_ops.py
@@ -209,6 +209,13 @@ def test_case_when_op(scalar_types_df: bpd.DataFrame, snapshot):
     snapshot.assert_match(sql, "out.sql")
 
 
+def test_coalesce(scalar_types_df: bpd.DataFrame, snapshot):
+    bf_df = scalar_types_df[["int64_col", "int64_too"]]
+    sql = utils._apply_binary_op(bf_df, ops.coalesce_op, "int64_col", "int64_too")
+
+    snapshot.assert_match(sql, "out.sql")
+
+
 def test_clip(scalar_types_df: bpd.DataFrame, snapshot):
     op_expr = ops.clip_op.as_expr("rowindex", "int64_col", "int64_too")
 


### PR DESCRIPTION
Migrated the coalesce_op operator from Ibis to SQLGlot.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes b/447388852 🦕
