### PR TITLE
chore: librarian release pull request: 20260207T015024Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:e7cc6823efb073a8a26e7cefdd869f12ec228abfbd2a44aa9a7eacc284023677
 libraries:
   - id: bigframes
-    version: 2.34.0
+    version: 2.35.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@
 
 [1]: https://pypi.org/project/bigframes/#history
 
+## [2.35.0](https://github.com/googleapis/python-bigquery-dataframes/compare/v2.34.0...v2.35.0) (2026-02-07)
+
+
+### Documentation
+
+* fix cast method shown on public docs (#2436) ([ad0f33c65ee01409826c381ae0f70aad65bb6a27](https://github.com/googleapis/python-bigquery-dataframes/commit/ad0f33c65ee01409826c381ae0f70aad65bb6a27))
+
+
+### Features
+
+* remove redundant "started." messages from progress output (#2440) ([2017cc2f27f0a432af46f60b3286b231caa4a98b](https://github.com/googleapis/python-bigquery-dataframes/commit/2017cc2f27f0a432af46f60b3286b231caa4a98b))
+* Add bigframes.pandas.col with basic operators (#2405) ([12741677c0391efb5d05281fc756445ccbb1387e](https://github.com/googleapis/python-bigquery-dataframes/commit/12741677c0391efb5d05281fc756445ccbb1387e))
+* Disable progress bars in Anywidget mode (#2444) ([4e2689a1c975c4cabaf36b7d0817dcbedc926853](https://github.com/googleapis/python-bigquery-dataframes/commit/4e2689a1c975c4cabaf36b7d0817dcbedc926853))
+* Disable progress bars in Anywidget mode to reduce notebook clutter (#2437) ([853240daf45301ad534c635c8955cb6ce91d23c2](https://github.com/googleapis/python-bigquery-dataframes/commit/853240daf45301ad534c635c8955cb6ce91d23c2))
+* add bigquery.ai.generate_text function (#2433) ([5bd0029a99e7653843de4ac7d57370c9dffeed4d](https://github.com/googleapis/python-bigquery-dataframes/commit/5bd0029a99e7653843de4ac7d57370c9dffeed4d))
+* Add a bigframes cell magic for ipython (#2395) ([e6de52ded6c5091275a936dec36f01a6cf701233](https://github.com/googleapis/python-bigquery-dataframes/commit/e6de52ded6c5091275a936dec36f01a6cf701233))
+* add `bigframes.bigquery.ai.generate_embedding` (#2343) ([e91536c8a5b2d8d896767510ced80c6fd2a68a97](https://github.com/googleapis/python-bigquery-dataframes/commit/e91536c8a5b2d8d896767510ced80c6fd2a68a97))
+* add bigframe.bigquery.load_data function (#2426) ([4b0f13b2fe10fa5b07d3ca3b7cb1ae1cb95030c7](https://github.com/googleapis/python-bigquery-dataframes/commit/4b0f13b2fe10fa5b07d3ca3b7cb1ae1cb95030c7))
+
+
+### Bug Fixes
+
+* suppress JSONDtypeWarning in Anywidget mode and clean up progress output (#2441) ([e0d185ad2c0245b17eac315f71152a46c6da41bb](https://github.com/googleapis/python-bigquery-dataframes/commit/e0d185ad2c0245b17eac315f71152a46c6da41bb))
+* exlcude gcsfs 2026.2.0 (#2445) ([311de31e79227408515f087dafbab7edc54ddf1b](https://github.com/googleapis/python-bigquery-dataframes/commit/311de31e79227408515f087dafbab7edc54ddf1b))
+* always display the results in the `%%bqsql` cell magics output (#2439) ([2d973b54550f30429dbd10894f78db7bb0c57345](https://github.com/googleapis/python-bigquery-dataframes/commit/2d973b54550f30429dbd10894f78db7bb0c57345))
+
 ## [2.34.0](https://github.com/googleapis/python-bigquery-dataframes/compare/v2.33.0...v2.34.0) (2026-02-02)
 
 

--- a/bigframes/version.py
+++ b/bigframes/version.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.34.0"
+__version__ = "2.35.0"
 
 # {x-release-please-start-date}
-__release_date__ = "2026-02-02"
+__release_date__ = "2026-02-07"
 # {x-release-please-end}

--- a/third_party/bigframes_vendored/version.py
+++ b/third_party/bigframes_vendored/version.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.34.0"
+__version__ = "2.35.0"
 
 # {x-release-please-start-date}
-__release_date__ = "2026-02-02"
+__release_date__ = "2026-02-07"
 # {x-release-please-end}


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:e7cc6823efb073a8a26e7cefdd869f12ec228abfbd2a44aa9a7eacc284023677
<details><summary>bigframes: 2.35.0</summary>

## [2.35.0](https://github.com/googleapis/python-bigquery-dataframes/compare/v2.34.0...v2.35.0) (2026-02-07)

### Features

* Add bigframes.pandas.col with basic operators (#2405) ([12741677](https://github.com/googleapis/python-bigquery-dataframes/commit/12741677))

* remove redundant &#34;started.&#34; messages from progress output (#2440) ([2017cc2f](https://github.com/googleapis/python-bigquery-dataframes/commit/2017cc2f))

* add bigframe.bigquery.load_data function (#2426) ([4b0f13b2](https://github.com/googleapis/python-bigquery-dataframes/commit/4b0f13b2))

* Disable progress bars in Anywidget mode (#2444) ([4e2689a1](https://github.com/googleapis/python-bigquery-dataframes/commit/4e2689a1))

* add bigquery.ai.generate_text function (#2433) ([5bd0029a](https://github.com/googleapis/python-bigquery-dataframes/commit/5bd0029a))

* Disable progress bars in Anywidget mode to reduce notebook clutter (#2437) ([853240da](https://github.com/googleapis/python-bigquery-dataframes/commit/853240da))

* Add a bigframes cell magic for ipython (#2395) ([e6de52de](https://github.com/googleapis/python-bigquery-dataframes/commit/e6de52de))

* add `bigframes.bigquery.ai.generate_embedding` (#2343) ([e91536c8](https://github.com/googleapis/python-bigquery-dataframes/commit/e91536c8))

### Bug Fixes

* always display the results in the `%%bqsql` cell magics output (#2439) ([2d973b54](https://github.com/googleapis/python-bigquery-dataframes/commit/2d973b54))

* exlcude gcsfs 2026.2.0 (#2445) ([311de31e](https://github.com/googleapis/python-bigquery-dataframes/commit/311de31e))

* suppress JSONDtypeWarning in Anywidget mode and clean up progress output (#2441) ([e0d185ad](https://github.com/googleapis/python-bigquery-dataframes/commit/e0d185ad))

### Documentation

* fix cast method shown on public docs (#2436) ([ad0f33c6](https://github.com/googleapis/python-bigquery-dataframes/commit/ad0f33c6))

</details>