### PR TITLE
feat: add deprecation warnings for .blob accessor and read_gbq_object_table

### DIFF
--- a/bigframes/series.py
+++ b/bigframes/series.py
@@ -317,6 +317,14 @@ class Series(vendored_pandas_series.Series):
 
     @property
     def blob(self) -> blob.BlobAccessor:
+        """
+        Accessor for Blob operations.
+        """
+        warnings.warn(
+            "The blob accessor is deprecated and will be removed in a future release.",
+            category=bfe.ApiDeprecationWarning,
+            stacklevel=2,
+        )
         return blob.BlobAccessor(self)
 
     @property

--- a/bigframes/series.py
+++ b/bigframes/series.py
@@ -321,7 +321,7 @@ class Series(vendored_pandas_series.Series):
         Accessor for Blob operations.
         """
         warnings.warn(
-            "The blob accessor is deprecated and will be removed in a future release.",
+            "The blob accessor is deprecated and will be removed in a future release. Use bigframes.bigquery.obj functions instead.",
             category=bfe.ApiDeprecationWarning,
             stacklevel=2,
         )

--- a/bigframes/session/__init__.py
+++ b/bigframes/session/__init__.py
@@ -2291,6 +2291,11 @@ class Session(
             bigframes.pandas.DataFrame:
                 Result BigFrames DataFrame.
         """
+        warnings.warn(
+            "read_gbq_object_table is deprecated and will be removed in a future release.",
+            category=bfe.ApiDeprecationWarning,
+            stacklevel=2,
+        )
         # TODO(garrettwu): switch to pseudocolumn when b/374988109 is done.
         table = self.bqclient.get_table(object_table)
         connection = table._properties["externalDataConfiguration"]["connectionId"]

--- a/bigframes/session/__init__.py
+++ b/bigframes/session/__init__.py
@@ -2292,7 +2292,7 @@ class Session(
                 Result BigFrames DataFrame.
         """
         warnings.warn(
-            "read_gbq_object_table is deprecated and will be removed in a future release.",
+            "read_gbq_object_table is deprecated and will be removed in a future release. Use read_gbq with 'ref' column instead.",
             category=bfe.ApiDeprecationWarning,
             stacklevel=2,
         )


### PR DESCRIPTION
  This PR introduces ApiDeprecationWarning (which inherits from FutureWarning) to the following APIs to notify users of their
  upcoming removal in a future release:

   - `Series.blob` accessor: Added a warning to the property getter in bigframes/series.py.
   - `read_gbq_object_table`: Added a warning to the implementation in bigframes/session/Session. This will also trigger when called via bigframes.pandas.read_gbq_object_table.

Fixes #<478952368> 🦕
