### PR TITLE
docs: Update multimodal notebook to use public runtime helpers

### DIFF
--- a/notebooks/multimodal/multimodal_dataframe.ipynb
+++ b/notebooks/multimodal/multimodal_dataframe.ipynb
@@ -92,7 +92,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 1,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -130,7 +130,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": null,
+      "execution_count": 2,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -1322,22 +1322,11 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 17,
+      "execution_count": 3,
       "metadata": {
         "id": "oDDuYtUm5Yiy"
       },
-      "outputs": [
-        {
-          "name": "stderr",
-          "output_type": "stream",
-          "text": [
-            "/usr/local/google/home/shuowei/src/github.com/googleapis/python-bigquery-dataframes/bigframes/dtypes.py:959: JSONDtypeWarning: JSON columns will be represented as pandas.ArrowDtype(pyarrow.json_())\n",
-            "instead of using `db_dtypes` in the future when available in pandas\n",
-            "(https://github.com/pandas-dev/pandas/issues/60958) and pyarrow.\n",
-            "  warnings.warn(msg, bigframes.exceptions.JSONDtypeWarning)\n"
-          ]
-        }
-      ],
+      "outputs": [],
       "source": [
         "df_pdf = bpd.from_glob_path(\"gs://cloud-samples-data/bigquery/tutorials/cymbal-pets/documents/*\", name=\"pdf\")"
       ]
