### PR TITLE
feat: Stabilize interactive table height to prevent notebook layout shifts

### DIFF
--- a/bigframes/display/table_widget.css
+++ b/bigframes/display/table_widget.css
@@ -81,7 +81,7 @@ body[data-theme='dark'] .bigframes-widget.bigframes-widget {
 .bigframes-widget .table-container {
   background-color: var(--bf-bg);
   margin: 0;
-  height: 400px;
+  max-height: 620px;
   overflow: auto;
   padding: 0;
 }

--- a/bigframes/display/table_widget.css
+++ b/bigframes/display/table_widget.css
@@ -81,7 +81,7 @@ body[data-theme='dark'] .bigframes-widget.bigframes-widget {
 .bigframes-widget .table-container {
   background-color: var(--bf-bg);
   margin: 0;
-  max-height: 620px;
+  height: 400px;
   overflow: auto;
   padding: 0;
 }

--- a/bigframes/display/table_widget.js
+++ b/bigframes/display/table_widget.js
@@ -170,8 +170,26 @@ function render({ model, el }) {
     model.save_changes();
   }
 
+  let isHeightInitialized = false;
+
   function handleTableHTMLChange() {
     tableContainer.innerHTML = model.get(ModelProperty.TABLE_HTML);
+
+    // After the first render, dynamically set the container height to fit the
+    // initial page (usually 10 rows) and then lock it.
+    setTimeout(() => {
+      if (!isHeightInitialized) {
+        const table = tableContainer.querySelector('table');
+        if (table) {
+          const tableHeight = table.offsetHeight;
+          // Add a small buffer(e.g. 2px) for borders to avoid scrollbars.
+          if (tableHeight > 0) {
+            tableContainer.style.height = `${tableHeight + 2}px`;
+            isHeightInitialized = true;
+          }
+        }
+      }
+    }, 0);
 
     const sortableColumns = model.get(ModelProperty.ORDERABLE_COLUMNS);
     const currentSortContext = model.get(ModelProperty.SORT_CONTEXT) || [];

--- a/notebooks/dataframes/anywidget_mode.ipynb
+++ b/notebooks/dataframes/anywidget_mode.ipynb
@@ -120,16 +120,16 @@
      "output_type": "stream",
      "text": [
       "state gender  year     name  number\n",
-      "   AL      F  1910    Sadie      40\n",
-      "   AL      F  1910     Mary     875\n",
-      "   AR      F  1910     Vera      39\n",
-      "   AR      F  1910    Marie      78\n",
-      "   AR      F  1910  Lucille      66\n",
-      "   CA      F  1910 Virginia     101\n",
-      "   DC      F  1910 Margaret      72\n",
-      "   GA      F  1910  Mildred     133\n",
-      "   GA      F  1910     Vera      51\n",
-      "   GA      F  1910   Sallie      92\n",
+      "   AL      F  1910    Annie     482\n",
+      "   AL      F  1910   Myrtle     104\n",
+      "   AR      F  1910  Lillian      56\n",
+      "   CT      F  1910     Anne      38\n",
+      "   CT      F  1910  Frances      45\n",
+      "   FL      F  1910 Margaret      53\n",
+      "   GA      F  1910      Mae      73\n",
+      "   GA      F  1910 Beatrice      96\n",
+      "   GA      F  1910     Lola      47\n",
+      "   IA      F  1910    Viola      49\n",
       "...\n",
       "\n",
       "[5552452 rows x 5 columns]\n"
@@ -143,14 +143,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "220340b0",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "✅ Completed. "
+       "\n",
+       "    Query started with request ID bigframes-dev:US.161c75bd-f9f8-4b21-8a45-1d7dfc659034.<details><summary>SQL</summary><pre>SELECT\n",
+       "`state` AS `state`,\n",
+       "`gender` AS `gender`,\n",
+       "`year` AS `year`,\n",
+       "`name` AS `name`,\n",
+       "`number` AS `number`\n",
+       "FROM\n",
+       "(SELECT\n",
+       "  `t0`.`state`,\n",
+       "  `t0`.`gender`,\n",
+       "  `t0`.`year`,\n",
+       "  `t0`.`name`,\n",
+       "  `t0`.`number`,\n",
+       "  `t0`.`bfuid_col_2` AS `bfuid_col_15`\n",
+       "FROM `bigframes-dev._8b037bfb7316dddf9d92b12dcf93e008906bfe52._c58be946_1477_4c00_b699_0ae022f13563_bqdf_8e323719-899f-4da2-89cd-2dbb53ab1dfc` AS `t0`)\n",
+       "ORDER BY `bfuid_col_15` ASC NULLS LAST</pre></details>\n",
+       "    "
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -162,7 +179,9 @@
     {
      "data": {
       "text/html": [
-       "✅ Completed. "
+       "✅ Completed. \n",
+       "    Query processed 215.9 MB in 7 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud. google.com/bigquery?project=bigframes-dev&j=bq:US:job_IuiJsjhfPtOrKuTIOqPIjnVLX820&page=queryresults\">Job bigframes-dev:US.job_IuiJsjhfPtOrKuTIOqPIjnVLX820 details</a>]\n",
+       "    "
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -174,7 +193,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a5c2a45c5cc044b59656a2f6b71f710f",
+       "model_id": "e68fbb9eb4d24bab837c77730d31c8a1",
        "version_major": 2,
        "version_minor": 1
       },
@@ -210,80 +229,80 @@
        "      <td>AL</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Vera</td>\n",
-       "      <td>71</td>\n",
+       "      <td>Hazel</td>\n",
+       "      <td>51</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>AR</td>\n",
+       "      <td>AL</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Viola</td>\n",
-       "      <td>37</td>\n",
+       "      <td>Lucy</td>\n",
+       "      <td>76</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>AR</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Alice</td>\n",
-       "      <td>57</td>\n",
+       "      <td>Nellie</td>\n",
+       "      <td>39</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>AR</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Edna</td>\n",
-       "      <td>95</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>AR</td>\n",
-       "      <td>F</td>\n",
-       "      <td>1910</td>\n",
-       "      <td>Ollie</td>\n",
+       "      <td>Lena</td>\n",
        "      <td>40</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>CA</td>\n",
+       "      <th>4</th>\n",
+       "      <td>CO</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Beatrice</td>\n",
-       "      <td>37</td>\n",
+       "      <td>Thelma</td>\n",
+       "      <td>36</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>CO</td>\n",
+       "      <td>F</td>\n",
+       "      <td>1910</td>\n",
+       "      <td>Ruth</td>\n",
+       "      <td>68</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
        "      <td>CT</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Marion</td>\n",
-       "      <td>36</td>\n",
+       "      <td>Elizabeth</td>\n",
+       "      <td>86</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
-       "      <td>CT</td>\n",
+       "      <td>DC</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Marie</td>\n",
-       "      <td>36</td>\n",
+       "      <td>Mary</td>\n",
+       "      <td>80</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
        "      <td>FL</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Alice</td>\n",
-       "      <td>53</td>\n",
+       "      <td>Annie</td>\n",
+       "      <td>101</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
-       "      <td>GA</td>\n",
+       "      <td>FL</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Thelma</td>\n",
-       "      <td>133</td>\n",
+       "      <td>Alma</td>\n",
+       "      <td>39</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -291,25 +310,67 @@
        "</div>[5552452 rows x 5 columns in total]"
       ],
       "text/plain": [
-       "state gender  year     name  number\n",
-       "   AL      F  1910     Vera      71\n",
-       "   AR      F  1910    Viola      37\n",
-       "   AR      F  1910    Alice      57\n",
-       "   AR      F  1910     Edna      95\n",
-       "   AR      F  1910    Ollie      40\n",
-       "   CA      F  1910 Beatrice      37\n",
-       "   CT      F  1910   Marion      36\n",
-       "   CT      F  1910    Marie      36\n",
-       "   FL      F  1910    Alice      53\n",
-       "   GA      F  1910   Thelma     133\n",
+       "state gender  year      name  number\n",
+       "   AL      F  1910     Hazel      51\n",
+       "   AL      F  1910      Lucy      76\n",
+       "   AR      F  1910    Nellie      39\n",
+       "   AR      F  1910      Lena      40\n",
+       "   CO      F  1910    Thelma      36\n",
+       "   CO      F  1910      Ruth      68\n",
+       "   CT      F  1910 Elizabeth      86\n",
+       "   DC      F  1910      Mary      80\n",
+       "   FL      F  1910     Annie     101\n",
+       "   FL      F  1910      Alma      39\n",
        "...\n",
        "\n",
        "[5552452 rows x 5 columns]"
       ]
      },
-     "execution_count": 5,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "text/html": [
+       "✅ Completed. \n",
+       "    Query processed 215.9 MB in 9 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud. google.com/bigquery?project=bigframes-dev&j=bq:US:job_IEjIRaqt2w-_pAttPw1VAVuRPxA7&page=queryresults\">Job bigframes-dev:US.job_IEjIRaqt2w-_pAttPw1VAVuRPxA7 details</a>]\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "✅ Completed. \n",
+       "    Query processed 215.9 MB in 5 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud. google.com/bigquery?project=bigframes-dev&j=bq:US:job_Mi-3m2AkEC1iPgWi7hmcWa1M1oIA&page=queryresults\">Job bigframes-dev:US.job_Mi-3m2AkEC1iPgWi7hmcWa1M1oIA details</a>]\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "✅ Completed. \n",
+       "    Query processed 215.9 MB in 6 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud. google.com/bigquery?project=bigframes-dev&j=bq:US:job_j8pvY385WwIY7tGvhI7Yxc62aBwd&page=queryresults\">Job bigframes-dev:US.job_j8pvY385WwIY7tGvhI7Yxc62aBwd details</a>]\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [
@@ -327,14 +388,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "42bb02ab",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "✅ Completed. "
+       "✅ Completed. \n",
+       "    Query processed 171.4 MB in 30 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud. google.com/bigquery?project=bigframes-dev&j=bq:US:ff90d507-bec8-4d24-abc3-0209ac28e21f&page=queryresults\">Job bigframes-dev:US.ff90d507-bec8-4d24-abc3-0209ac28e21f details</a>]\n",
+       "    "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "✅ Completed. \n",
+       "    Query processed 88.8 MB in a moment of slot time.\n",
+       "    "
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -356,44 +433,24 @@
      "output_type": "display_data"
     },
     {
-     "data": {
-      "application/vnd.jupyter.widget-view+json": {
-       "model_id": "004beca7d4034b498add8f9edd55027b",
-       "version_major": 2,
-       "version_minor": 1
-      },
-      "text/html": [
-       "<pre>0    1910\n",
-       "1    1910\n",
-       "2    1910\n",
-       "3    1910\n",
-       "4    1910\n",
-       "5    1910\n",
-       "6    1910\n",
-       "7    1910\n",
-       "8    1910\n",
-       "9    1910</pre><p>[5552452 rows]</p>"
-      ],
-      "text/plain": [
-       "1910\n",
-       "1910\n",
-       "1910\n",
-       "1910\n",
-       "1910\n",
-       "1910\n",
-       "1910\n",
-       "1910\n",
-       "1910\n",
-       "1910\n",
-       "Name: year, dtype: Int64\n",
-       "...\n",
-       "\n",
-       "[5552452 rows]"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1910\n",
+      "1910\n",
+      "1910\n",
+      "1910\n",
+      "1910\n",
+      "1910\n",
+      "1910\n",
+      "1910\n",
+      "1910\n",
+      "1910\n",
+      "Name: year, dtype: Int64\n",
+      "...\n",
+      "\n",
+      "[5552452 rows]\n"
+     ]
     }
    ],
    "source": [
@@ -419,7 +476,9 @@
     {
      "data": {
       "text/html": [
-       "✅ Completed. "
+       "✅ Completed. \n",
+       "    Query processed 88.8 MB in 3 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud. google.com/bigquery?project=bigframes-dev&j=bq:US:job_517TdI--FMoURkV7QQNMltY_-dZ7&page=queryresults\">Job bigframes-dev:US.job_517TdI--FMoURkV7QQNMltY_-dZ7 details</a>]\n",
+       "    "
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -431,7 +490,9 @@
     {
      "data": {
       "text/html": [
-       "✅ Completed. "
+       "✅ Completed. \n",
+       "    Query processed 88.8 MB in 2 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud. google.com/bigquery?project=bigframes-dev&j=bq:US:job_rCeYkeBPqmTKNFWFgwXjz5Ed8uWI&page=queryresults\">Job bigframes-dev:US.job_rCeYkeBPqmTKNFWFgwXjz5Ed8uWI details</a>]\n",
+       "    "
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -443,7 +504,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "1251df51c4ba44d0b93af07917888511",
+       "model_id": "3e630b1a56c740e781772ca5f5c7267a",
        "version_major": 2,
        "version_minor": 1
       },
@@ -544,7 +605,9 @@
     {
      "data": {
       "text/html": [
-       "✅ Completed. "
+       "✅ Completed. \n",
+       "    Query processed 215.9 MB in 11 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud. google.com/bigquery?project=bigframes-dev&j=bq:US:job_XwXTDb6gWVkuyIFMeWA0waE33bSg&page=queryresults\">Job bigframes-dev:US.job_XwXTDb6gWVkuyIFMeWA0waE33bSg details</a>]\n",
+       "    "
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -556,7 +619,9 @@
     {
      "data": {
       "text/html": [
-       "✅ Completed. "
+       "✅ Completed. \n",
+       "    Query processed 215.9 MB in 7 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud. google.com/bigquery?project=bigframes-dev&j=bq:US:job_bCW0LYK5_PzyyGPf9OAg4YfNMG1C&page=queryresults\">Job bigframes-dev:US.job_bCW0LYK5_PzyyGPf9OAg4YfNMG1C details</a>]\n",
+       "    "
       ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
@@ -575,12 +640,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "45a462a3a42a445bb06d89132b7d0331",
+       "model_id": "a6a2b19314b04283a5a66ca9d66eb771",
        "version_major": 2,
        "version_minor": 1
       },
       "text/plain": [
-       "<bigframes.display.anywidget.TableWidget object at 0x7f2660d67100>"
+       "<bigframes.display.anywidget.TableWidget object at 0x7f7170161810>"
       ]
      },
      "execution_count": 8,
@@ -655,27 +720,8 @@
     {
      "data": {
       "text/html": [
-       "\n",
-       "    Query started with request ID bigframes-dev:US.a9f6b054-3709-49d6-8109-c325ffe07679.<details><summary>SQL</summary><pre>SELECT\n",
-       "`state` AS `state`,\n",
-       "`gender` AS `gender`,\n",
-       "`year` AS `year`,\n",
-       "`name` AS `name`,\n",
-       "`number` AS `number`\n",
-       "FROM\n",
-       "(SELECT\n",
-       "  *\n",
-       "FROM (\n",
-       "  SELECT\n",
-       "    `state`,\n",
-       "    `gender`,\n",
-       "    `year`,\n",
-       "    `name`,\n",
-       "    `number`\n",
-       "  FROM `bigquery-public-data.usa_names.usa_1910_2013` FOR SYSTEM_TIME AS OF TIMESTAMP(&#x27;2025-12-29T22:47:29.748716+00:00&#x27;)\n",
-       ") AS `t0`)\n",
-       "ORDER BY `name` ASC NULLS LAST ,`year` ASC NULLS LAST ,`state` ASC NULLS LAST\n",
-       "LIMIT 5</pre></details>\n",
+       "✅ Completed. \n",
+       "    Query processed 215.9 MB in a moment of slot time.\n",
        "    "
       ],
       "text/plain": [
@@ -689,7 +735,7 @@
      "data": {
       "text/html": [
        "✅ Completed. \n",
-       "    Query processed 0 Bytes in a moment of slot time.\n",
+       "    Query processed 215.9 MB in a moment of slot time.\n",
        "    "
       ],
       "text/plain": [
@@ -709,12 +755,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "219f91f2341d42b8b96da795a79fc3e8",
+       "model_id": "beb362548a6b4fd4a163569edd6f1a90",
        "version_major": 2,
        "version_minor": 1
       },
       "text/plain": [
-       "<bigframes.display.anywidget.TableWidget object at 0x7f2660d676f0>"
+       "<bigframes.display.anywidget.TableWidget object at 0x7f7171287e10>"
       ]
      },
      "execution_count": 10,
@@ -750,24 +796,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "added-cell-1",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "\n",
-       "    Query started with request ID bigframes-dev:US.8819b8bd-6697-4c65-a8bc-c7a95a06fe8e.<details><summary>SQL</summary><pre>\n",
-       "  SELECT\n",
-       "    AI.GENERATE(\n",
-       "      prompt=&gt;(&quot;Extract the values.&quot;, OBJ.GET_ACCESS_URL(OBJ.FETCH_METADATA(OBJ.MAKE_REF(gcs_path, &quot;us.conn&quot;)), &quot;r&quot;)),\n",
-       "      connection_id=&gt;&quot;bigframes-dev.us.bigframes-default-connection&quot;,\n",
-       "      output_schema=&gt;&quot;publication_date string, class_international string, application_number string, filing_date string&quot;) AS result,\n",
-       "    *\n",
-       "  FROM `bigquery-public-data.labeled_patents.extracted_data`\n",
-       "  LIMIT 5;\n",
-       "</pre></details>\n",
+       "✅ Completed. \n",
+       "    Query processed 85.9 kB in 19 seconds of slot time.\n",
        "    "
       ],
       "text/plain": [
@@ -776,6 +813,243 @@
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/google/home/shuowei/src/python-bigquery-dataframes/bigframes/dtypes.py:987: JSONDtypeWarning: JSON columns will be represented as pandas.ArrowDtype(pyarrow.json_())\n",
+      "instead of using `db_dtypes` in the future when available in pandas\n",
+      "(https://github.com/pandas-dev/pandas/issues/60958) and pyarrow.\n",
+      "  warnings.warn(msg, bigframes.exceptions.JSONDtypeWarning)\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "✅ Completed. "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/html": [
+       "✅ Completed. "
+      ],
+      "text/plain": [
+       "<IPython.core.display.HTML object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/google/home/shuowei/src/python-bigquery-dataframes/bigframes/dtypes.py:987: JSONDtypeWarning: JSON columns will be represented as pandas.ArrowDtype(pyarrow.json_())\n",
+      "instead of using `db_dtypes` in the future when available in pandas\n",
+      "(https://github.com/pandas-dev/pandas/issues/60958) and pyarrow.\n",
+      "  warnings.warn(msg, bigframes.exceptions.JSONDtypeWarning)\n",
+      "/usr/local/google/home/shuowei/src/python-bigquery-dataframes/bigframes/dtypes.py:987: JSONDtypeWarning: JSON columns will be represented as pandas.ArrowDtype(pyarrow.json_())\n",
+      "instead of using `db_dtypes` in the future when available in pandas\n",
+      "(https://github.com/pandas-dev/pandas/issues/60958) and pyarrow.\n",
+      "  warnings.warn(msg, bigframes.exceptions.JSONDtypeWarning)\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "02a46cf499b442d4bfe03934195e67df",
+       "version_major": 2,
+       "version_minor": 1
+      },
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>result</th>\n",
+       "      <th>gcs_path</th>\n",
+       "      <th>issuer</th>\n",
+       "      <th>language</th>\n",
+       "      <th>publication_date</th>\n",
+       "      <th>class_international</th>\n",
+       "      <th>class_us</th>\n",
+       "      <th>application_number</th>\n",
+       "      <th>filing_date</th>\n",
+       "      <th>priority_date_eu</th>\n",
+       "      <th>representative_line_1_eu</th>\n",
+       "      <th>applicant_line_1</th>\n",
+       "      <th>inventor_line_1</th>\n",
+       "      <th>title_line_1</th>\n",
+       "      <th>number</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>{'application_number': None, 'class_internatio...</td>\n",
+       "      <td>gs://gcs-public-data--labeled-patents/espacene...</td>\n",
+       "      <td>EU</td>\n",
+       "      <td>DE</td>\n",
+       "      <td>03.10.2018</td>\n",
+       "      <td>H01L 21/20</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>18166536.5</td>\n",
+       "      <td>16.02.2016</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>Scheider, Sascha et al</td>\n",
+       "      <td>EV Group E. Thallner GmbH</td>\n",
+       "      <td>Kurz, Florian</td>\n",
+       "      <td>VORRICHTUNG ZUM BONDEN VON SUBSTRATEN</td>\n",
+       "      <td>EP 3 382 744 A1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>{'application_number': None, 'class_internatio...</td>\n",
+       "      <td>gs://gcs-public-data--labeled-patents/espacene...</td>\n",
+       "      <td>EU</td>\n",
+       "      <td>DE</td>\n",
+       "      <td>03.10.2018</td>\n",
+       "      <td>A01K 31/00</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>18171005.4</td>\n",
+       "      <td>05.02.2015</td>\n",
+       "      <td>05.02.2014</td>\n",
+       "      <td>Stork Bamberger Patentanw√§lte</td>\n",
+       "      <td>Linco Food Systems A/S</td>\n",
+       "      <td>Thrane, Uffe</td>\n",
+       "      <td>MASTH√ÑHNCHENCONTAINER ALS BESTANDTEIL EINER E...</td>\n",
+       "      <td>EP 3 381 276 A1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>{'application_number': None, 'class_internatio...</td>\n",
+       "      <td>gs://gcs-public-data--labeled-patents/espacene...</td>\n",
+       "      <td>EU</td>\n",
+       "      <td>DE</td>\n",
+       "      <td>03.10.2018</td>\n",
+       "      <td>G06F 11/30</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>18157347.8</td>\n",
+       "      <td>19.02.2018</td>\n",
+       "      <td>31.03.2017</td>\n",
+       "      <td>Hoffmann Eitle</td>\n",
+       "      <td>FUJITSU LIMITED</td>\n",
+       "      <td>Kukihara, Kensuke</td>\n",
+       "      <td>METHOD EXECUTED BY A COMPUTER, INFORMATION PRO...</td>\n",
+       "      <td>EP 3 382 553 A1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>{'application_number': None, 'class_internatio...</td>\n",
+       "      <td>gs://gcs-public-data--labeled-patents/espacene...</td>\n",
+       "      <td>EU</td>\n",
+       "      <td>DE</td>\n",
+       "      <td>03.10.2018</td>\n",
+       "      <td>H05B 6/12</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>18165514.3</td>\n",
+       "      <td>03.04.2018</td>\n",
+       "      <td>30.03.2017</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>BSH Hausger√§te GmbH</td>\n",
+       "      <td>Acero Acero, Jesus</td>\n",
+       "      <td>VORRICHTUNG ZUR INDUKTIVEN ENERGIE√úBERTRAGUNG</td>\n",
+       "      <td>EP 3 383 141 A2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>{'application_number': None, 'class_internatio...</td>\n",
+       "      <td>gs://gcs-public-data--labeled-patents/espacene...</td>\n",
+       "      <td>EU</td>\n",
+       "      <td>DE</td>\n",
+       "      <td>29.08.018</td>\n",
+       "      <td>E04H 6/12</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>18157874.1</td>\n",
+       "      <td>21.02.2018</td>\n",
+       "      <td>22.02.2017</td>\n",
+       "      <td>Liedtke &amp; Partner Patentanw√§lte</td>\n",
+       "      <td>SHB Hebezeugbau GmbH</td>\n",
+       "      <td>VOLGER, Alexander</td>\n",
+       "      <td>STEUERUNGSSYSTEM F√úR AUTOMATISCHE PARKH√ÑUSER</td>\n",
+       "      <td>EP 3 366 869 A1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>5 rows × 15 columns</p>\n",
+       "</div>[5 rows x 15 columns in total]"
+      ],
+      "text/plain": [
+       "                                              result  \\\n",
+       "0  {'application_number': None, 'class_internatio...   \n",
+       "1  {'application_number': None, 'class_internatio...   \n",
+       "2  {'application_number': None, 'class_internatio...   \n",
+       "3  {'application_number': None, 'class_internatio...   \n",
+       "4  {'application_number': None, 'class_internatio...   \n",
+       "\n",
+       "                                            gcs_path issuer language  \\\n",
+       "0  gs://gcs-public-data--labeled-patents/espacene...     EU       DE   \n",
+       "1  gs://gcs-public-data--labeled-patents/espacene...     EU       DE   \n",
+       "2  gs://gcs-public-data--labeled-patents/espacene...     EU       DE   \n",
+       "3  gs://gcs-public-data--labeled-patents/espacene...     EU       DE   \n",
+       "4  gs://gcs-public-data--labeled-patents/espacene...     EU       DE   \n",
+       "\n",
+       "  publication_date class_international class_us application_number  \\\n",
+       "0       03.10.2018          H01L 21/20     <NA>         18166536.5   \n",
+       "1       03.10.2018          A01K 31/00     <NA>         18171005.4   \n",
+       "2       03.10.2018          G06F 11/30     <NA>         18157347.8   \n",
+       "3       03.10.2018           H05B 6/12     <NA>         18165514.3   \n",
+       "4        29.08.018           E04H 6/12     <NA>         18157874.1   \n",
+       "\n",
+       "  filing_date priority_date_eu          representative_line_1_eu  \\\n",
+       "0  16.02.2016             <NA>            Scheider, Sascha et al   \n",
+       "1  05.02.2015       05.02.2014    Stork Bamberger Patentanw√§lte   \n",
+       "2  19.02.2018       31.03.2017                    Hoffmann Eitle   \n",
+       "3  03.04.2018       30.03.2017                              <NA>   \n",
+       "4  21.02.2018       22.02.2017  Liedtke & Partner Patentanw√§lte   \n",
+       "\n",
+       "            applicant_line_1     inventor_line_1  \\\n",
+       "0  EV Group E. Thallner GmbH       Kurz, Florian   \n",
+       "1     Linco Food Systems A/S        Thrane, Uffe   \n",
+       "2            FUJITSU LIMITED   Kukihara, Kensuke   \n",
+       "3       BSH Hausger√§te GmbH  Acero Acero, Jesus   \n",
+       "4       SHB Hebezeugbau GmbH   VOLGER, Alexander   \n",
+       "\n",
+       "                                        title_line_1           number  \n",
+       "0              VORRICHTUNG ZUM BONDEN VON SUBSTRATEN  EP 3 382 744 A1  \n",
+       "1  MASTH√ÑHNCHENCONTAINER ALS BESTANDTEIL EINER E...  EP 3 381 276 A1  \n",
+       "2  METHOD EXECUTED BY A COMPUTER, INFORMATION PRO...  EP 3 382 553 A1  \n",
+       "3     VORRICHTUNG ZUR INDUKTIVEN ENERGIE√úBERTRAGUNG  EP 3 383 141 A2  \n",
+       "4     STEUERUNGSSYSTEM F√úR AUTOMATISCHE PARKH√ÑUSER  EP 3 366 869 A1  \n",
+       "\n",
+       "[5 rows x 15 columns]"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [

--- a/tests/js/table_widget.test.js
+++ b/tests/js/table_widget.test.js
@@ -340,6 +340,33 @@ describe('TableWidget', () => {
    * Tests that the widget correctly renders HTML with truncated columns (ellipsis)
    * and ensures that the ellipsis column is not treated as a sortable column.
    */
+  it('should have a fixed height for the table container', () => {
+    // Mock the initial state
+    model.get.mockImplementation((property) => {
+      if (property === 'table_html') {
+        return '<table>...</table>';
+      }
+      return null;
+    });
+
+    // Load the CSS
+    const fs = require('fs');
+    const path = require('path');
+    const css = fs.readFileSync(
+      path.resolve(__dirname, '../../bigframes/display/table_widget.css'),
+      'utf8',
+    );
+    const style = document.createElement('style');
+    style.textContent = css;
+    document.head.appendChild(style);
+
+    render({ model, el });
+
+    const tableContainer = el.querySelector('.table-container');
+    const styles = window.getComputedStyle(tableContainer);
+    expect(styles.height).toBe('400px');
+  });
+
   it('should render truncated columns with ellipsis and not make ellipsis sortable', () => {
     // Mock HTML with truncated columns
     // Use the structure produced by the python backend


### PR DESCRIPTION
 This update introduces a new feature in the interactive table display that prevents notebook layout shifts when changing the number of rows per page. The table height is now intelligently set and fixed after its initial display, creating a more stable and predictable user experience.

Verified at:
vs code notebook: https://screencast.googleplex.com/cast/NTY2NjM1NDQwNDI2MTg4OHwzNDEwZTA5Zi0wOA

Fixes #<460861785> 🦕
