### PR TITLE
deps: update dependency sqlglot to ">=25.20.0,<28"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ dependencies = [
     "requests >=2.27.1",
     "shapely >=1.8.5",
     # 25.20.0 introduces this fix https://github.com/TobikoData/sqlmesh/issues/3095 for rtrim/ltrim.
-    "sqlglot >=25.20.0",
+    "sqlglot >=25.20.0,<28",
     "tabulate >=0.9",
     "ipywidgets >=7.7.1",
     "humanize >=4.6.0",


### PR DESCRIPTION
With the new release of v28.0.0 of sqlglot, all generated SQL are missed CTE statements (WITH clauses) an causing presubmit failures. This change is locking sqlglot into older version until we figured out the root cause.