### PR TITLE
feat: Disable progress bars in Anywidget mode to reduce notebook clutter

### DIFF
--- a/bigframes/core/compile/polars/compiler.py
+++ b/bigframes/core/compile/polars/compiler.py
@@ -429,7 +429,13 @@ if polars_installed:
         @compile_op.register(json_ops.JSONDecode)
         def _(self, op: ops.ScalarOp, input: pl.Expr) -> pl.Expr:
             assert isinstance(op, json_ops.JSONDecode)
-            return input.str.json_decode(_DTYPE_MAPPING[op.to_type])
+            if op.safe:
+                # Polars does not support safe JSON decoding (returning null on failure).
+                # Fallback to BigQuery execution.
+                raise NotImplementedError(
+                    "Safe JSON decoding is not supported in Polars executor."
+                )
+            return input.str.json_decode(_bigframes_dtype_to_polars_dtype(op.to_type))
 
         @compile_op.register(arr_ops.ToArrayOp)
         def _(self, op: ops.ToArrayOp, *inputs: pl.Expr) -> pl.Expr:

--- a/bigframes/core/compile/polars/compiler.py
+++ b/bigframes/core/compile/polars/compiler.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import dataclasses
 import functools
 import itertools
+import json
 from typing import cast, Literal, Optional, Sequence, Tuple, Type, TYPE_CHECKING
 
 import pandas as pd
@@ -429,13 +430,68 @@ if polars_installed:
         @compile_op.register(json_ops.JSONDecode)
         def _(self, op: ops.ScalarOp, input: pl.Expr) -> pl.Expr:
             assert isinstance(op, json_ops.JSONDecode)
+            target_dtype = _bigframes_dtype_to_polars_dtype(op.to_type)
             if op.safe:
                 # Polars does not support safe JSON decoding (returning null on failure).
-                # Fallback to BigQuery execution.
-                raise NotImplementedError(
-                    "Safe JSON decoding is not supported in Polars executor."
-                )
-            return input.str.json_decode(_bigframes_dtype_to_polars_dtype(op.to_type))
+                # We use map_elements to provide safe JSON decoding.
+                def safe_decode(val):
+                    if val is None:
+                        return None
+                    try:
+                        decoded = json.loads(val)
+                    except Exception:
+                        return None
+
+                    if decoded is None:
+                        return None
+
+                    if op.to_type == bigframes.dtypes.INT_DTYPE:
+                        if type(decoded) is bool:
+                            return None
+                        if isinstance(decoded, int):
+                            return decoded
+                        if isinstance(decoded, float):
+                            if decoded.is_integer():
+                                return int(decoded)
+                        if isinstance(decoded, str):
+                            try:
+                                return int(decoded)
+                            except Exception:
+                                pass
+                        return None
+
+                    if op.to_type == bigframes.dtypes.FLOAT_DTYPE:
+                        if type(decoded) is bool:
+                            return None
+                        if isinstance(decoded, (int, float)):
+                            return float(decoded)
+                        if isinstance(decoded, str):
+                            try:
+                                return float(decoded)
+                            except Exception:
+                                pass
+                        return None
+
+                    if op.to_type == bigframes.dtypes.BOOL_DTYPE:
+                        if isinstance(decoded, bool):
+                            return decoded
+                        if isinstance(decoded, str):
+                            if decoded.lower() == "true":
+                                return True
+                            if decoded.lower() == "false":
+                                return False
+                        return None
+
+                    if op.to_type == bigframes.dtypes.STRING_DTYPE:
+                        if isinstance(decoded, str):
+                            return decoded
+                        return None
+
+                    return decoded
+
+                return input.map_elements(safe_decode, return_dtype=target_dtype)
+
+            return input.str.json_decode(target_dtype)
 
         @compile_op.register(arr_ops.ToArrayOp)
         def _(self, op: ops.ToArrayOp, *inputs: pl.Expr) -> pl.Expr:

--- a/bigframes/core/compile/polars/lowering.py
+++ b/bigframes/core/compile/polars/lowering.py
@@ -391,7 +391,7 @@ def _lower_cast(cast_op: ops.AsTypeOp, arg: expression.Expression):
         return arg
 
     if arg.output_type == dtypes.JSON_DTYPE:
