### PR TITLE
feat: Suppress redundant "Completed" status in progress callback

### DIFF
--- a/bigframes/formatting_helpers.py
+++ b/bigframes/formatting_helpers.py
@@ -205,11 +205,7 @@ def progress_callback(
                     display.HTML(f"✅ Completed. {previous_display_html}"),
                     display_id=current_display_id,
                 )
-            else:
-                display.update_display(
-                    display.HTML(""),
-                    display_id=current_display_id,
-                )
+
         elif isinstance(event, bigframes.core.events.SessionClosed):
             display.update_display(
                 display.HTML(f"Session {event.session_id} closed."),

--- a/bigframes/formatting_helpers.py
+++ b/bigframes/formatting_helpers.py
@@ -198,10 +198,16 @@ def progress_callback(
                 display_id=current_display_id,
             )
         elif isinstance(event, bigframes.core.events.ExecutionFinished):
-            display.update_display(
-                display.HTML(f"✅ Completed. {previous_display_html}"),
-                display_id=current_display_id,
-            )
+            if previous_display_html:
+                display.update_display(
+                    display.HTML(f"✅ Completed. {previous_display_html}"),
+                    display_id=current_display_id,
+                )
+            else:
+                display.update_display(
+                    display.HTML(""),
+                    display_id=current_display_id,
+                )
         elif isinstance(event, bigframes.core.events.SessionClosed):
             display.update_display(
                 display.HTML(f"Session {event.session_id} closed."),

--- a/notebooks/dataframes/anywidget_mode.ipynb
+++ b/notebooks/dataframes/anywidget_mode.ipynb
@@ -91,9 +91,7 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "✅ Completed. "
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -422,9 +420,7 @@
     },
     {
      "data": {
-      "text/html": [
-       "✅ Completed. "
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -826,9 +822,7 @@
     },
     {
      "data": {
-      "text/html": [
-       "✅ Completed. "
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -838,9 +832,7 @@
     },
     {
      "data": {
-      "text/html": [
-       "✅ Completed. "
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]

--- a/notebooks/dataframes/anywidget_mode.ipynb
+++ b/notebooks/dataframes/anywidget_mode.ipynb
@@ -117,17 +117,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "state gender  year     name  number\n",
-      "   AL      F  1910    Annie     482\n",
-      "   AL      F  1910   Myrtle     104\n",
-      "   AR      F  1910  Lillian      56\n",
-      "   CT      F  1910     Anne      38\n",
-      "   CT      F  1910  Frances      45\n",
-      "   FL      F  1910 Margaret      53\n",
-      "   GA      F  1910      Mae      73\n",
-      "   GA      F  1910 Beatrice      96\n",
-      "   GA      F  1910     Lola      47\n",
-      "   IA      F  1910    Viola      49\n",
+      "state gender  year    name  number\n",
+      "   AL      F  1910 Lillian      99\n",
+      "   AL      F  1910    Ruby     204\n",
+      "   AL      F  1910   Helen      76\n",
+      "   AL      F  1910  Eunice      41\n",
+      "   AR      F  1910    Dora      42\n",
+      "   CA      F  1910    Edna      62\n",
+      "   CA      F  1910   Helen     239\n",
+      "   CO      F  1910   Alice      46\n",
+      "   FL      F  1910  Willie      71\n",
+      "   FL      F  1910  Thelma      65\n",
       "...\n",
       "\n",
       "[5552452 rows x 5 columns]\n"
@@ -141,32 +141,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "220340b0",
    "metadata": {},
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "\n",
-       "    Query started with request ID bigframes-dev:US.161c75bd-f9f8-4b21-8a45-1d7dfc659034.<details><summary>SQL</summary><pre>SELECT\n",
-       "`state` AS `state`,\n",
-       "`gender` AS `gender`,\n",
-       "`year` AS `year`,\n",
-       "`name` AS `name`,\n",
-       "`number` AS `number`\n",
-       "FROM\n",
-       "(SELECT\n",
-       "  `t0`.`state`,\n",
-       "  `t0`.`gender`,\n",
-       "  `t0`.`year`,\n",
-       "  `t0`.`name`,\n",
-       "  `t0`.`number`,\n",
-       "  `t0`.`bfuid_col_2` AS `bfuid_col_15`\n",
-       "FROM `bigframes-dev._8b037bfb7316dddf9d92b12dcf93e008906bfe52._c58be946_1477_4c00_b699_0ae022f13563_bqdf_8e323719-899f-4da2-89cd-2dbb53ab1dfc` AS `t0`)\n",
-       "ORDER BY `bfuid_col_15` ASC NULLS LAST</pre></details>\n",
-       "    "
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -176,11 +157,7 @@
     },
     {
      "data": {
-      "text/html": [
-       "✅ Completed. \n",
-       "    Query processed 215.9 MB in 7 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud. google.com/bigquery?project=bigframes-dev&j=bq:US:job_IuiJsjhfPtOrKuTIOqPIjnVLX820&page=queryresults\">Job bigframes-dev:US.job_IuiJsjhfPtOrKuTIOqPIjnVLX820 details</a>]\n",
-       "    "
-      ],
+      "text/html": [],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -191,7 +168,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e68fbb9eb4d24bab837c77730d31c8a1",
+       "model_id": "6fb22be7f21f4d1dacd76dc62a1a7818",
        "version_major": 2,
        "version_minor": 1
       },
@@ -227,80 +204,80 @@
        "      <td>AL</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Hazel</td>\n",
-       "      <td>51</td>\n",
+       "      <td>Lillian</td>\n",
+       "      <td>99</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>AL</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Lucy</td>\n",
-       "      <td>76</td>\n",
+       "      <td>Ruby</td>\n",
+       "      <td>204</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>AR</td>\n",
+       "      <td>AL</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Nellie</td>\n",
-       "      <td>39</td>\n",
+       "      <td>Helen</td>\n",
+       "      <td>76</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
-       "      <td>AR</td>\n",
+       "      <td>AL</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Lena</td>\n",
-       "      <td>40</td>\n",
+       "      <td>Eunice</td>\n",
+       "      <td>41</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>CO</td>\n",
+       "      <td>AR</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Thelma</td>\n",
-       "      <td>36</td>\n",
+       "      <td>Dora</td>\n",
+       "      <td>42</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>CO</td>\n",
+       "      <td>CA</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Ruth</td>\n",
-       "      <td>68</td>\n",
+       "      <td>Edna</td>\n",
+       "      <td>62</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>6</th>\n",
-       "      <td>CT</td>\n",
+       "      <td>CA</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Elizabeth</td>\n",
-       "      <td>86</td>\n",
+       "      <td>Helen</td>\n",
+       "      <td>239</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>7</th>\n",
-       "      <td>DC</td>\n",
+       "      <td>CO</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Mary</td>\n",
-       "      <td>80</td>\n",
+       "      <td>Alice</td>\n",
+       "      <td>46</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
        "      <td>FL</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Annie</td>\n",
-       "      <td>101</td>\n",
+       "      <td>Willie</td>\n",
+       "      <td>71</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
        "      <td>FL</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Alma</td>\n",
-       "      <td>39</td>\n",
+       "      <td>Thelma</td>\n",
+       "      <td>65</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -308,67 +285,25 @@
        "</div>[5552452 rows x 5 columns in total]"
       ],
       "text/plain": [
-       "state gender  year      name  number\n",
-       "   AL      F  1910     Hazel      51\n",
-       "   AL      F  1910      Lucy      76\n",
-       "   AR      F  1910    Nellie      39\n",
-       "   AR      F  1910      Lena      40\n",
-       "   CO      F  1910    Thelma      36\n",
-       "   CO      F  1910      Ruth      68\n",
-       "   CT      F  1910 Elizabeth      86\n",
-       "   DC      F  1910      Mary      80\n",
-       "   FL      F  1910     Annie     101\n",
-       "   FL      F  1910      Alma      39\n",
+       "state gender  year    name  number\n",
+       "   AL      F  1910 Lillian      99\n",
+       "   AL      F  1910    Ruby     204\n",
+       "   AL      F  1910   Helen      76\n",
+       "   AL      F  1910  Eunice      41\n",
+       "   AR      F  1910    Dora      42\n",
+       "   CA      F  1910    Edna      62\n",
+       "   CA      F  1910   Helen     239\n",
+       "   CO      F  1910   Alice      46\n",
+       "   FL      F  1910  Willie      71\n",
+       "   FL      F  1910  Thelma      65\n",
        "...\n",
        "\n",
        "[5552452 rows x 5 columns]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "text/html": [
-       "✅ Completed. \n",
-       "    Query processed 215.9 MB in 9 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud. google.com/bigquery?project=bigframes-dev&j=bq:US:job_IEjIRaqt2w-_pAttPw1VAVuRPxA7&page=queryresults\">Job bigframes-dev:US.job_IEjIRaqt2w-_pAttPw1VAVuRPxA7 details</a>]\n",
-       "    "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "✅ Completed. \n",
-       "    Query processed 215.9 MB in 5 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud. google.com/bigquery?project=bigframes-dev&j=bq:US:job_Mi-3m2AkEC1iPgWi7hmcWa1M1oIA&page=queryresults\">Job bigframes-dev:US.job_Mi-3m2AkEC1iPgWi7hmcWa1M1oIA details</a>]\n",
-       "    "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "✅ Completed. \n",
-       "    Query processed 215.9 MB in 6 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud. google.com/bigquery?project=bigframes-dev&j=bq:US:job_j8pvY385WwIY7tGvhI7Yxc62aBwd&page=queryresults\">Job bigframes-dev:US.job_j8pvY385WwIY7tGvhI7Yxc62aBwd details</a>]\n",
-       "    "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
     }
    ],
    "source": [
@@ -394,7 +329,7 @@
      "data": {
       "text/html": [
        "✅ Completed. \n",
-       "    Query processed 171.4 MB in 30 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud. google.com/bigquery?project=bigframes-dev&j=bq:US:ff90d507-bec8-4d24-abc3-0209ac28e21f&page=queryresults\">Job bigframes-dev:US.ff90d507-bec8-4d24-abc3-0209ac28e21f details</a>]\n",
+       "    Query processed 171.4 MB in 41 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:492b5260-9f44-495c-be09-2ae1324a986c&page=queryresults\">Job bigframes-dev:US.492b5260-9f44-495c-be09-2ae1324a986c details</a>]\n",
        "    "
       ],
       "text/plain": [
@@ -473,7 +408,7 @@
      "data": {
       "text/html": [
        "✅ Completed. \n",
-       "    Query processed 88.8 MB in 3 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud. google.com/bigquery?project=bigframes-dev&j=bq:US:job_517TdI--FMoURkV7QQNMltY_-dZ7&page=queryresults\">Job bigframes-dev:US.job_517TdI--FMoURkV7QQNMltY_-dZ7 details</a>]\n",
+       "    Query processed 88.8 MB in 2 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:job_gsx0h2jHoOSYwqGKUS3lAYLf_qi3&page=queryresults\">Job bigframes-dev:US.job_gsx0h2jHoOSYwqGKUS3lAYLf_qi3 details</a>]\n",
        "    "
       ],
       "text/plain": [
@@ -487,7 +422,7 @@
      "data": {
       "text/html": [
        "✅ Completed. \n",
-       "    Query processed 88.8 MB in 2 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud. google.com/bigquery?project=bigframes-dev&j=bq:US:job_rCeYkeBPqmTKNFWFgwXjz5Ed8uWI&page=queryresults\">Job bigframes-dev:US.job_rCeYkeBPqmTKNFWFgwXjz5Ed8uWI details</a>]\n",
+       "    Query processed 88.8 MB in 3 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:job_1VivAJ2InPdg5RXjWfvAJ1B0oxO3&page=queryresults\">Job bigframes-dev:US.job_1VivAJ2InPdg5RXjWfvAJ1B0oxO3 details</a>]\n",
        "    "
       ],
       "text/plain": [
@@ -500,7 +435,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3e630b1a56c740e781772ca5f5c7267a",
+       "model_id": "7d82208e7e5e40dd9dbf64c4c561cab3",
        "version_major": 2,
        "version_minor": 1
       },
@@ -602,7 +537,7 @@
      "data": {
       "text/html": [
        "✅ Completed. \n",
-       "    Query processed 215.9 MB in 11 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud. google.com/bigquery?project=bigframes-dev&j=bq:US:job_XwXTDb6gWVkuyIFMeWA0waE33bSg&page=queryresults\">Job bigframes-dev:US.job_XwXTDb6gWVkuyIFMeWA0waE33bSg details</a>]\n",
+       "    Query processed 215.9 MB in 10 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:job_cmNyG5sJ1IDCyFINx7teExQOZ6UQ&page=queryresults\">Job bigframes-dev:US.job_cmNyG5sJ1IDCyFINx7teExQOZ6UQ details</a>]\n",
        "    "
       ],
       "text/plain": [
@@ -616,7 +551,7 @@
      "data": {
       "text/html": [
        "✅ Completed. \n",
-       "    Query processed 215.9 MB in 7 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud. google.com/bigquery?project=bigframes-dev&j=bq:US:job_bCW0LYK5_PzyyGPf9OAg4YfNMG1C&page=queryresults\">Job bigframes-dev:US.job_bCW0LYK5_PzyyGPf9OAg4YfNMG1C details</a>]\n",
+       "    Query processed 215.9 MB in 8 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:job_aQvP3Sn04Ss4flSLaLhm0sKzFvrd&page=queryresults\">Job bigframes-dev:US.job_aQvP3Sn04Ss4flSLaLhm0sKzFvrd details</a>]\n",
        "    "
       ],
       "text/plain": [
@@ -636,12 +571,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "a6a2b19314b04283a5a66ca9d66eb771",
+       "model_id": "52d11291ba1d42e6b544acbd86eef6cf",
        "version_major": 2,
        "version_minor": 1
       },
       "text/plain": [
-       "<bigframes.display.anywidget.TableWidget object at 0x7f7170161810>"
+       "<bigframes.display.anywidget.TableWidget object at 0x7f377c1c65d0>"
       ]
      },
      "execution_count": 8,
@@ -751,12 +686,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "beb362548a6b4fd4a163569edd6f1a90",
+       "model_id": "32c61c84740d45a0ac37202a76c7c14e",
        "version_major": 2,
        "version_minor": 1
       },
       "text/plain": [
-       "<bigframes.display.anywidget.TableWidget object at 0x7f7171287e10>"
+       "<bigframes.display.anywidget.TableWidget object at 0x7f377c1edcd0>"
       ]
      },
      "execution_count": 10,
@@ -800,7 +735,7 @@
      "data": {
       "text/html": [
        "✅ Completed. \n",
-       "    Query processed 85.9 kB in 19 seconds of slot time.\n",
+       "    Query processed 85.9 kB in 21 seconds of slot time.\n",
        "    "
       ],
       "text/plain": [
@@ -857,7 +792,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "02a46cf499b442d4bfe03934195e67df",
+       "model_id": "9d60a47296214553bb10c434b5ee8330",
        "version_major": 2,
        "version_minor": 1
       },
@@ -904,56 +839,20 @@
        "      <td>gs://gcs-public-data--labeled-patents/espacene...</td>\n",
        "      <td>EU</td>\n",
        "      <td>DE</td>\n",
-       "      <td>03.10.2018</td>\n",
-       "      <td>H01L 21/20</td>\n",
+       "      <td>29.08.018</td>\n",
+       "      <td>E04H 6/12</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>18166536.5</td>\n",
-       "      <td>16.02.2016</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>Scheider, Sascha et al</td>\n",
-       "      <td>EV Group E. Thallner GmbH</td>\n",
-       "      <td>Kurz, Florian</td>\n",
-       "      <td>VORRICHTUNG ZUM BONDEN VON SUBSTRATEN</td>\n",
-       "      <td>EP 3 382 744 A1</td>\n",
+       "      <td>18157874.1</td>\n",
+       "      <td>21.02.2018</td>\n",
+       "      <td>22.02.2017</td>\n",
+       "      <td>Liedtke &amp; Partner Patentanw√§lte</td>\n",
+       "      <td>SHB Hebezeugbau GmbH</td>\n",
+       "      <td>VOLGER, Alexander</td>\n",
+       "      <td>STEUERUNGSSYSTEM F√úR AUTOMATISCHE PARKH√ÑUSER</td>\n",
+       "      <td>EP 3 366 869 A1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>{'application_number': None, 'class_internatio...</td>\n",
-       "      <td>gs://gcs-public-data--labeled-patents/espacene...</td>\n",
-       "      <td>EU</td>\n",
-       "      <td>DE</td>\n",
-       "      <td>03.10.2018</td>\n",
-       "      <td>A01K 31/00</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>18171005.4</td>\n",
-       "      <td>05.02.2015</td>\n",
-       "      <td>05.02.2014</td>\n",
-       "      <td>Stork Bamberger Patentanw√§lte</td>\n",
-       "      <td>Linco Food Systems A/S</td>\n",
-       "      <td>Thrane, Uffe</td>\n",
-       "      <td>MASTH√ÑHNCHENCONTAINER ALS BESTANDTEIL EINER E...</td>\n",
-       "      <td>EP 3 381 276 A1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>{'application_number': None, 'class_internatio...</td>\n",
-       "      <td>gs://gcs-public-data--labeled-patents/espacene...</td>\n",
-       "      <td>EU</td>\n",
-       "      <td>DE</td>\n",
-       "      <td>03.10.2018</td>\n",
-       "      <td>G06F 11/30</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>18157347.8</td>\n",
-       "      <td>19.02.2018</td>\n",
-       "      <td>31.03.2017</td>\n",
-       "      <td>Hoffmann Eitle</td>\n",
-       "      <td>FUJITSU LIMITED</td>\n",
-       "      <td>Kukihara, Kensuke</td>\n",
-       "      <td>METHOD EXECUTED BY A COMPUTER, INFORMATION PRO...</td>\n",
-       "      <td>EP 3 382 553 A1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
        "      <td>{'application_number': None, 'class_internatio...</td>\n",
        "      <td>gs://gcs-public-data--labeled-patents/espacene...</td>\n",
        "      <td>EU</td>\n",
@@ -971,22 +870,58 @@
        "      <td>EP 3 383 141 A2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>{'application_number': None, 'class_internatio...</td>\n",
+       "      <td>gs://gcs-public-data--labeled-patents/espacene...</td>\n",
+       "      <td>EU</td>\n",
+       "      <td>DE</td>\n",
+       "      <td>03.10.2018</td>\n",
+       "      <td>H01L 21/20</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>18166536.5</td>\n",
+       "      <td>16.02.2016</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>Scheider, Sascha et al</td>\n",
+       "      <td>EV Group E. Thallner GmbH</td>\n",
+       "      <td>Kurz, Florian</td>\n",
+       "      <td>VORRICHTUNG ZUM BONDEN VON SUBSTRATEN</td>\n",
+       "      <td>EP 3 382 744 A1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>{'application_number': None, 'class_internatio...</td>\n",
+       "      <td>gs://gcs-public-data--labeled-patents/espacene...</td>\n",
+       "      <td>EU</td>\n",
+       "      <td>DE</td>\n",
+       "      <td>03.10.2018</td>\n",
+       "      <td>G06F 11/30</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>18157347.8</td>\n",
+       "      <td>19.02.2018</td>\n",
+       "      <td>31.03.2017</td>\n",
+       "      <td>Hoffmann Eitle</td>\n",
+       "      <td>FUJITSU LIMITED</td>\n",
+       "      <td>Kukihara, Kensuke</td>\n",
+       "      <td>METHOD EXECUTED BY A COMPUTER, INFORMATION PRO...</td>\n",
+       "      <td>EP 3 382 553 A1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>{'application_number': None, 'class_internatio...</td>\n",
        "      <td>gs://gcs-public-data--labeled-patents/espacene...</td>\n",
        "      <td>EU</td>\n",
        "      <td>DE</td>\n",
-       "      <td>29.08.018</td>\n",
-       "      <td>E04H 6/12</td>\n",
+       "      <td>03.10.2018</td>\n",
+       "      <td>A01K 31/00</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
-       "      <td>18157874.1</td>\n",
-       "      <td>21.02.2018</td>\n",
-       "      <td>22.02.2017</td>\n",
-       "      <td>Liedtke &amp; Partner Patentanw√§lte</td>\n",
-       "      <td>SHB Hebezeugbau GmbH</td>\n",
-       "      <td>VOLGER, Alexander</td>\n",
-       "      <td>STEUERUNGSSYSTEM F√úR AUTOMATISCHE PARKH√ÑUSER</td>\n",
-       "      <td>EP 3 366 869 A1</td>\n",
+       "      <td>18171005.4</td>\n",
+       "      <td>05.02.2015</td>\n",
+       "      <td>05.02.2014</td>\n",
+       "      <td>Stork Bamberger Patentanw√§lte</td>\n",
+       "      <td>Linco Food Systems A/S</td>\n",
+       "      <td>Thrane, Uffe</td>\n",
+       "      <td>MASTH√ÑHNCHENCONTAINER ALS BESTANDTEIL EINER E...</td>\n",
+       "      <td>EP 3 381 276 A1</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1009,32 +944,32 @@
        "4  gs://gcs-public-data--labeled-patents/espacene...     EU       DE   \n",
        "\n",
        "  publication_date class_international class_us application_number  \\\n",
-       "0       03.10.2018          H01L 21/20     <NA>         18166536.5   \n",
-       "1       03.10.2018          A01K 31/00     <NA>         18171005.4   \n",
-       "2       03.10.2018          G06F 11/30     <NA>         18157347.8   \n",
-       "3       03.10.2018           H05B 6/12     <NA>         18165514.3   \n",
-       "4        29.08.018           E04H 6/12     <NA>         18157874.1   \n",
+       "0        29.08.018           E04H 6/12     <NA>         18157874.1   \n",
+       "1       03.10.2018           H05B 6/12     <NA>         18165514.3   \n",
+       "2       03.10.2018          H01L 21/20     <NA>         18166536.5   \n",
+       "3       03.10.2018          G06F 11/30     <NA>         18157347.8   \n",
+       "4       03.10.2018          A01K 31/00     <NA>         18171005.4   \n",
        "\n",
        "  filing_date priority_date_eu          representative_line_1_eu  \\\n",
-       "0  16.02.2016             <NA>            Scheider, Sascha et al   \n",
-       "1  05.02.2015       05.02.2014    Stork Bamberger Patentanw√§lte   \n",
-       "2  19.02.2018       31.03.2017                    Hoffmann Eitle   \n",
-       "3  03.04.2018       30.03.2017                              <NA>   \n",
-       "4  21.02.2018       22.02.2017  Liedtke & Partner Patentanw√§lte   \n",
+       "0  21.02.2018       22.02.2017  Liedtke & Partner Patentanw√§lte   \n",
+       "1  03.04.2018       30.03.2017                              <NA>   \n",
+       "2  16.02.2016             <NA>            Scheider, Sascha et al   \n",
+       "3  19.02.2018       31.03.2017                    Hoffmann Eitle   \n",
+       "4  05.02.2015       05.02.2014    Stork Bamberger Patentanw√§lte   \n",
        "\n",
        "            applicant_line_1     inventor_line_1  \\\n",
-       "0  EV Group E. Thallner GmbH       Kurz, Florian   \n",
-       "1     Linco Food Systems A/S        Thrane, Uffe   \n",
-       "2            FUJITSU LIMITED   Kukihara, Kensuke   \n",
-       "3       BSH Hausger√§te GmbH  Acero Acero, Jesus   \n",
-       "4       SHB Hebezeugbau GmbH   VOLGER, Alexander   \n",
+       "0       SHB Hebezeugbau GmbH   VOLGER, Alexander   \n",
+       "1       BSH Hausger√§te GmbH  Acero Acero, Jesus   \n",
+       "2  EV Group E. Thallner GmbH       Kurz, Florian   \n",
+       "3            FUJITSU LIMITED   Kukihara, Kensuke   \n",
+       "4     Linco Food Systems A/S        Thrane, Uffe   \n",
        "\n",
        "                                        title_line_1           number  \n",
-       "0              VORRICHTUNG ZUM BONDEN VON SUBSTRATEN  EP 3 382 744 A1  \n",
-       "1  MASTH√ÑHNCHENCONTAINER ALS BESTANDTEIL EINER E...  EP 3 381 276 A1  \n",
-       "2  METHOD EXECUTED BY A COMPUTER, INFORMATION PRO...  EP 3 382 553 A1  \n",
-       "3     VORRICHTUNG ZUR INDUKTIVEN ENERGIE√úBERTRAGUNG  EP 3 383 141 A2  \n",
-       "4     STEUERUNGSSYSTEM F√úR AUTOMATISCHE PARKH√ÑUSER  EP 3 366 869 A1  \n",
+       "0     STEUERUNGSSYSTEM F√úR AUTOMATISCHE PARKH√ÑUSER  EP 3 366 869 A1  \n",
+       "1     VORRICHTUNG ZUR INDUKTIVEN ENERGIE√úBERTRAGUNG  EP 3 383 141 A2  \n",
+       "2              VORRICHTUNG ZUM BONDEN VON SUBSTRATEN  EP 3 382 744 A1  \n",
+       "3  METHOD EXECUTED BY A COMPUTER, INFORMATION PRO...  EP 3 382 553 A1  \n",
+       "4  MASTH√ÑHNCHENCONTAINER ALS BESTANDTEIL EINER E...  EP 3 381 276 A1  \n",
        "\n",
        "[5 rows x 15 columns]"
       ]


### PR DESCRIPTION
This PR refines the visual feedback provided during operation progress. Specifically, it prevents the display of a standalone "✅ Completed." message and green checkmark when no query execution information (like slot time or bytes processed) is available. This often occurs during metadata-only operations or  cached results where the "Completed" status is redundant.

Fixes #<479944983> 🦕
