### PR TITLE
chore: librarian release pull request: 20251113T215818Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,8 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
 libraries:
   - id: bigframes
-    version: 2.28.0
+    version: 2.29.0
+    last_generated_commit: ""
     apis: []
     source_roots:
       - .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,35 @@
 
 [1]: https://pypi.org/project/bigframes/#history
 
+## [2.29.0](https://github.com/googleapis/google-cloud-python/compare/bigframes-v2.28.0...bigframes-v2.29.0) (2025-11-13)
+
+
+### Documentation
+
+* switch API reference docs to pydata theme (#2237) ([9b86dcf87929648bf5ab565dfd46a23b639f01ac](https://github.com/googleapis/google-cloud-python/commit/9b86dcf87929648bf5ab565dfd46a23b639f01ac))
+* update notebook for JSON subfields support in to_pandas_batches() (#2138) ([5663d2a18064589596558af109e915f87d426eb0](https://github.com/googleapis/google-cloud-python/commit/5663d2a18064589596558af109e915f87d426eb0))
+
+
+### Features
+
+* pivot_table supports fill_value arg (#2257) ([8f490e68a9a2584236486060ad3b55923781d975](https://github.com/googleapis/google-cloud-python/commit/8f490e68a9a2584236486060ad3b55923781d975))
+* Support mixed scalar-analytic expressions (#2239) ([20ab469d29767a2f04fe02aa66797893ecd1c539](https://github.com/googleapis/google-cloud-python/commit/20ab469d29767a2f04fe02aa66797893ecd1c539))
+* Support builtins funcs for df.agg (#2256) ([956a5b00dff55b73e3cbebb4e6e81672680f1f63](https://github.com/googleapis/google-cloud-python/commit/956a5b00dff55b73e3cbebb4e6e81672680f1f63))
+* Preserve source names better for more readable sql (#2243) ([64995d659837a8576b2ee9335921904e577c7014](https://github.com/googleapis/google-cloud-python/commit/64995d659837a8576b2ee9335921904e577c7014))
+* Add bigframes.pandas.crosstab (#2231) ([c62e5535ed4c19b6d65f9a46cb1531e8099621b2](https://github.com/googleapis/google-cloud-python/commit/c62e5535ed4c19b6d65f9a46cb1531e8099621b2))
+* SQL Cell no longer escapes formatted string values (#2245) ([d2d38f94ed8333eae6f9cff3833177756eefe85a](https://github.com/googleapis/google-cloud-python/commit/d2d38f94ed8333eae6f9cff3833177756eefe85a))
+* support left_index and right_index for merge (#2220) ([da9ba267812c01ffa6fa0b09943d7a4c63b8f187](https://github.com/googleapis/google-cloud-python/commit/da9ba267812c01ffa6fa0b09943d7a4c63b8f187))
+* add bigframes.bigquery.st_regionstats to join raster data from Earth Engine (#2228) ([10ec52f30a0a9c61b9eda9cf4f9bd6aa0cd95db5](https://github.com/googleapis/google-cloud-python/commit/10ec52f30a0a9c61b9eda9cf4f9bd6aa0cd95db5))
+* add DataFrame.resample and Series.resample (#2213) ([c9ca02c5194c8b8e9b940eddd2224efd2ff0d5d9](https://github.com/googleapis/google-cloud-python/commit/c9ca02c5194c8b8e9b940eddd2224efd2ff0d5d9))
+
+
+### Bug Fixes
+
+* do not warn with DefaultIndexWarning in partial ordering mode (#2230) ([cc2dbae684103a21fe8838468f7eb8267188780d](https://github.com/googleapis/google-cloud-python/commit/cc2dbae684103a21fe8838468f7eb8267188780d))
+* Correctly iterate over null struct values in ManagedArrowTable (#2209) ([12e04d55f0d6aef1297b7ca773935aecf3313ee7](https://github.com/googleapis/google-cloud-python/commit/12e04d55f0d6aef1297b7ca773935aecf3313ee7))
+* simplify UnsupportedTypeError message (#2212) ([6c9a18d7e67841c6fe6c1c6f34f80b950815141f](https://github.com/googleapis/google-cloud-python/commit/6c9a18d7e67841c6fe6c1c6f34f80b950815141f))
+* support results with STRUCT and ARRAY columns containing JSON subfields in `to_pandas_batches()` (#2216) ([3d8b17fa5eb9bbfc9e151031141a419f2dc3acb4](https://github.com/googleapis/google-cloud-python/commit/3d8b17fa5eb9bbfc9e151031141a419f2dc3acb4))
+
 ## [2.29.0](https://github.com/googleapis/python-bigquery-dataframes/compare/v2.28.0...v2.29.0) (2025-11-10)
 
 

--- a/bigframes/version.py
+++ b/bigframes/version.py
@@ -15,5 +15,5 @@
 __version__ = "2.29.0"
 
 # {x-release-please-start-date}
-__release_date__ = "2025-11-10"
+__release_date__ = "2025-11-13"
 # {x-release-please-end}

--- a/third_party/bigframes_vendored/version.py
+++ b/third_party/bigframes_vendored/version.py
@@ -15,5 +15,5 @@
 __version__ = "2.29.0"
 
 # {x-release-please-start-date}
-__release_date__ = "2025-11-10"
+__release_date__ = "2025-11-13"
 # {x-release-please-end}


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v1.0.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
<details><summary>bigframes: 2.29.0</summary>

## [2.29.0](https://github.com/googleapis/python-bigquery-dataframes/compare/v2.28.0...v2.29.0) (2025-11-13)

### Features

* add bigframes.bigquery.st_regionstats to join raster data from Earth Engine (#2228) ([10ec52f3](https://github.com/googleapis/python-bigquery-dataframes/commit/10ec52f3))

* Support mixed scalar-analytic expressions (#2239) ([20ab469d](https://github.com/googleapis/python-bigquery-dataframes/commit/20ab469d))

* Preserve source names better for more readable sql (#2243) ([64995d65](https://github.com/googleapis/python-bigquery-dataframes/commit/64995d65))

* pivot_table supports fill_value arg (#2257) ([8f490e68](https://github.com/googleapis/python-bigquery-dataframes/commit/8f490e68))

* Support builtins funcs for df.agg (#2256) ([956a5b00](https://github.com/googleapis/python-bigquery-dataframes/commit/956a5b00))

* Add bigframes.pandas.crosstab (#2231) ([c62e5535](https://github.com/googleapis/python-bigquery-dataframes/commit/c62e5535))

* add DataFrame.resample and Series.resample (#2213) ([c9ca02c5](https://github.com/googleapis/python-bigquery-dataframes/commit/c9ca02c5))

* SQL Cell no longer escapes formatted string values (#2245) ([d2d38f94](https://github.com/googleapis/python-bigquery-dataframes/commit/d2d38f94))

* support left_index and right_index for merge (#2220) ([da9ba267](https://github.com/googleapis/python-bigquery-dataframes/commit/da9ba267))

### Bug Fixes

* Correctly iterate over null struct values in ManagedArrowTable (#2209) ([12e04d55](https://github.com/googleapis/python-bigquery-dataframes/commit/12e04d55))

* support results with STRUCT and ARRAY columns containing JSON subfields in `to_pandas_batches()` (#2216) ([3d8b17fa](https://github.com/googleapis/python-bigquery-dataframes/commit/3d8b17fa))

* simplify UnsupportedTypeError message (#2212) ([6c9a18d7](https://github.com/googleapis/python-bigquery-dataframes/commit/6c9a18d7))

* do not warn with DefaultIndexWarning in partial ordering mode (#2230) ([cc2dbae6](https://github.com/googleapis/python-bigquery-dataframes/commit/cc2dbae6))

### Documentation

* update notebook for JSON subfields support in to_pandas_batches() (#2138) ([5663d2a1](https://github.com/googleapis/python-bigquery-dataframes/commit/5663d2a1))

* switch API reference docs to pydata theme (#2237) ([9b86dcf8](https://github.com/googleapis/python-bigquery-dataframes/commit/9b86dcf8))

</details>