### PR TITLE
fix: Update max_instances default to reflect actual value

### DIFF
--- a/tests/system/large/functions/test_remote_function.py
+++ b/tests/system/large/functions/test_remote_function.py
@@ -1651,13 +1651,12 @@ def test_remote_function_gcf_timeout_max_supported_exceeded(session):
             return x * x
 
 
-# Note: Zero represents default, which is 100 instances actually, which is why the remote function still works
-# in the df.apply() call here
+# The default value of 100 is used if the maximum instances value is not set.
 @pytest.mark.parametrize(
     ("max_instances_args", "expected_max_instances"),
     [
-        pytest.param({}, 0, id="no-set"),
-        pytest.param({"cloud_function_max_instances": None}, 0, id="set-None"),
+        pytest.param({}, 100, id="no-set"),
+        pytest.param({"cloud_function_max_instances": None}, 100, id="set-None"),
         pytest.param({"cloud_function_max_instances": 1000}, 1000, id="set-explicit"),
     ],
 )


### PR DESCRIPTION
The default maximum instances for cloud functions is 100, not 0. Updated the `expected_max_instances` in the `parametrize` decorator to 100 for the 'no-set' and 'set-None' test cases to accurately reflect the runtime behavior.

Thank you for opening a Pull Request! Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [ ] Make sure to open an issue as a [bug/issue](https://github.com/googleapis/python-bigquery-dataframes/issues/new/choose) before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [ ] Ensure the tests and linter pass
- [ ] Code coverage does not decrease (if any source code was changed)
- [ ] Appropriate docs were updated (if necessary)

Fixes b/465212379 🦕
