### PR TITLE
refactor: make sqlglot compile_sql a top-level function

### DIFF
--- a/bigframes/core/compile/sqlglot/__init__.py
+++ b/bigframes/core/compile/sqlglot/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 from __future__ import annotations
 
-from bigframes.core.compile.sqlglot.compiler import SQLGlotCompiler
+from bigframes.core.compile.sqlglot.compiler import compile_sql
 import bigframes.core.compile.sqlglot.expressions.ai_ops  # noqa: F401
 import bigframes.core.compile.sqlglot.expressions.array_ops  # noqa: F401
 import bigframes.core.compile.sqlglot.expressions.blob_ops  # noqa: F401
@@ -29,4 +29,4 @@ import bigframes.core.compile.sqlglot.expressions.string_ops  # noqa: F401
 import bigframes.core.compile.sqlglot.expressions.struct_ops  # noqa: F401
 import bigframes.core.compile.sqlglot.expressions.timedelta_ops  # noqa: F401
 
-__all__ = ["SQLGlotCompiler"]
+__all__ = ["compile_sql"]

--- a/bigframes/session/direct_gbq_execution.py
+++ b/bigframes/session/direct_gbq_execution.py
@@ -40,9 +40,7 @@ class DirectGbqExecutor(semi_executor.SemiExecutor):
     ):
         self.bqclient = bqclient
         self._compile_fn = (
-            compile.compile_sql
-            if compiler == "ibis"
-            else sqlglot.SQLGlotCompiler()._compile_sql
+            compile.compile_sql if compiler == "ibis" else sqlglot.compile_sql
         )
         self._publisher = publisher
 

--- a/bigframes/testing/compiler_session.py
+++ b/bigframes/testing/compiler_session.py
@@ -16,7 +16,7 @@ import dataclasses
 import typing
 
 import bigframes.core
-import bigframes.core.compile.sqlglot as sqlglot
+import bigframes.core.compile as compile
 import bigframes.session.executor
 
 
@@ -24,7 +24,7 @@ import bigframes.session.executor
 class SQLCompilerExecutor(bigframes.session.executor.Executor):
     """Executor for SQL compilation using sqlglot."""
 
-    compiler = sqlglot
+    compiler = compile.sqlglot
 
     def to_sql(
         self,
@@ -38,9 +38,9 @@ class SQLCompilerExecutor(bigframes.session.executor.Executor):
 
         # Compared with BigQueryCachingExecutor, SQLCompilerExecutor skips
         # caching the subtree.
-        return self.compiler.SQLGlotCompiler().compile(
-            array_value.node, ordered=ordered
-        )
+        return self.compiler.compile_sql(
+            compile.CompileRequest(array_value.node, sort_rows=ordered)
+        ).sql
 
     def execute(
         self,

--- a/tests/unit/core/compile/sqlglot/test_compile_random_sample.py
+++ b/tests/unit/core/compile/sqlglot/test_compile_random_sample.py
@@ -16,7 +16,7 @@ import pytest
 
 from bigframes.core import nodes
 import bigframes.core as core
-import bigframes.core.compile.sqlglot as sqlglot
+import bigframes.core.compile as compile
 
 pytest.importorskip("pytest_snapshot")
 
@@ -31,5 +31,5 @@ def test_compile_random_sample(
     operation, this test constructs the node directly and then compiles it to SQL.
     """
     node = nodes.RandomSampleNode(scalar_types_array_value.node, fraction=0.1)
-    sql = sqlglot.compiler.SQLGlotCompiler().compile(node)
+    sql = compile.sqlglot.compile_sql(compile.CompileRequest(node, sort_rows=True)).sql
     snapshot.assert_match(sql, "out.sql")

--- a/tests/unit/session/test_io_bigquery.py
+++ b/tests/unit/session/test_io_bigquery.py
@@ -156,7 +156,6 @@ def test_create_job_configs_labels_length_limit_met():
         )
 
     assert labels is not None
-    assert len(labels) == 56
     assert "dataframe-max" in labels.values()
     assert "dataframe-head" not in labels.values()
     assert "bigframes-api" in labels.keys()


### PR DESCRIPTION
This change prepares to enable SQLGlot as the default compiler. Making compile_sql a top-level function makes it consistent with the existing Ibis API, which simplifies onboarding.