### PR TITLE
chore: librarian release pull request: 20260122T223457Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
 libraries:
   - id: bigframes
-    version: 2.32.0
+    version: 2.33.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 [1]: https://pypi.org/project/bigframes/#history
 
+## [2.33.0](https://github.com/googleapis/google-cloud-python/compare/bigframes-v2.32.0...bigframes-v2.33.0) (2026-01-22)
+
+
+### Features
+
+* add bigquery.ml.transform function (#2394) ([1f9ee373c1f1d0cd08b80169c3063b862ea46465](https://github.com/googleapis/google-cloud-python/commit/1f9ee373c1f1d0cd08b80169c3063b862ea46465))
+* Add BigQuery ObjectRef functions to `bigframes.bigquery.obj` (#2380) ([9c3bbc36983dffb265454f27b37450df8c5fbc71](https://github.com/googleapis/google-cloud-python/commit/9c3bbc36983dffb265454f27b37450df8c5fbc71))
+* Stabilize interactive table height to prevent notebook layout shifts (#2378) ([a634e976c0f44087ca2a65f68cf2775ae6f04024](https://github.com/googleapis/google-cloud-python/commit/a634e976c0f44087ca2a65f68cf2775ae6f04024))
+* Add max_columns control for anywidget mode (#2374) ([34b5975f6911c5aa5ffc64a2fe6967a9f3d86f78](https://github.com/googleapis/google-cloud-python/commit/34b5975f6911c5aa5ffc64a2fe6967a9f3d86f78))
+* Add dark mode to anywidget mode (#2365) ([2763b41d4b86939e389f76789f5b2acd44f18169](https://github.com/googleapis/google-cloud-python/commit/2763b41d4b86939e389f76789f5b2acd44f18169))
+* Configure Biome for Consistent Code Style (#2364) ([81e27b3d81da9b1684eae0b7f0b9abfd7badcc4f](https://github.com/googleapis/google-cloud-python/commit/81e27b3d81da9b1684eae0b7f0b9abfd7badcc4f))
+
+
+### Bug Fixes
+
+* Throw if write api commit op has stream_errors (#2385) ([7abfef0598d476ef233364a01f72d73291983c30](https://github.com/googleapis/google-cloud-python/commit/7abfef0598d476ef233364a01f72d73291983c30))
+* implement retry logic for cloud function endpoint fetching (#2369) ([0f593c27bfee89fe1bdfc880504f9ab0ac28a24e](https://github.com/googleapis/google-cloud-python/commit/0f593c27bfee89fe1bdfc880504f9ab0ac28a24e))
+
 ## [2.32.0](https://github.com/googleapis/google-cloud-python/compare/bigframes-v2.31.0...bigframes-v2.32.0) (2026-01-05)
 
 

--- a/bigframes/version.py
+++ b/bigframes/version.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.32.0"
+__version__ = "2.33.0"
 
 # {x-release-please-start-date}
-__release_date__ = "2026-01-05"
+__release_date__ = "2026-01-22"
 # {x-release-please-end}

--- a/third_party/bigframes_vendored/version.py
+++ b/third_party/bigframes_vendored/version.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.32.0"
+__version__ = "2.33.0"
 
 # {x-release-please-start-date}
-__release_date__ = "2026-01-05"
+__release_date__ = "2026-01-22"
 # {x-release-please-end}


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:c8612d3fffb3f6a32353b2d1abd16b61e87811866f7ec9d65b59b02eb452a620
<details><summary>bigframes: 2.33.0</summary>

## [2.33.0](https://github.com/googleapis/python-bigquery-dataframes/compare/v2.32.0...v2.33.0) (2026-01-22)

### Features

* add bigquery.ml.transform function (#2394) ([1f9ee373](https://github.com/googleapis/python-bigquery-dataframes/commit/1f9ee373))

* Add dark mode to anywidget mode (#2365) ([2763b41d](https://github.com/googleapis/python-bigquery-dataframes/commit/2763b41d))

* Add max_columns control for anywidget mode (#2374) ([34b5975f](https://github.com/googleapis/python-bigquery-dataframes/commit/34b5975f))

* Configure Biome for Consistent Code Style (#2364) ([81e27b3d](https://github.com/googleapis/python-bigquery-dataframes/commit/81e27b3d))

* Add BigQuery ObjectRef functions to `bigframes.bigquery.obj` (#2380) ([9c3bbc36](https://github.com/googleapis/python-bigquery-dataframes/commit/9c3bbc36))

* Stabilize interactive table height to prevent notebook layout shifts (#2378) ([a634e976](https://github.com/googleapis/python-bigquery-dataframes/commit/a634e976))

### Bug Fixes

* implement retry logic for cloud function endpoint fetching (#2369) ([0f593c27](https://github.com/googleapis/python-bigquery-dataframes/commit/0f593c27))

* Throw if write api commit op has stream_errors (#2385) ([7abfef05](https://github.com/googleapis/python-bigquery-dataframes/commit/7abfef05))

### Performance Improvements

* Avoid requery for some result downsample methods (#2219) ([95763ff2](https://github.com/googleapis/python-bigquery-dataframes/commit/95763ff2))

</details>