### PR TITLE
Fix: Defer TableWidget import to prevent ZMQ port conflicts

### DIFF
--- a/bigframes/display/__init__.py
+++ b/bigframes/display/__init__.py
@@ -16,11 +16,24 @@
 
 from __future__ import annotations
 
-try:
-    import anywidget  # noqa
+from typing import Any
 
-    from bigframes.display.anywidget import TableWidget
 
-    __all__ = ["TableWidget"]
-except Exception:
-    pass
+def __getattr__(name: str) -> Any:
+    if name == "TableWidget":
+        try:
+            import anywidget  # noqa
+
+            from bigframes.display.anywidget import TableWidget
+
+            return TableWidget
+        except Exception:
+            raise AttributeError(
+                f"module '{__name__}' has no attribute '{name}'. "
+                "TableWidget requires anywidget and traitlets to be installed. "
+                "Please `pip install anywidget traitlets` or `pip install 'bigframes[anywidget]'`."
+            )
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+__all__ = ["TableWidget"]

--- a/bigframes/display/__init__.py
+++ b/bigframes/display/__init__.py
@@ -20,6 +20,15 @@ from typing import Any
 
 
 def __getattr__(name: str) -> Any:
+    """Lazily import TableWidget to avoid ZMQ port conflicts.
+
+    anywidget and traitlets eagerly initialize kernel communication channels on
+    import. This can lead to race conditions and ZMQ port conflicts when
+    multiple Jupyter kernels are started in parallel, such as during notebook
+    tests. By using __getattr__, we defer the import of TableWidget until it is
+    explicitly accessed, preventing premature initialization and avoiding port
+    collisions.
+    """
     if name == "TableWidget":
         try:
             import anywidget  # noqa


### PR DESCRIPTION
This PR addresses a flaky ZMQError: Address already in use that occasionally occurred during parallel notebook test execution.

  **Problem:**
  The bigframes.display module eagerly imported anywidget and traitlets at module load time (`bigframes/display/__init__.py`). This meant that when multiple Jupyter kernels were spun up simultaneously by nox for parallel testing, they would all try to initialize traitlets.HasTraits objects with sync=True properties. This led to race conditions and ZMQ port conflicts, causing notebook tests (including those that did not directly use anywidget like `streaming_dataframe.ipynb`) to fail. Log is [here](https://fusion2.corp.google.com/invocations/72088900-0196-4441-944b-ad68e491a8f8/targets/bigframes%2Fpresubmit%2Fnotebook/log).

  **Solution:**
  The TableWidget class import in `bigframes/display/__init__.py` has been refactored to use Python's `__getattr__` for lazy loading. This ensures that anywidget and traitlets are only imported and their associated kernel communication channels are initialized when display.TableWidget is actually accessed by the code. This prevents premature initialization and eliminates the port collision race condition during parallel test startup.

Fixes #<465768150> 🦕