-        return json_ops.JSONDecode(cast_op.to_type).as_expr(arg)
+        return json_ops.JSONDecode(cast_op.to_type, safe=cast_op.safe).as_expr(arg)
     if (
         arg.output_type == dtypes.STRING_DTYPE
         and cast_op.to_type == dtypes.DATETIME_DTYPE

--- a/bigframes/display/anywidget.py
+++ b/bigframes/display/anywidget.py
@@ -133,25 +133,26 @@ class TableWidget(_WIDGET_BASE):
         # obtain the row counts
         # TODO(b/428238610): Start iterating over the result of `to_pandas_batches()`
         # before we get here so that the count might already be cached.
-        self._reset_batches_for_new_page_size()
+        with bigframes.option_context("display.progress_bar", None):
+            self._reset_batches_for_new_page_size()
 
-        if self._batches is None:
-            self._error_message = (
-                "Could not retrieve data batches. Data might be unavailable or "
-                "an error occurred."
-            )
-            self.row_count = None
-        elif self._batches.total_rows is None:
-            # Total rows is unknown, this is an expected state.
-            # TODO(b/461536343): Cheaply discover if we have exactly 1 page.
-            # There are cases where total rows is not set, but there are no additional
-            # pages. We could disable the "next" button in these cases.
-            self.row_count = None
-        else:
-            self.row_count = self._batches.total_rows
+            if self._batches is None:
+                self._error_message = (
+                    "Could not retrieve data batches. Data might be unavailable or "
+                    "an error occurred."
+                )
+                self.row_count = None
+            elif self._batches.total_rows is None:
+                # Total rows is unknown, this is an expected state.
+                # TODO(b/461536343): Cheaply discover if we have exactly 1 page.
+                # There are cases where total rows is not set, but there are no additional
+                # pages. We could disable the "next" button in these cases.
+                self.row_count = None
+            else:
+                self.row_count = self._batches.total_rows
 
-        # get the initial page
-        self._set_table_html()
+            # get the initial page
+            self._set_table_html()
 
     @traitlets.observe("_initial_load_complete")
     def _on_initial_load_complete(self, change: dict[str, Any]):
@@ -281,7 +282,9 @@ class TableWidget(_WIDGET_BASE):
     def _set_table_html(self) -> None:
         """Sets the current html data based on the current page and page size."""
         new_page = None
-        with self._setting_html_lock:
+        with self._setting_html_lock, bigframes.option_context(
+            "display.progress_bar", None
+        ):
             if self._error_message:
                 self.table_html = (
                     f"<div class='bigframes-error-message'>"

--- a/bigframes/display/html.py
+++ b/bigframes/display/html.py
@@ -363,7 +363,8 @@ def repr_mimebundle(
 
     if opts.repr_mode == "anywidget":
         try:
-            return get_anywidget_bundle(obj, include=include, exclude=exclude)
+            with bigframes.option_context("display.progress_bar", None):
+                return get_anywidget_bundle(obj, include=include, exclude=exclude)
         except ImportError:
             # Anywidget is an optional dependency, so warn rather than fail.
             # TODO(shuowei): When Anywidget becomes the default for all repr modes,

--- a/bigframes/operations/json_ops.py
+++ b/bigframes/operations/json_ops.py
@@ -220,6 +220,7 @@ class JSONKeys(base_ops.UnaryOp):
 class JSONDecode(base_ops.UnaryOp):
     name: typing.ClassVar[str] = "json_decode"
     to_type: dtypes.Dtype
+    safe: bool = False
 
     def output_type(self, *input_types):
         input_type = input_types[0]

--- a/bigframes/session/polars_executor.py
+++ b/bigframes/session/polars_executor.py
@@ -34,6 +34,7 @@ from bigframes.operations import (
     numeric_ops,
     string_ops,
 )
+import bigframes.operations.json_ops as json_ops
 from bigframes.session import executor, semi_executor
 
 if TYPE_CHECKING:
@@ -94,6 +95,7 @@ _COMPATIBLE_SCALAR_OPS = (
     string_ops.EndsWithOp,
     string_ops.StrContainsOp,
     string_ops.StrContainsRegexOp,
+    json_ops.JSONDecode,
 )
 _COMPATIBLE_AGG_OPS = (
     agg_ops.SizeOp,

--- a/notebooks/dataframes/anywidget_mode.ipynb
+++ b/notebooks/dataframes/anywidget_mode.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "d10bfca4",
    "metadata": {},
    "outputs": [],
@@ -91,7 +91,9 @@
    "outputs": [
     {
      "data": {
-      "text/html": [],
+      "text/html": [
+       "Starting."
+      ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -117,17 +119,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "state gender  year    name  number\n",
-      "   AL      F  1910 Lillian      99\n",
-      "   AL      F  1910    Ruby     204\n",
-      "   AL      F  1910   Helen      76\n",
-      "   AL      F  1910  Eunice      41\n",
-      "   AR      F  1910    Dora      42\n",
-      "   CA      F  1910    Edna      62\n",
-      "   CA      F  1910   Helen     239\n",
-      "   CO      F  1910   Alice      46\n",
-      "   FL      F  1910  Willie      71\n",
-      "   FL      F  1910  Thelma      65\n",
+      "state gender  year     name  number\n",
+      "   AL      F  1910    Annie     482\n",
+      "   AL      F  1910   Myrtle     104\n",
+      "   AR      F  1910  Lillian      56\n",
+      "   CT      F  1910     Anne      38\n",
+      "   CT      F  1910  Frances      45\n",
+      "   FL      F  1910 Margaret      53\n",
+      "   GA      F  1910      Mae      73\n",
+      "   GA      F  1910 Beatrice      96\n",
+      "   GA      F  1910     Lola      47\n",
+      "   IA      F  1910    Viola      49\n",
       "...\n",
       "\n",
       "[5552452 rows x 5 columns]\n"
@@ -147,28 +149,8 @@
    "outputs": [
     {
      "data": {
-      "text/html": [],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6fb22be7f21f4d1dacd76dc62a1a7818",
+       "model_id": "c74c3719ba43489890185b5c9880acfc",
        "version_major": 2,
        "version_minor": 1
       },
@@ -204,80 +186,80 @@
        "      <td>AL</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Lillian</td>\n",
-       "      <td>99</td>\n",
+       "      <td>Hazel</td>\n",
+       "      <td>51</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>AL</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Ruby</td>\n",
-       "      <td>204</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>AL</td>\n",
-       "      <td>F</td>\n",
-       "      <td>1910</td>\n",
-       "      <td>Helen</td>\n",
+       "      <td>Lucy</td>\n",
        "      <td>76</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>AL</td>\n",
-       "      <td>F</td>\n",
-       "      <td>1910</td>\n",
-       "      <td>Eunice</td>\n",
-       "      <td>41</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
+       "      <th>2</th>\n",
        "      <td>AR</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Dora</td>\n",
-       "      <td>42</td>\n",
+       "      <td>Nellie</td>\n",
+       "      <td>39</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>5</th>\n",
-       "      <td>CA</td>\n",
+       "      <th>3</th>\n",
+       "      <td>AR</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Edna</td>\n",
-       "      <td>62</td>\n",
+       "      <td>Lena</td>\n",
+       "      <td>40</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>6</th>\n",
-       "      <td>CA</td>\n",
-       "      <td>F</td>\n",
-       "      <td>1910</td>\n",
-       "      <td>Helen</td>\n",
-       "      <td>239</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>7</th>\n",
+       "      <th>4</th>\n",
        "      <td>CO</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Alice</td>\n",
-       "      <td>46</td>\n",
+       "      <td>Thelma</td>\n",
+       "      <td>36</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>CO</td>\n",
+       "      <td>F</td>\n",
+       "      <td>1910</td>\n",
+       "      <td>Ruth</td>\n",
+       "      <td>68</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>CT</td>\n",
+       "      <td>F</td>\n",
+       "      <td>1910</td>\n",
+       "      <td>Elizabeth</td>\n",
+       "      <td>86</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>DC</td>\n",
+       "      <td>F</td>\n",
+       "      <td>1910</td>\n",
+       "      <td>Mary</td>\n",
+       "      <td>80</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>8</th>\n",
        "      <td>FL</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Willie</td>\n",
-       "      <td>71</td>\n",
+       "      <td>Annie</td>\n",
+       "      <td>101</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>9</th>\n",
        "      <td>FL</td>\n",
        "      <td>F</td>\n",
        "      <td>1910</td>\n",
-       "      <td>Thelma</td>\n",
-       "      <td>65</td>\n",
+       "      <td>Alma</td>\n",
+       "      <td>39</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -285,17 +267,17 @@
        "</div>[5552452 rows x 5 columns in total]"
       ],
       "text/plain": [
-       "state gender  year    name  number\n",
-       "   AL      F  1910 Lillian      99\n",
-       "   AL      F  1910    Ruby     204\n",
-       "   AL      F  1910   Helen      76\n",
-       "   AL      F  1910  Eunice      41\n",
-       "   AR      F  1910    Dora      42\n",
-       "   CA      F  1910    Edna      62\n",
-       "   CA      F  1910   Helen     239\n",
-       "   CO      F  1910   Alice      46\n",
-       "   FL      F  1910  Willie      71\n",
-       "   FL      F  1910  Thelma      65\n",
+       "state gender  year      name  number\n",
+       "   AL      F  1910     Hazel      51\n",
+       "   AL      F  1910      Lucy      76\n",
+       "   AR      F  1910    Nellie      39\n",
+       "   AR      F  1910      Lena      40\n",
+       "   CO      F  1910    Thelma      36\n",
+       "   CO      F  1910      Ruth      68\n",
+       "   CT      F  1910 Elizabeth      86\n",
+       "   DC      F  1910      Mary      80\n",
+       "   FL      F  1910     Annie     101\n",
+       "   FL      F  1910      Alma      39\n",
        "...\n",
        "\n",
        "[5552452 rows x 5 columns]"
@@ -329,7 +311,7 @@
      "data": {
       "text/html": [
        "✅ Completed. \n",
-       "    Query processed 171.4 MB in 41 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:492b5260-9f44-495c-be09-2ae1324a986c&page=queryresults\">Job bigframes-dev:US.492b5260-9f44-495c-be09-2ae1324a986c details</a>]\n",
+       "    Query processed 171.4 MB in 35 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:e15f1b34-e414-42d2-857b-926ea25947c4&page=queryresults\">Job bigframes-dev:US.e15f1b34-e414-42d2-857b-926ea25947c4 details</a>]\n",
        "    "
       ],
       "text/plain": [
@@ -355,7 +337,9 @@
     },
     {
      "data": {
-      "text/html": [],
+      "text/html": [
+       "Starting."
+      ],
       "text/plain": [
        "<IPython.core.display.HTML object>"
       ]
@@ -406,36 +390,8 @@
    "outputs": [
     {
      "data": {
-      "text/html": [
-       "✅ Completed. \n",
-       "    Query processed 88.8 MB in 2 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:job_gsx0h2jHoOSYwqGKUS3lAYLf_qi3&page=queryresults\">Job bigframes-dev:US.job_gsx0h2jHoOSYwqGKUS3lAYLf_qi3 details</a>]\n",
-       "    "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "✅ Completed. \n",
-       "    Query processed 88.8 MB in 3 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:job_1VivAJ2InPdg5RXjWfvAJ1B0oxO3&page=queryresults\">Job bigframes-dev:US.job_1VivAJ2InPdg5RXjWfvAJ1B0oxO3 details</a>]\n",
-       "    "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7d82208e7e5e40dd9dbf64c4c561cab3",
+       "model_id": "2ad9004bda464950ab6eda63b1b86a3a",
        "version_major": 2,
        "version_minor": 1
       },
@@ -534,34 +490,6 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "✅ Completed. \n",
-       "    Query processed 215.9 MB in 10 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:job_cmNyG5sJ1IDCyFINx7teExQOZ6UQ&page=queryresults\">Job bigframes-dev:US.job_cmNyG5sJ1IDCyFINx7teExQOZ6UQ details</a>]\n",
-       "    "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "✅ Completed. \n",
-       "    Query processed 215.9 MB in 8 seconds of slot time. [<a target=\"_blank\" href=\"https://console.cloud.google.com/bigquery?project=bigframes-dev&j=bq:US:job_aQvP3Sn04Ss4flSLaLhm0sKzFvrd&page=queryresults\">Job bigframes-dev:US.job_aQvP3Sn04Ss4flSLaLhm0sKzFvrd details</a>]\n",
-       "    "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -571,12 +499,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "52d11291ba1d42e6b544acbd86eef6cf",
+       "model_id": "c1b84125429c4fbc90a22e1adbeea901",
        "version_major": 2,
        "version_minor": 1
       },
       "text/plain": [
-       "<bigframes.display.anywidget.TableWidget object at 0x7f377c1c65d0>"
+       "<bigframes.display.anywidget.TableWidget object at 0x7f5aac5e4cd0>"
       ]
      },
      "execution_count": 8,
@@ -649,34 +577,6 @@
    "metadata": {},
    "outputs": [
     {
-     "data": {
-      "text/html": [
-       "✅ Completed. \n",
-       "    Query processed 215.9 MB in a moment of slot time.\n",
-       "    "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [
-       "✅ Completed. \n",
-       "    Query processed 215.9 MB in a moment of slot time.\n",
-       "    "
-      ],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -686,12 +586,12 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "32c61c84740d45a0ac37202a76c7c14e",
+       "model_id": "23fc730e004b4eec807d2829bffa3ce0",
        "version_major": 2,
        "version_minor": 1
       },
       "text/plain": [
-       "<bigframes.display.anywidget.TableWidget object at 0x7f377c1edcd0>"
+       "<bigframes.display.anywidget.TableWidget object at 0x7f5abc063e10>"
       ]
      },
      "execution_count": 10,
@@ -752,33 +652,7 @@
       "/usr/local/google/home/shuowei/src/python-bigquery-dataframes/bigframes/dtypes.py:987: JSONDtypeWarning: JSON columns will be represented as pandas.ArrowDtype(pyarrow.json_())\n",
       "instead of using `db_dtypes` in the future when available in pandas\n",
       "(https://github.com/pandas-dev/pandas/issues/60958) and pyarrow.\n",
-      "  warnings.warn(msg, bigframes.exceptions.JSONDtypeWarning)\n"
-     ]
-    },
-    {
-     "data": {
-      "text/html": [],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "text/html": [],
-      "text/plain": [
-       "<IPython.core.display.HTML object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    },
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
+      "  warnings.warn(msg, bigframes.exceptions.JSONDtypeWarning)\n",
       "/usr/local/google/home/shuowei/src/python-bigquery-dataframes/bigframes/dtypes.py:987: JSONDtypeWarning: JSON columns will be represented as pandas.ArrowDtype(pyarrow.json_())\n",
       "instead of using `db_dtypes` in the future when available in pandas\n",
       "(https://github.com/pandas-dev/pandas/issues/60958) and pyarrow.\n",
@@ -792,7 +666,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "9d60a47296214553bb10c434b5ee8330",
+       "model_id": "a3bf6021c6fd44299d317d3b44213b50",
        "version_major": 2,
        "version_minor": 1
       },
@@ -839,24 +713,6 @@
        "      <td>gs://gcs-public-data--labeled-patents/espacene...</td>\n",
        "      <td>EU</td>\n",
        "      <td>DE</td>\n",
-       "      <td>29.08.018</td>\n",
-       "      <td>E04H 6/12</td>\n",
-       "      <td>&lt;NA&gt;</td>\n",
-       "      <td>18157874.1</td>\n",
-       "      <td>21.02.2018</td>\n",
-       "      <td>22.02.2017</td>\n",
-       "      <td>Liedtke &amp; Partner Patentanw√§lte</td>\n",
-       "      <td>SHB Hebezeugbau GmbH</td>\n",
-       "      <td>VOLGER, Alexander</td>\n",
-       "      <td>STEUERUNGSSYSTEM F√úR AUTOMATISCHE PARKH√ÑUSER</td>\n",
-       "      <td>EP 3 366 869 A1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>{'application_number': None, 'class_internatio...</td>\n",
-       "      <td>gs://gcs-public-data--labeled-patents/espacene...</td>\n",
-       "      <td>EU</td>\n",
-       "      <td>DE</td>\n",
        "      <td>03.10.2018</td>\n",
        "      <td>H05B 6/12</td>\n",
        "      <td>&lt;NA&gt;</td>\n",
@@ -870,7 +726,7 @@
        "      <td>EP 3 383 141 A2</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>2</th>\n",
+       "      <th>1</th>\n",
        "      <td>{'application_number': None, 'class_internatio...</td>\n",
        "      <td>gs://gcs-public-data--labeled-patents/espacene...</td>\n",
        "      <td>EU</td>\n",
@@ -888,7 +744,7 @@
        "      <td>EP 3 382 744 A1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>3</th>\n",
+       "      <th>2</th>\n",
        "      <td>{'application_number': None, 'class_internatio...</td>\n",
        "      <td>gs://gcs-public-data--labeled-patents/espacene...</td>\n",
        "      <td>EU</td>\n",
@@ -906,7 +762,7 @@
        "      <td>EP 3 382 553 A1</td>\n",
        "    </tr>\n",
        "    <tr>\n",
-       "      <th>4</th>\n",
+       "      <th>3</th>\n",
        "      <td>{'application_number': None, 'class_internatio...</td>\n",
        "      <td>gs://gcs-public-data--labeled-patents/espacene...</td>\n",
        "      <td>EU</td>\n",
@@ -922,6 +778,24 @@
        "      <td>Thrane, Uffe</td>\n",
        "      <td>MASTH√ÑHNCHENCONTAINER ALS BESTANDTEIL EINER E...</td>\n",
        "      <td>EP 3 381 276 A1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>{'application_number': None, 'class_internatio...</td>\n",
+       "      <td>gs://gcs-public-data--labeled-patents/espacene...</td>\n",
+       "      <td>EU</td>\n",
+       "      <td>DE</td>\n",
+       "      <td>29.08.018</td>\n",
+       "      <td>E04H 6/12</td>\n",
+       "      <td>&lt;NA&gt;</td>\n",
+       "      <td>18157874.1</td>\n",
+       "      <td>21.02.2018</td>\n",
+       "      <td>22.02.2017</td>\n",
+       "      <td>Liedtke &amp; Partner Patentanw√§lte</td>\n",
+       "      <td>SHB Hebezeugbau GmbH</td>\n",
+       "      <td>VOLGER, Alexander</td>\n",
+       "      <td>STEUERUNGSSYSTEM F√úR AUTOMATISCHE PARKH√ÑUSER</td>\n",
+       "      <td>EP 3 366 869 A1</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -944,32 +818,32 @@
        "4  gs://gcs-public-data--labeled-patents/espacene...     EU       DE   \n",
        "\n",
        "  publication_date class_international class_us application_number  \\\n",
-       "0        29.08.018           E04H 6/12     <NA>         18157874.1   \n",
-       "1       03.10.2018           H05B 6/12     <NA>         18165514.3   \n",
-       "2       03.10.2018          H01L 21/20     <NA>         18166536.5   \n",
-       "3       03.10.2018          G06F 11/30     <NA>         18157347.8   \n",
-       "4       03.10.2018          A01K 31/00     <NA>         18171005.4   \n",
+       "0       03.10.2018           H05B 6/12     <NA>         18165514.3   \n",
+       "1       03.10.2018          H01L 21/20     <NA>         18166536.5   \n",
+       "2       03.10.2018          G06F 11/30     <NA>         18157347.8   \n",
+       "3       03.10.2018          A01K 31/00     <NA>         18171005.4   \n",
+       "4        29.08.018           E04H 6/12     <NA>         18157874.1   \n",
        "\n",
        "  filing_date priority_date_eu          representative_line_1_eu  \\\n",
-       "0  21.02.2018       22.02.2017  Liedtke & Partner Patentanw√§lte   \n",
-       "1  03.04.2018       30.03.2017                              <NA>   \n",
-       "2  16.02.2016             <NA>            Scheider, Sascha et al   \n",
-       "3  19.02.2018       31.03.2017                    Hoffmann Eitle   \n",
-       "4  05.02.2015       05.02.2014    Stork Bamberger Patentanw√§lte   \n",
+       "0  03.04.2018       30.03.2017                              <NA>   \n",
+       "1  16.02.2016             <NA>            Scheider, Sascha et al   \n",
+       "2  19.02.2018       31.03.2017                    Hoffmann Eitle   \n",
+       "3  05.02.2015       05.02.2014    Stork Bamberger Patentanw√§lte   \n",
+       "4  21.02.2018       22.02.2017  Liedtke & Partner Patentanw√§lte   \n",
        "\n",
        "            applicant_line_1     inventor_line_1  \\\n",
-       "0       SHB Hebezeugbau GmbH   VOLGER, Alexander   \n",
-       "1       BSH Hausger√§te GmbH  Acero Acero, Jesus   \n",
-       "2  EV Group E. Thallner GmbH       Kurz, Florian   \n",
-       "3            FUJITSU LIMITED   Kukihara, Kensuke   \n",
-       "4     Linco Food Systems A/S        Thrane, Uffe   \n",
+       "0       BSH Hausger√§te GmbH  Acero Acero, Jesus   \n",
+       "1  EV Group E. Thallner GmbH       Kurz, Florian   \n",
+       "2            FUJITSU LIMITED   Kukihara, Kensuke   \n",
+       "3     Linco Food Systems A/S        Thrane, Uffe   \n",
+       "4       SHB Hebezeugbau GmbH   VOLGER, Alexander   \n",
        "\n",
        "                                        title_line_1           number  \n",
-       "0     STEUERUNGSSYSTEM F√úR AUTOMATISCHE PARKH√ÑUSER  EP 3 366 869 A1  \n",
-       "1     VORRICHTUNG ZUR INDUKTIVEN ENERGIE√úBERTRAGUNG  EP 3 383 141 A2  \n",
-       "2              VORRICHTUNG ZUM BONDEN VON SUBSTRATEN  EP 3 382 744 A1  \n",
-       "3  METHOD EXECUTED BY A COMPUTER, INFORMATION PRO...  EP 3 382 553 A1  \n",
-       "4  MASTH√ÑHNCHENCONTAINER ALS BESTANDTEIL EINER E...  EP 3 381 276 A1  \n",
+       "0     VORRICHTUNG ZUR INDUKTIVEN ENERGIE√úBERTRAGUNG  EP 3 383 141 A2  \n",
+       "1              VORRICHTUNG ZUM BONDEN VON SUBSTRATEN  EP 3 382 744 A1  \n",
+       "2  METHOD EXECUTED BY A COMPUTER, INFORMATION PRO...  EP 3 382 553 A1  \n",
+       "3  MASTH√ÑHNCHENCONTAINER ALS BESTANDTEIL EINER E...  EP 3 381 276 A1  \n",
+       "4     STEUERUNGSSYSTEM F√úR AUTOMATISCHE PARKH√ÑUSER  EP 3 366 869 A1  \n",
        "\n",
        "[5 rows x 15 columns]"
       ]

--- a/tests/unit/test_series_polars.py
+++ b/tests/unit/test_series_polars.py
@@ -4142,7 +4142,6 @@ def test_json_astype_others_raise_error(data, to_type):
         bf_series.astype(to_type, errors="raise").to_pandas()
 
 
-@pytest.mark.skip(reason="AssertionError: Series NA mask are different")
 @pytest.mark.parametrize(
     ("data", "to_type"),
     [


### PR DESCRIPTION
This PR improves the user experience of the interactive Anywidget display mode by automatically disabling progress bars and job logging during widget operations.

  Changes:
   - Wrapped the get_anywidget_bundle call in repr_mimebundle with option_context("display.progress_bar", None) to silence the initial widget load.
   - Wrapped TableWidget._initial_load and TableWidget._set_table_html methods to silence subsequent interactions like pagination and sorting.


  Motivation:
  When interacting with the TableWidget (paging, sorting), the repeated appearance of progress bars creates visual noise and clutter in the notebook output cell, distracting from the interactive data exploration experience. This change ensures a clean and seamless interface.

Verified at:
 -  vs code notebook: https://screencast.googleplex.com/cast/NTY2NDkzOTc4Mjk2MzIwMHwwYjU0Njc1MS03MA
 - colab notebook: https://screencast.googleplex.com/cast/NjIzMjM0NTEyNzQxOTkwNHxiMDM0YzM2Ni1iZQ

Fixes #<482120359> 🦕
