### PR TITLE
fix: calling info() on empty dataframes no longer leads to errors

### DIFF
--- a/bigframes/dataframe.py
+++ b/bigframes/dataframe.py
@@ -521,9 +521,9 @@ class DataFrame(vendored_pandas_frame.DataFrame):
         if self._block.has_index:
             index_type = "MultiIndex" if self.index.nlevels > 1 else "Index"
 
-            # These accessses are kind of expensive, maybe should try to skip?
             index_stats = f"{n_rows} entries"
             if n_rows > 0:
+                # These accessses are kind of expensive, maybe should try to skip?
                 first_indice = self.index[0]
                 last_indice = self.index[-1]
                 index_stats += f", {first_indice} to {last_indice}"

--- a/bigframes/dataframe.py
+++ b/bigframes/dataframe.py
@@ -522,13 +522,19 @@ class DataFrame(vendored_pandas_frame.DataFrame):
             index_type = "MultiIndex" if self.index.nlevels > 1 else "Index"
 
             # These accessses are kind of expensive, maybe should try to skip?
-            first_indice = self.index[0]
-            last_indice = self.index[-1]
-            obuf.write(
-                f"{index_type}: {n_rows} entries, {first_indice} to {last_indice}\n"
-            )
+            index_stats = f"{n_rows} entries"
+            if n_rows > 0:
+                first_indice = self.index[0]
+                last_indice = self.index[-1]
+                index_stats += f", {first_indice} to {last_indice}"
+            obuf.write(f"{index_type}: {index_stats}\n")
         else:
             obuf.write("NullIndex\n")
+
+        if n_columns == 0:
+            # We don't display any more information if the dataframe has no columns
+            obuf.write("Empty DataFrame\n")
+            return
 
         dtype_strings = self.dtypes.astype("string")
         if show_all_columns:

--- a/tests/system/small/test_dataframe.py
+++ b/tests/system/small/test_dataframe.py
@@ -671,11 +671,57 @@ def test_df_info(scalars_dfs):
         "dtypes: Float64(1), Int64(3), binary[pyarrow](1), boolean(1), date32[day][pyarrow](1), decimal128(38, 9)[pyarrow](1), duration[us][pyarrow](1), geometry(1), string(1), time64[us][pyarrow](1), timestamp[us, tz=UTC][pyarrow](1), timestamp[us][pyarrow](1)\n"
         "memory usage: 1341 bytes\n"
     )
-
     scalars_df, _ = scalars_dfs
-    bf_result = io.StringIO()
 
+    bf_result = io.StringIO()
     scalars_df.info(buf=bf_result)
+
+    assert expected == bf_result.getvalue()
+
+
+def test_df_info_no_rows(session):
+    expected = (
+        "<class 'bigframes.dataframe.DataFrame'>\n"
+        "Index: 0 entries\n"
+        "Data columns (total 1 columns):\n"
+        "  #  Column    Non-Null Count    Dtype\n"
+        "---  --------  ----------------  -------\n"
+        "  0  col       0 non-null        Float64\n"
+        "dtypes: Float64(1)\n"
+        "memory usage: 0 bytes\n"
+    )
+    df = session.DataFrame({"col": []})
+
+    bf_result = io.StringIO()
+    df.info(buf=bf_result)
+
+    assert expected == bf_result.getvalue()
+
+
+def test_df_info_no_cols(session):
+    expected = (
+        "<class 'bigframes.dataframe.DataFrame'>\n"
+        "Index: 3 entries, 1 to 3\n"
+        "Empty DataFrame\n"
+    )
+    df = session.DataFrame({}, index=[1, 2, 3])
+
+    bf_result = io.StringIO()
+    df.info(buf=bf_result)
+
+    assert expected == bf_result.getvalue()
+
+
+def test_df_info_no_cols_no_rows(session):
+    expected = (
+        "<class 'bigframes.dataframe.DataFrame'>\n"
+        "Index: 0 entries\n"
+        "Empty DataFrame\n"
+    )
+    df = session.DataFrame({})
+
+    bf_result = io.StringIO()
+    df.info(buf=bf_result)
 
     assert expected == bf_result.getvalue()
 


### PR DESCRIPTION


Fixes #460154155 🦕
