### PR TITLE
tests: fix `test_get_formatted_time` from the `humanize` package upgrade

### DIFF
--- a/tests/unit/test_formatting_helpers.py
+++ b/tests/unit/test_formatting_helpers.py
@@ -67,7 +67,7 @@ def test_get_formatted_bytes(test_input, expected):
 
 
 @pytest.mark.parametrize(
-    "test_input, expected", [(None, None), ("string", "string"), (100000, "a minute")]
+    "test_input, expected", [(None, None), ("string", "string"), (66000, "a minute")]
 )
 def test_get_formatted_time(test_input, expected):
     assert formatting_helpers.get_formatted_time(test_input) == expected


### PR DESCRIPTION
This change can fix the `test_get_formatted_time` to avoid the inconsistent results from the `humanize` package upgrade. Please refer to the internal screenshot for details: screenshot/BcJFk78xtYtLnyo
