### PR TITLE
chore: Migrate maximum_op operator to SQLGlot

### DIFF
--- a/bigframes/core/compile/sqlglot/expressions/comparison_ops.py
+++ b/bigframes/core/compile/sqlglot/expressions/comparison_ops.py
@@ -109,6 +109,11 @@ def _(left: TypedExpr, right: TypedExpr) -> sge.Expression:
     return sge.LTE(this=left_expr, expression=right_expr)
 
 
+@register_binary_op(ops.maximum_op)
+def _(left: TypedExpr, right: TypedExpr) -> sge.Expression:
+    return sge.Greatest(expressions=[left.expr, right.expr])
+
+
 @register_binary_op(ops.minimum_op)
 def _(left: TypedExpr, right: TypedExpr) -> sge.Expression:
     return sge.Least(this=left.expr, expressions=right.expr)

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_comparison_ops/test_maximum_op/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_comparison_ops/test_maximum_op/out.sql
@@ -1,0 +1,14 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `int64_col` AS `bfcol_0`,
+    `float64_col` AS `bfcol_1`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    *,
+    GREATEST(`bfcol_0`, `bfcol_1`) AS `bfcol_2`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_2` AS `int64_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/expressions/test_comparison_ops.py
+++ b/tests/unit/core/compile/sqlglot/expressions/test_comparison_ops.py
@@ -110,6 +110,13 @@ def test_le_numeric(scalar_types_df: bpd.DataFrame, snapshot):
     snapshot.assert_match(bf_df.sql, "out.sql")
 
 
+def test_maximum_op(scalar_types_df: bpd.DataFrame, snapshot):
+    bf_df = scalar_types_df[["int64_col", "float64_col"]]
+    sql = utils._apply_binary_op(bf_df, ops.maximum_op, "int64_col", "float64_col")
+
+    snapshot.assert_match(sql, "out.sql")
+
+
 def test_minimum_op(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df = scalar_types_df[["int64_col", "float64_col"]]
     sql = utils._apply_binary_op(bf_df, ops.minimum_op, "int64_col", "float64_col")


### PR DESCRIPTION
Migrated the maximum_op and minimum_op operators to SQLGlot.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes b/447388852 🦕
