### PR TITLE
chore: librarian release pull request: 20260331T225508Z

### DIFF
--- a/.librarian/state.yaml
+++ b/.librarian/state.yaml
@@ -1,7 +1,7 @@
 image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:160860d189ff1c2f7515638478823712fa5b243e27ccc33a2728669fa1e2ed0c
 libraries:
   - id: bigframes
-    version: 2.38.0
+    version: 2.39.0
     last_generated_commit: ""
     apis: []
     source_roots:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@
 
 [1]: https://pypi.org/project/bigframes/#history
 
+## [2.39.0](https://github.com/googleapis/python-bigquery-dataframes/compare/v2.38.0...v2.39.0) (2026-03-31)
+
+
+### Documentation
+
+* Rename Blob column references to ObjectRef column (#2535) ([44e0ffd947e9db66ab612f92de6e31f1085e7968](https://github.com/googleapis/python-bigquery-dataframes/commit/44e0ffd947e9db66ab612f92de6e31f1085e7968))
+* gemini retouch of the index page for seo (#2514) ([2e5311e2242b039da4c8e37b7b48942fa8ed34c2](https://github.com/googleapis/python-bigquery-dataframes/commit/2e5311e2242b039da4c8e37b7b48942fa8ed34c2))
+
+
+### Features
+
+* expose DataFrame.bigquery in both pandas and bigframes DataFrames (#2533) ([69fe317612a69aa92f06f0c418c67aa1f9488bd2](https://github.com/googleapis/python-bigquery-dataframes/commit/69fe317612a69aa92f06f0c418c67aa1f9488bd2))
+* support full round-trip persistence for multimodal reference cols (#2511) ([494a0a113b1ba6dcdc9f9b85a4f750d093f5652f](https://github.com/googleapis/python-bigquery-dataframes/commit/494a0a113b1ba6dcdc9f9b85a4f750d093f5652f))
+* add `df.bigquery.ai.forecast` method to pandas dataframe accessor (#2518) ([1126cec9cdfcc1ec1062c60e5affbe1b60223767](https://github.com/googleapis/python-bigquery-dataframes/commit/1126cec9cdfcc1ec1062c60e5affbe1b60223767))
+
+
+### Bug Fixes
+
+* handle aggregate operations on empty selections (#2510) ([34fb5daa93726d0d3ff364912a3c1de0fc535fb2](https://github.com/googleapis/python-bigquery-dataframes/commit/34fb5daa93726d0d3ff364912a3c1de0fc535fb2))
+* Localize BigQuery log suppression for gbq.py (#2541) ([af49ca29399aa2c63753d9045fd382e30334d134](https://github.com/googleapis/python-bigquery-dataframes/commit/af49ca29399aa2c63753d9045fd382e30334d134))
+* to_gbq may swap data columns when replace table (#2532) ([17ecc65e1c0397ef349fca4afcf5a77af72aa798](https://github.com/googleapis/python-bigquery-dataframes/commit/17ecc65e1c0397ef349fca4afcf5a77af72aa798))
+* Respect remote function config changes even if logic unchanged (#2512) ([b9524284ad3b457b15598f546bac04c76b3e27b8](https://github.com/googleapis/python-bigquery-dataframes/commit/b9524284ad3b457b15598f546bac04c76b3e27b8))
+* support melting empty DataFrames without crashing (#2509) ([e8c46032154e186042314d97aa813301413d8a13](https://github.com/googleapis/python-bigquery-dataframes/commit/e8c46032154e186042314d97aa813301413d8a13))
+
 ## [2.38.0](https://github.com/googleapis/python-bigquery-dataframes/compare/v2.37.0...v2.38.0) (2026-03-16)
 
 

--- a/bigframes/version.py
+++ b/bigframes/version.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.38.0"
+__version__ = "2.39.0"
 
 # {x-release-please-start-date}
-__release_date__ = "2026-03-16"
+__release_date__ = "2026-03-31"
 # {x-release-please-end}

--- a/third_party/bigframes_vendored/version.py
+++ b/third_party/bigframes_vendored/version.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = "2.38.0"
+__version__ = "2.39.0"
 
 # {x-release-please-start-date}
-__release_date__ = "2026-03-16"
+__release_date__ = "2026-03-31"
 # {x-release-please-end}


### PR DESCRIPTION
PR created by the Librarian CLI to initialize a release. Merging this PR will auto trigger a release.

Librarian Version: v0.7.0
Language Image: us-central1-docker.pkg.dev/cloud-sdk-librarian-prod/images-prod/python-librarian-generator@sha256:160860d189ff1c2f7515638478823712fa5b243e27ccc33a2728669fa1e2ed0c
<details><summary>bigframes: 2.39.0</summary>

## [2.39.0](https://github.com/googleapis/python-bigquery-dataframes/compare/v2.38.0...v2.39.0) (2026-03-31)

### Features

* add `df.bigquery.ai.forecast` method to pandas dataframe accessor (#2518) ([1126cec9](https://github.com/googleapis/python-bigquery-dataframes/commit/1126cec9))

* support full round-trip persistence for multimodal reference cols (#2511) ([494a0a11](https://github.com/googleapis/python-bigquery-dataframes/commit/494a0a11))

* expose DataFrame.bigquery in both pandas and bigframes DataFrames (#2533) ([69fe3176](https://github.com/googleapis/python-bigquery-dataframes/commit/69fe3176))

### Bug Fixes

* to_gbq may swap data columns when replace table (#2532) ([17ecc65e](https://github.com/googleapis/python-bigquery-dataframes/commit/17ecc65e))

* handle aggregate operations on empty selections (#2510) ([34fb5daa](https://github.com/googleapis/python-bigquery-dataframes/commit/34fb5daa))

* Localize BigQuery log suppression for gbq.py (#2541) ([af49ca29](https://github.com/googleapis/python-bigquery-dataframes/commit/af49ca29))

* Respect remote function config changes even if logic unchanged (#2512) ([b9524284](https://github.com/googleapis/python-bigquery-dataframes/commit/b9524284))

* support melting empty DataFrames without crashing (#2509) ([e8c46032](https://github.com/googleapis/python-bigquery-dataframes/commit/e8c46032))

### Performance Improvements

* Make executor data uploads async internally (#2529) ([96597f0b](https://github.com/googleapis/python-bigquery-dataframes/commit/96597f0b))

### Documentation

* gemini retouch of the index page for seo (#2514) ([2e5311e2](https://github.com/googleapis/python-bigquery-dataframes/commit/2e5311e2))

* Rename Blob column references to ObjectRef column (#2535) ([44e0ffd9](https://github.com/googleapis/python-bigquery-dataframes/commit/44e0ffd9))

</details>