### PR TITLE
chore: librarian release pull request: 20251210T234907Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
 libraries:
   - id: bigframes
-    version: 2.30.0
+    version: 2.31.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@
 
 [1]: https://pypi.org/project/bigframes/#history
 
+## [2.31.0](https://github.com/googleapis/google-cloud-python/compare/bigframes-v2.30.0...bigframes-v2.31.0) (2025-12-10)
+
+
+### Features
+
+* add `bigframes.bigquery.ml` methods (#2300) ([719b278c844ca80c1bec741873b30a9ee4fd6c56](https://github.com/googleapis/google-cloud-python/commit/719b278c844ca80c1bec741873b30a9ee4fd6c56))
+* add 'weekday' property to DatatimeMethod (#2304) ([fafd7c732d434eca3f8b5d849a87149f106e3d5d](https://github.com/googleapis/google-cloud-python/commit/fafd7c732d434eca3f8b5d849a87149f106e3d5d))
+
+
+### Bug Fixes
+
+* cache DataFrames to temp tables in bigframes.bigquery.ml methods to avoid time travel (#2318) ([d99383195ac3f1683842cfe472cca5a914b04d8e](https://github.com/googleapis/google-cloud-python/commit/d99383195ac3f1683842cfe472cca5a914b04d8e))
+
 ## [2.30.0](https://github.com/googleapis/google-cloud-python/compare/bigframes-v2.29.0...bigframes-v2.30.0) (2025-12-03)
 
 

--- a/bigframes/version.py
+++ b/bigframes/version.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.30.0"
+__version__ = "2.31.0"
 
 # {x-release-please-start-date}
-__release_date__ = "2025-12-03"
+__release_date__ = "2025-12-10"
 # {x-release-please-end}

--- a/third_party/bigframes_vendored/version.py
+++ b/third_party/bigframes_vendored/version.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.30.0"
+__version__ = "2.31.0"
 
 # {x-release-please-start-date}
-__release_date__ = "2025-12-03"
+__release_date__ = "2025-12-10"
 # {x-release-please-end}


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
<details><summary>bigframes: 2.31.0</summary>

## [2.31.0](https://github.com/googleapis/python-bigquery-dataframes/compare/v2.30.0...v2.31.0) (2025-12-10)

### Features

* add `bigframes.bigquery.ml` methods (#2300) ([719b278c](https://github.com/googleapis/python-bigquery-dataframes/commit/719b278c))

* add &#39;weekday&#39; property to DatatimeMethod (#2304) ([fafd7c73](https://github.com/googleapis/python-bigquery-dataframes/commit/fafd7c73))

### Bug Fixes

* cache DataFrames to temp tables in bigframes.bigquery.ml methods to avoid time travel (#2318) ([d9938319](https://github.com/googleapis/python-bigquery-dataframes/commit/d9938319))

### Reverts

* DataFrame display uses IPython&#39;s `_repr_mimebundle_` (#2316) ([e4e3ec85](https://github.com/googleapis/python-bigquery-dataframes/commit/e4e3ec85))

</details>