### PR TITLE
chore: Migrate timestamp_diff_op operator to SQLGlot

### DIFF
--- a/bigframes/core/compile/sqlglot/expressions/datetime_ops.py
+++ b/bigframes/core/compile/sqlglot/expressions/datetime_ops.py
@@ -21,6 +21,7 @@ from bigframes.core.compile.sqlglot.expressions.typed_expr import TypedExpr
 import bigframes.core.compile.sqlglot.scalar_compiler as scalar_compiler
 
 register_unary_op = scalar_compiler.scalar_op_compiler.register_unary_op
+register_binary_op = scalar_compiler.scalar_op_compiler.register_binary_op
 
 
 @register_unary_op(ops.FloorDtOp, pass_op=True)
@@ -77,6 +78,13 @@ def _(expr: TypedExpr) -> sge.Expression:
 @register_unary_op(ops.second_op)
 def _(expr: TypedExpr) -> sge.Expression:
     return sge.Extract(this=sge.Identifier(this="SECOND"), expression=expr.expr)
+
+
+@register_binary_op(ops.timestamp_diff_op)
+def _(left: TypedExpr, right: TypedExpr) -> sge.Expression:
+    return sge.TimestampDiff(
+        this=left.expr, expression=right.expr, unit=sge.Var(this="MICROSECOND")
+    )
 
 
 @register_unary_op(ops.StrftimeOp, pass_op=True)

--- a/tests/unit/core/compile/sqlglot/expressions/snapshots/test_datetime_ops/test_timestamp_diff/out.sql
+++ b/tests/unit/core/compile/sqlglot/expressions/snapshots/test_datetime_ops/test_timestamp_diff/out.sql
@@ -1,0 +1,13 @@
+WITH `bfcte_0` AS (
+  SELECT
+    `timestamp_col` AS `bfcol_0`
+  FROM `bigframes-dev`.`sqlglot_test`.`scalar_types`
+), `bfcte_1` AS (
+  SELECT
+    *,
+    TIMESTAMP_DIFF(`bfcol_0`, `bfcol_0`, MICROSECOND) AS `bfcol_1`
+  FROM `bfcte_0`
+)
+SELECT
+  `bfcol_1` AS `timestamp_col`
+FROM `bfcte_1`

--- a/tests/unit/core/compile/sqlglot/expressions/test_datetime_ops.py
+++ b/tests/unit/core/compile/sqlglot/expressions/test_datetime_ops.py
@@ -270,3 +270,11 @@ def test_sub_timedelta(scalar_types_df: bpd.DataFrame, snapshot):
     bf_df["timedelta_sub_timedelta"] = bf_df["duration_col"] - bf_df["duration_col"]
 
     snapshot.assert_match(bf_df.sql, "out.sql")
+
+
+def test_timestamp_diff(scalar_types_df: bpd.DataFrame, snapshot):
+    bf_df = scalar_types_df[["timestamp_col", "date_col"]]
+    sql = utils._apply_binary_op(
+        bf_df, ops.timestamp_diff_op, "timestamp_col", "timestamp_col"
+    )
+    snapshot.assert_match(sql, "out.sql")


### PR DESCRIPTION
Migrated the timestamp_diff_op operator to SQLGlot.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes b/447388852 🦕
