### PR TITLE
chore: librarian release pull request: 20260217T233413Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:1a2a85ab507aea26d787c06cc7979decb117164c81dd78a745982dfda80d4f68
 libraries:
   - id: bigframes
-    version: 2.35.0
+    version: 2.36.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@
 
 [1]: https://pypi.org/project/bigframes/#history
 
+## [2.36.0](https://github.com/googleapis/python-bigquery-dataframes/compare/v2.35.0...v2.36.0) (2026-02-17)
+
+
+### Documentation
+
+* update multimodal dataframe notebook to use public APIs (#2456) ([342fa723c4631d371364a87ae0ddd6fa03360a4b](https://github.com/googleapis/python-bigquery-dataframes/commit/342fa723c4631d371364a87ae0ddd6fa03360a4b))
+* use direct API for pdf chunk and pdf extract (#2452) ([543ce52c18269eab2a89886f226d1478dbabf9ba](https://github.com/googleapis/python-bigquery-dataframes/commit/543ce52c18269eab2a89886f226d1478dbabf9ba))
+* fix generate_text and generate_table input docs (#2455) ([078bd32ebd28af0d2cfba6bb874ba79e904183e2](https://github.com/googleapis/python-bigquery-dataframes/commit/078bd32ebd28af0d2cfba6bb874ba79e904183e2))
+* Update multimodal notebook to use public runtime helpers (#2451) ([e36dd8b492fd7ab433fa4cac732b31774c1e428b](https://github.com/googleapis/python-bigquery-dataframes/commit/e36dd8b492fd7ab433fa4cac732b31774c1e428b))
+* use direct API for audio transcription (#2447) ([59cbc5db66fd178ecce03bf4b8b4a504d7ef3e9f](https://github.com/googleapis/python-bigquery-dataframes/commit/59cbc5db66fd178ecce03bf4b8b4a504d7ef3e9f))
+* Add EXIF metadata extraction example to multimodal notebook (#2429) ([84c6f883aef8048e7013a8b3c03a1bde47e94eea](https://github.com/googleapis/python-bigquery-dataframes/commit/84c6f883aef8048e7013a8b3c03a1bde47e94eea))
+
+
+### Features
+
+* Initial support for biglake iceberg tables (#2409) ([ae35a9890a2f9903b12e431488362c091118bbdd](https://github.com/googleapis/python-bigquery-dataframes/commit/ae35a9890a2f9903b12e431488362c091118bbdd))
+* add bigquery.ai.generate_table function (#2453) ([b925aa243dad0e42ad126c9397f42be0aad7152d](https://github.com/googleapis/python-bigquery-dataframes/commit/b925aa243dad0e42ad126c9397f42be0aad7152d))
+
 ## [2.35.0](https://github.com/googleapis/python-bigquery-dataframes/compare/v2.34.0...v2.35.0) (2026-02-07)
 
 

--- a/bigframes/version.py
+++ b/bigframes/version.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.35.0"
+__version__ = "2.36.0"
 
 # {x-release-please-start-date}
-__release_date__ = "2026-02-07"
+__release_date__ = "2026-02-17"
 # {x-release-please-end}

--- a/third_party/bigframes_vendored/version.py
+++ b/third_party/bigframes_vendored/version.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.35.0"
+__version__ = "2.36.0"
 
 # {x-release-please-start-date}
-__release_date__ = "2026-02-07"
+__release_date__ = "2026-02-17"
 # {x-release-please-end}


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:1a2a85ab507aea26d787c06cc7979decb117164c81dd78a745982dfda80d4f68
<details><summary>bigframes: 2.36.0</summary>

## [2.36.0](https://github.com/googleapis/python-bigquery-dataframes/compare/v2.35.0...v2.36.0) (2026-02-17)

### Features

* Initial support for biglake iceberg tables (#2409) ([ae35a989](https://github.com/googleapis/python-bigquery-dataframes/commit/ae35a989))

* add bigquery.ai.generate_table function (#2453) ([b925aa24](https://github.com/googleapis/python-bigquery-dataframes/commit/b925aa24))

### Documentation

* fix generate_text and generate_table input docs (#2455) ([078bd32e](https://github.com/googleapis/python-bigquery-dataframes/commit/078bd32e))

* update multimodal dataframe notebook to use public APIs (#2456) ([342fa723](https://github.com/googleapis/python-bigquery-dataframes/commit/342fa723))

* use direct API for pdf chunk and pdf extract (#2452) ([543ce52c](https://github.com/googleapis/python-bigquery-dataframes/commit/543ce52c))

* use direct API for audio transcription (#2447) ([59cbc5db](https://github.com/googleapis/python-bigquery-dataframes/commit/59cbc5db))

* Add EXIF metadata extraction example to multimodal notebook (#2429) ([84c6f883](https://github.com/googleapis/python-bigquery-dataframes/commit/84c6f883))

* Update multimodal notebook to use public runtime helpers (#2451) ([e36dd8b4](https://github.com/googleapis/python-bigquery-dataframes/commit/e36dd8b4))

</details>