### PR TITLE
feat: change default progress_bar to None for reduced verbosity

### DIFF
--- a/third_party/bigframes_vendored/pandas/core/config_init.py
+++ b/third_party/bigframes_vendored/pandas/core/config_init.py
@@ -84,9 +84,9 @@ class DisplayOptions:
     """
 
     # Options unique to BigQuery DataFrames.
-    progress_bar: Optional[str] = "auto"
+    progress_bar: Optional[str] = None
     """
-    Determines if progress bars are shown during job runs. Default "auto".
+    Determines if progress bars are shown during job runs. Default None.
 
     Valid values are `auto`, `notebook`, and `terminal`. Set
     to `None` to remove progress bars.

--- a/third_party/bigframes_vendored/pandas/core/reshape/concat.py
+++ b/third_party/bigframes_vendored/pandas/core/reshape/concat.py
@@ -29,7 +29,6 @@ def concat(
     **Examples:**
 
         >>> import bigframes.pandas as pd
-        >>> pd.options.display.progress_bar = None
 
     Combine two ``Series``.
 

--- a/third_party/bigframes_vendored/pandas/core/reshape/encoding.py
+++ b/third_party/bigframes_vendored/pandas/core/reshape/encoding.py
@@ -27,7 +27,6 @@ def get_dummies(
     **Examples:**
 
         >>> import bigframes.pandas as pd
-        >>> pd.options.display.progress_bar = None
         >>> s = pd.Series(list('abca'))
         >>> pd.get_dummies(s)
                a      b      c


### PR DESCRIPTION
This change updates the default behavior of BigQuery DataFrames to be less verbose during execution.

  User-facing changes:
   * Quiet by Default: The default value for bigframes.options.display.progress_bar is now None (previously "auto"). This means operations triggering BigQuery jobs will execute silently without displaying progress bars or completion messages in the output.
   * Opt-in for Verbosity: Users who prefer to see progress feedback can easily re-enable it by setting the option explicitly:


```
   1     import bigframes.pandas as bpd
   2
   3     # Restore previous behavior
   4     bpd.options.display.progress_bar = "auto"
   5
   6     # Or specify a specific mode
   7     # bpd.options.display.progress_bar = "terminal"
   8     # bpd.options.display.progress_bar = "notebook"
```

  This change aims to provide a cleaner default experience, especially for users running multiple operations in sequence or in non-interactive environments.

Fixes #<481804767> 🦕
