### PR TITLE
refactor: switch RowNumber to 0-based indexing in sqlglot compiler

### DIFF
--- a/bigframes/core/compile/sqlglot/aggregations/nullary_compiler.py
+++ b/bigframes/core/compile/sqlglot/aggregations/nullary_compiler.py
@@ -49,5 +49,5 @@ def _(
     result: sge.Expression = sge.func("ROW_NUMBER")
     if window is None:
         # ROW_NUMBER always needs an OVER clause.
-        return sge.Window(this=result)
-    return apply_window_if_present(result, window, include_framing_clauses=False)
+        return sge.Window(this=result) - 1
+    return apply_window_if_present(result, window, include_framing_clauses=False) - 1

--- a/tests/unit/core/compile/sqlglot/aggregations/snapshots/test_nullary_compiler/test_row_number/out.sql
+++ b/tests/unit/core/compile/sqlglot/aggregations/snapshots/test_nullary_compiler/test_row_number/out.sql
@@ -19,7 +19,7 @@ WITH `bfcte_0` AS (
 ), `bfcte_1` AS (
   SELECT
     *,
-    ROW_NUMBER() OVER () AS `bfcol_32`
+    ROW_NUMBER() OVER () - 1 AS `bfcol_32`
   FROM `bfcte_0`
 )
 SELECT

--- a/tests/unit/core/compile/sqlglot/aggregations/snapshots/test_nullary_compiler/test_row_number_with_window/out.sql
+++ b/tests/unit/core/compile/sqlglot/aggregations/snapshots/test_nullary_compiler/test_row_number_with_window/out.sql
@@ -5,7 +5,7 @@ WITH `bfcte_0` AS (
 ), `bfcte_1` AS (
   SELECT
     *,
-    ROW_NUMBER() OVER (ORDER BY `int64_col` ASC NULLS LAST) AS `bfcol_1`
+    ROW_NUMBER() OVER (ORDER BY `int64_col` ASC NULLS LAST) - 1 AS `bfcol_1`
   FROM `bfcte_0`
 )
 SELECT

--- a/tests/unit/core/compile/sqlglot/snapshots/test_compile_concat/test_compile_concat/out.sql
+++ b/tests/unit/core/compile/sqlglot/snapshots/test_compile_concat/test_compile_concat/out.sql
@@ -7,7 +7,7 @@ WITH `bfcte_1` AS (
 ), `bfcte_3` AS (
   SELECT
     *,
-    ROW_NUMBER() OVER () AS `bfcol_7`
+    ROW_NUMBER() OVER () - 1 AS `bfcol_7`
   FROM `bfcte_1`
 ), `bfcte_5` AS (
   SELECT
@@ -32,7 +32,7 @@ WITH `bfcte_1` AS (
 ), `bfcte_2` AS (
   SELECT
     *,
-    ROW_NUMBER() OVER () AS `bfcol_22`
+    ROW_NUMBER() OVER () - 1 AS `bfcol_22`
   FROM `bfcte_0`
 ), `bfcte_4` AS (
   SELECT

--- a/tests/unit/core/compile/sqlglot/snapshots/test_compile_concat/test_compile_concat_filter_sorted/out.sql
+++ b/tests/unit/core/compile/sqlglot/snapshots/test_compile_concat/test_compile_concat_filter_sorted/out.sql
@@ -6,7 +6,7 @@ WITH `bfcte_2` AS (
 ), `bfcte_6` AS (
   SELECT
     *,
-    ROW_NUMBER() OVER (ORDER BY `int64_col` ASC NULLS LAST) AS `bfcol_4`
+    ROW_NUMBER() OVER (ORDER BY `int64_col` ASC NULLS LAST) - 1 AS `bfcol_4`
   FROM `bfcte_2`
 ), `bfcte_10` AS (
   SELECT
@@ -35,7 +35,7 @@ WITH `bfcte_2` AS (
 ), `bfcte_8` AS (
   SELECT
     *,
-    ROW_NUMBER() OVER () AS `bfcol_15`
+    ROW_NUMBER() OVER () - 1 AS `bfcol_15`
   FROM `bfcte_4`
 ), `bfcte_12` AS (
   SELECT
@@ -57,7 +57,7 @@ WITH `bfcte_2` AS (
 ), `bfcte_5` AS (
   SELECT
     *,
-    ROW_NUMBER() OVER (ORDER BY `int64_col` ASC NULLS LAST) AS `bfcol_25`
+    ROW_NUMBER() OVER (ORDER BY `int64_col` ASC NULLS LAST) - 1 AS `bfcol_25`
   FROM `bfcte_1`
 ), `bfcte_9` AS (
   SELECT
@@ -86,7 +86,7 @@ WITH `bfcte_2` AS (
 ), `bfcte_7` AS (
   SELECT
     *,
-    ROW_NUMBER() OVER () AS `bfcol_36`
+    ROW_NUMBER() OVER () - 1 AS `bfcol_36`
   FROM `bfcte_3`
 ), `bfcte_11` AS (
   SELECT


### PR DESCRIPTION
This change aims to fix the tests failing in #2248 because of a 1-based indexing error. 

Fixes internal issue 417774347 🦕