@@ -1496,7 +1485,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 10,
+      "execution_count": 4,
       "metadata": {},
       "outputs": [],
       "source": [
@@ -1506,7 +1495,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 11,
+      "execution_count": null,
       "metadata": {},
       "outputs": [
         {
@@ -1518,25 +1507,9 @@
             "(https://github.com/pandas-dev/pandas/issues/60958) and pyarrow.\n",
             "  warnings.warn(msg, bigframes.exceptions.JSONDtypeWarning)\n"
           ]
-        },
-        {
-          "data": {
-            "text/html": [
-              "<pre>0    Now, as all books, not primarily intended as p...</pre>"
-            ],
-            "text/plain": [
-              "0    Now, as all books, not primarily intended as p...\n",
-              "Name: transcribed_content, dtype: string"
-            ]
-          },
-          "execution_count": 11,
-          "metadata": {},
-          "output_type": "execute_result"
         }
       ],
       "source": [
-        "import bigframes.bigquery as bbq\n",
-        "\n",
         "# The audio_transcribe function is a convenience wrapper around bigframes.bigquery.ai.generate.\n",
         "# Here's how to perform the same operation directly:\n",
         "\n",
@@ -1565,7 +1538,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
+      "execution_count": null,
       "metadata": {},
       "outputs": [
         {
@@ -1701,7 +1674,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.10.15"
+      "version": "3.13.0"
     }
   },
   "nbformat": 4,

--- a/notebooks/multimodal/multimodal_dataframe.ipynb
+++ b/notebooks/multimodal/multimodal_dataframe.ipynb
@@ -134,7 +134,7 @@
       "metadata": {},
       "outputs": [],
       "source": [
-        "import bigframes.operations as ops\n",
+        "import bigframes.bigquery as bbq\n",
         "\n",
         "def get_runtime_json_str(series, mode=\"R\", with_metadata=False):\n",
         "    \"\"\"\n",
@@ -148,16 +148,16 @@
         "    \"\"\"\n",
         "    # 1. Optionally fetch metadata\n",
         "    s = (\n",
-        "        series._apply_unary_op(ops.obj_fetch_metadata_op)\n",
+        "        bbq.obj.fetch_metadata(series)\n",
         "        if with_metadata\n",
         "        else series\n",
         "    )\n",
         "    \n",
         "    # 2. Retrieve the access URL runtime object\n",
-        "    runtime = s._apply_unary_op(ops.ObjGetAccessUrl(mode=mode))\n",
+        "    runtime = bbq.obj.get_access_url(s, mode=mode)\n",
         "    \n",
         "    # 3. Convert the runtime object to a JSON string\n",
-        "    return runtime._apply_unary_op(ops.ToJSONString())"
+        "    return bbq.to_json_string(runtime)"
       ]
     },
     {
@@ -1536,7 +1536,6 @@
       ],
       "source": [
         "import bigframes.bigquery as bbq\n",
-        "import bigframes.operations as ops\n",
         "\n",
         "# The audio_transcribe function is a convenience wrapper around bigframes.bigquery.ai.generate.\n",
         "# Here's how to perform the same operation directly:\n",
@@ -1551,8 +1550,8 @@
         "\n",
         "# Convert the audio series to the runtime representation required by the model.\n",
         "# This involves fetching metadata and getting a signed access URL.\n",
-        "audio_metadata = audio_series._apply_unary_op(ops.obj_fetch_metadata_op)\n",
-        "audio_runtime = audio_metadata._apply_unary_op(ops.ObjGetAccessUrl(mode=\"R\"))\n",
+        "audio_metadata = bbq.obj.fetch_metadata(audio_series)\n",
+        "audio_runtime = bbq.obj.get_access_url(audio_metadata, mode=\"R\")\n",
         "\n",
         "transcribed_results = bbq.ai.generate(\n",
         "    prompt=(prompt_text, audio_runtime),\n",

--- a/notebooks/multimodal/multimodal_dataframe.ipynb
+++ b/notebooks/multimodal/multimodal_dataframe.ipynb
@@ -92,7 +92,7 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 9,
+      "execution_count": null,
       "metadata": {
         "colab": {
           "base_uri": "https://localhost:8080/"
@@ -126,6 +126,38 @@
         "\n",
         "import bigframes.pandas as bpd\n",
         "import bigframes.bigquery as bbq"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import bigframes.operations as ops\n",
+        "\n",
+        "def get_runtime_json_str(series, mode=\"R\", with_metadata=False):\n",
+        "    \"\"\"\n",
+        "    Get the runtime (contains signed URL to access gcs data) and apply the\n",
+        "    ToJSONSTring transformation.\n",
+        "    \n",
+        "    Args:\n",
+        "        series: bigframes.series.Series to operate on.\n",
+        "        mode: \"R\" for read, \"RW\" for read/write.\n",
+        "        with_metadata: Whether to fetch and include blob metadata.\n",
+        "    \"\"\"\n",
+        "    # 1. Optionally fetch metadata\n",
+        "    s = (\n",
+        "        series._apply_unary_op(ops.obj_fetch_metadata_op)\n",
+        "        if with_metadata\n",
+        "        else series\n",
+        "    )\n",
+        "    \n",
+        "    # 2. Retrieve the access URL runtime object\n",
+        "    runtime = s._apply_unary_op(ops.ObjGetAccessUrl(mode=mode))\n",
+        "    \n",
+        "    # 3. Convert the runtime object to a JSON string\n",
+        "    return runtime._apply_unary_op(ops.ToJSONString())"
       ]
     },
     {
@@ -1638,7 +1670,7 @@
         "\n",
         "# Generate a JSON string containing the runtime information (including signed read URLs)\n",
         "# This allows the UDF to download the images from Google Cloud Storage\n",
-        "access_urls = exif_image_df[\"blob_col\"].blob.get_runtime_json_str(mode=\"R\")\n",
+        "access_urls = get_runtime_json_str(exif_image_df[\"blob_col\"], mode=\"R\")\n",
         "\n",
         "# Apply the BigQuery Python UDF to the runtime JSON strings\n",
         "# We cast to string to ensure the input matches the UDF's signature\n",
@@ -1670,7 +1702,7 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.13.0"
+      "version": "3.10.15"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
  This PR updates notebooks/multimodal/multimodal_dataframe.ipynb to use public APIs (bigframes.bigquery.obj and
  bigframes.bigquery.to_json_string) instead of internal operations for retrieving runtime JSON strings.

Fixes #<478952827> 🦕
